### PR TITLE
Expose const ref of resource and mutex in SharedResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 - Implement `ContactPhaseList::getPresentPhase()` method (https://github.com/dic-iit/bipedal-locomotion-framework/pull/396)
 
 ### Changed
+- Expose reference of resource and mutex in SharedResource (https://github.com/dic-iit/bipedal-locomotion-framework/pull/398).
 
 ### Fix
 

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimatorIO.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimatorIO.h
@@ -11,6 +11,7 @@
 #include <Eigen/Dense>
 #include <manif/manif.h>
 
+#include <BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimatorParams.h>
 #include <BipedalLocomotion/Contacts/Contact.h>
 #include <manif/manif.h>
 #include <map>

--- a/src/Perception/include/BipedalLocomotion/Perception/Features/ArucoDetector.h
+++ b/src/Perception/include/BipedalLocomotion/Perception/Features/ArucoDetector.h
@@ -57,6 +57,7 @@ struct ArucoDetectorOutput
 {
     std::unordered_map<int, ArucoMarkerData> markers;
     double timeNow{-1.0};
+    cv::Mat imgWithMarkers;
 };
 
 class ArucoDetector : public System::Source<ArucoDetectorOutput>

--- a/src/Perception/src/ArucoDetector.cpp
+++ b/src/Perception/src/ArucoDetector.cpp
@@ -18,6 +18,7 @@ using namespace BipedalLocomotion::Conversions;
 #include <opencv2/aruco.hpp>
 #include <opencv2/calib3d.hpp>
 #include <opencv2/core/eigen.hpp>
+#include <opencv2/opencv.hpp>
 
 class ArucoDetector::Impl
 {
@@ -187,7 +188,7 @@ bool ArucoDetector::advance()
         log()->error("{} Unable to run advance(). Please set an image first.", printPrefix);
         return false;
     }
-
+    
     m_pimpl->resetBuffers();
     std::vector<std::vector<cv::Point2f>> detectedmarkerCorners;
     cv::aruco::detectMarkers(m_pimpl->currentImg,
@@ -218,6 +219,9 @@ bool ArucoDetector::advance()
                                        m_pimpl->poseEig};
             m_pimpl->out.markers[m_pimpl->currentDetectedMarkerIds[idx]] = markerData;
         }
+        
+        getImageWithDetectedMarkers(m_pimpl->out.imgWithMarkers, /** drawFrames = */true);
+        
         m_pimpl->out.timeNow = m_pimpl->currentTime;
     }
 

--- a/src/System/include/BipedalLocomotion/System/SharedResource.h
+++ b/src/System/include/BipedalLocomotion/System/SharedResource.h
@@ -21,7 +21,9 @@ namespace System
  * shared resource you can use it only with shared_ptr. For this reason the only way to create a
  * shared resource is to use the SharedResource::create() static method. If want a visual
  * interpretation of shared resource you may imagine it as the wire connecting two blocks running in
- * two separate threads. The implementation of SharedResource is thread safe.
+ * two separate threads. The implementation of SharedResource is thread safe, except when getting the
+ * resource by reference or when the resource type is a smart pointer.
+ * In this case, the user is obliged to access the mutex and lock/unlock it as required.
  */
 template <class T> class SharedResource
 {
@@ -45,6 +47,20 @@ public:
     T get();
 
     /**
+     * Get the resource using const reference.
+     * @note one must not forget to access the mutex and
+     *       perform necessary locking and unlocking
+     * @return the const reference of the object inside the shared resource.
+     */
+    const T& get() const;
+
+    /**
+     * Get the mutex by reference.
+     * @return the reference of the mutex.
+     */
+    std::mutex& mutex();
+
+    /**
      * Method used to create a shared resource.
      * @return a pointer of a shared resource.
      */
@@ -61,6 +77,16 @@ template <class T> T SharedResource<T>::get()
 {
     const std::lock_guard<std::mutex> lock(m_mutex);
     return m_resource;
+}
+
+template <class T> const T& SharedResource<T>::get() const
+{
+    return m_resource;
+}
+
+template <class T> std::mutex& SharedResource<T>::mutex()
+{
+    return m_mutex;
 }
 
 template <class T> typename SharedResource<T>::Ptr SharedResource<T>::create()

--- a/src/System/tests/AdvanceableRunnerTest.cpp
+++ b/src/System/tests/AdvanceableRunnerTest.cpp
@@ -43,6 +43,11 @@ public:
     {
         return true;
     }
+
+    void printSomething(const int& id)
+    {
+        BipedalLocomotion::log()->info("DummyBlock {}: status: {}.", id, m_output);
+    }
 };
 
 TEST_CASE("Test Block")
@@ -76,10 +81,13 @@ TEST_CASE("Test Block")
     // run the block
     auto thread0 = runner0.run();
     auto thread1 = runner1.run();
-
+    
     while (!output0->get() || !output1->get())
     {
-        BipedalLocomotion::clock().sleepFor(std::chrono::duration<double>(0.01));
+        auto wrong0 = runner0.getMutexLockedAdvanceableAccessor();
+        wrong0->printSomething(0);        
+	runner1.getMutexLockedAdvanceableAccessor()->printSomething(1);        
+        BipedalLocomotion::clock().sleepFor(std::chrono::duration<double>(0.001));
     }
 
     // close the runner


### PR DESCRIPTION
This will allow the proper usage of `SharedResource` with smart pointers across multiple threads.