### PR TITLE
Implement ContactWrench python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ All notable changes to this project are documented in this file.
 - Implement `create_tsid` utility function for the python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/433)
 - Implement the `AngularMomentumTask` in the `TSID` component and the associated python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/436)
 - Implement `QPTSID::toString` method and the associated python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/440)
+- Implement `ContactWrench` python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/441)
 
 ### Changed
+- Inherits all the `Eigen::Matrix` constructors in the `Wrenchd` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/441)
+
 ### Fix
 
 ## [0.4.0] - 2021-10-15

--- a/bindings/python/Contacts/src/Contacts.cpp
+++ b/bindings/python/Contacts/src/Contacts.cpp
@@ -77,6 +77,10 @@ void CreateContact(pybind11::module& module)
         .def_readwrite("last_update_time", &EstimatedContact::lastUpdateTime)
         .def("get_contact_details", &EstimatedContact::getContactDetails)
         .def("set_contact_state_stamped", &EstimatedContact::setContactStateStamped);
+
+    py::class_<ContactWrench, ContactBase>(module, "ContactWrench")
+        .def(py::init())
+        .def_readwrite("wrench", &ContactWrench::wrench);
 }
 
 void CreateContactList(pybind11::module& module)

--- a/src/Math/include/BipedalLocomotion/Math/Wrench.h
+++ b/src/Math/include/BipedalLocomotion/Math/Wrench.h
@@ -26,22 +26,10 @@ template <class Scalar> class Wrench : public Eigen::Matrix<Scalar, 6, 1>
 public:
     using Base = Eigen::Matrix<Scalar, 6, 1>;
 
-    Wrench()
-        : Eigen::Matrix<Scalar, 6, 1>()
-    {
-    }
-
-    template <typename OtherDerived>
-    Wrench(const Eigen::MatrixBase<OtherDerived>& other)
-        : Eigen::Matrix<Scalar, 6, 1>(other)
-    {
-    }
-
-    template <typename OtherDerived> Wrench& operator=(const Eigen::MatrixBase<OtherDerived>& other)
-    {
-        this->Base::operator=(other);
-        return *this;
-    }
+    /**
+     * Inherit Eigen constructors
+     */
+    using Base::Base;
 
     /**
      * Get the linear force of the wrench


### PR DESCRIPTION
This PR introduces the python bindings for the `ContactWrench`. To correctly convert the `Wrenchd` class into a `numpy` object I had to inherits all the `Eigen::Matrix` constructors in the `Wrenchd` class 7ba03bbfac7d115e271c884d0dc2ca32f9a10ab5 .

Without this `pybind11` was complaining with the following error.

```
[ 75%] Building CXX object bindings/python/CMakeFiles/pybind11_blf.dir/Contacts/src/Contacts.cpp.o
In file included from /home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/bindings/python/Contacts/src/Contacts.cpp:8:
/usr/include/pybind11/eigen.h: In instantiation of ‘bool pybind11::detail::type_caster<Type, typename std::enable_if<std::integral_constant<bool, (pybind11::detail::negation<std::integral_constant<bool, (decltype (pybind11::detail::is_template_base_of_impl<Eigen::DenseBase>::check((typename pybind11::detail::intrinsic_type<T>::type*)(nullptr)))::value && std::is_base_of<Eigen::MapBase<Derived, 0>, T>::value)> >::value && decltype (pybind11::detail::is_template_base_of_impl<Eigen::PlainObjectBase>::check((typename pybind11::detail::intrinsic_type<T>::type*)(nullptr)))::value)>::value, void>::type>::load(pybind11::handle, bool) [with Type = BipedalLocomotion::Math::Wrench<double>; typename std::enable_if<std::integral_constant<bool, (pybind11::detail::negation<std::integral_constant<bool, (decltype (pybind11::detail::is_template_base_of_impl<Eigen::DenseBase>::check((typename pybind11::detail::intrinsic_type<T>::type*)(nullptr)))::value && std::is_base_of<Eigen::MapBase<Derived, 0>, T>::value)> >::value && decltype (pybind11::detail::is_template_base_of_impl<Eigen::PlainObjectBase>::check((typename pybind11::detail::intrinsic_type<T>::type*)(nullptr)))::value)>::value, void>::type = void]’:
/usr/include/pybind11/cast.h:1927:9:   required from ‘bool pybind11::detail::argument_loader<Args>::load_impl_sequence(pybind11::detail::function_call&, std::index_sequence<Is ...>) [with long unsigned int ...Is = {0, 1}; Args = {BipedalLocomotion::Contacts::ContactWrench&, const BipedalLocomotion::Math::Wrench<double>&}; std::index_sequence<Is ...> = std::integer_sequence<long unsigned int, 0, 1>]’
/usr/include/pybind11/cast.h:1907:50:   required from ‘bool pybind11::detail::argument_loader<Args>::load_args(pybind11::detail::function_call&) [with Args = {BipedalLocomotion::Contacts::ContactWrench&, const BipedalLocomotion::Math::Wrench<double>&}]’
/usr/include/pybind11/pybind11.h:141:17:   required from ‘void pybind11::cpp_function::initialize(Func&&, Return (*)(Args ...), const Extra& ...) [with Func = pybind11::class_<type_, options>::def_readwrite(const char*, D C::*, const Extra& ...) [with C = BipedalLocomotion::Contacts::ContactWrench; D = BipedalLocomotion::Math::Wrench<double>; Extra = {}; type_ = BipedalLocomotion::Contacts::ContactWrench; options = {BipedalLocomotion::Contacts::ContactBase}]::<lambda(pybind11::class_<BipedalLocomotion::Contacts::ContactWrench, BipedalLocomotion::Contacts::ContactBase>::type&, const BipedalLocomotion::Math::Wrench<double>&)>; Return = void; Args = {BipedalLocomotion::Contacts::ContactWrench&, const BipedalLocomotion::Math::Wrench<double>&}; Extra = {pybind11::is_method}]’
/usr/include/pybind11/pybind11.h:71:9:   required from ‘pybind11::cpp_function::cpp_function(Func&&, const Extra& ...) [with Func = pybind11::class_<type_, options>::def_readwrite(const char*, D C::*, const Extra& ...) [with C = BipedalLocomotion::Contacts::ContactWrench; D = BipedalLocomotion::Math::Wrench<double>; Extra = {}; type_ = BipedalLocomotion::Contacts::ContactWrench; options = {BipedalLocomotion::Contacts::ContactBase}]::<lambda(pybind11::class_<BipedalLocomotion::Contacts::ContactWrench, BipedalLocomotion::Contacts::ContactBase>::type&, const BipedalLocomotion::Math::Wrench<double>&)>; Extra = {pybind11::is_method}; <template-parameter-1-3> = void]’
/usr/include/pybind11/pybind11.h:1189:22:   required from ‘pybind11::class_<type_, options>& pybind11::class_<type_, options>::def_readwrite(const char*, D C::*, const Extra& ...) [with C = BipedalLocomotion::Contacts::ContactWrench; D = BipedalLocomotion::Math::Wrench<double>; Extra = {}; type_ = BipedalLocomotion::Contacts::ContactWrench; options = {BipedalLocomotion::Contacts::ContactBase}]’
/home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/bindings/python/Contacts/src/Contacts.cpp:83:56:   required from here
/usr/include/pybind11/eigen.h:276:17: error: no matching function for call to ‘BipedalLocomotion::Math::Wrench<double>::Wrench(pybind11::detail::EigenIndex&, pybind11::detail::EigenIndex&)’
  276 |         value = Type(fits.rows, fits.cols);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Contacts/include/BipedalLocomotion/Contacts/Contact.h:11,
                 from /home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/bindings/python/Contacts/src/Contacts.cpp:14:
/home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Math/include/BipedalLocomotion/Math/Wrench.h:35:5: note: candidate: ‘template<class OtherDerived> BipedalLocomotion::Math::Wrench<Scalar>::Wrench(const Eigen::MatrixBase<OtherDerived>&)’
   35 |     Wrench(const Eigen::MatrixBase<OtherDerived>& other)
      |     ^~~~~~
/home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Math/include/BipedalLocomotion/Math/Wrench.h:35:5: note:   template argument deduction/substitution failed:
In file included from /home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/bindings/python/Contacts/src/Contacts.cpp:8:
/usr/include/pybind11/eigen.h:276:17: note:   mismatched types ‘const Eigen::MatrixBase<Derived>’ and ‘pybind11::detail::EigenIndex’ {aka ‘long int’}
  276 |         value = Type(fits.rows, fits.cols);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Contacts/include/BipedalLocomotion/Contacts/Contact.h:11,
                 from /home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/bindings/python/Contacts/src/Contacts.cpp:14:
/home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Math/include/BipedalLocomotion/Math/Wrench.h:29:5: note: candidate: ‘BipedalLocomotion::Math::Wrench<Scalar>::Wrench() [with Scalar = double]’
   29 |     Wrench()
      |     ^~~~~~
/home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Math/include/BipedalLocomotion/Math/Wrench.h:29:5: note:   candidate expects 0 arguments, 2 provided
/home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Math/include/BipedalLocomotion/Math/Wrench.h:24:31: note: candidate: ‘BipedalLocomotion::Math::Wrench<double>::Wrench(const BipedalLocomotion::Math::Wrench<double>&)’
   24 | template <class Scalar> class Wrench : public Eigen::Matrix<Scalar, 6, 1>
      |                               ^~~~~~
/home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Math/include/BipedalLocomotion/Math/Wrench.h:24:31: note:   candidate expects 1 argument, 2 provided
/home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Math/include/BipedalLocomotion/Math/Wrench.h:24:31: note: candidate: ‘BipedalLocomotion::Math::Wrench<double>::Wrench(BipedalLocomotion::Math::Wrench<double>&&)’
/home/gromualdi/robot-code/robotology-superbuild/src/bipedal-locomotion-framework/src/Math/include/BipedalLocomotion/Math/Wrench.h:24:31: note:   candidate expects 1 argument, 2 provided
make[2]: *** [bindings/python/CMakeFiles/pybind11_blf.dir/build.make:193: bindings/python/CMakeFiles/pybind11_blf.dir/Contacts/src/Contacts.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:4354: bindings/python/CMakeFiles/pybind11_blf.dir/all] Error 2
```

Indeed `pybind11` assumes the type is default contractible by calling [`type_caster<MyType>
converter;`](https://github.com/pybind/pybind11/blob/6de30d317277c26a72ed1929e09f225b74f23b7a/include/pybind11/eigen.h#L247-L250).
In the `load` method of `type_caster` class a new `Eigen::Matrix` is allocated with [`value = Type(fits.rows, fits.cols);`](https://github.com/pybind/pybind11/blob/6de30d317277c26a72ed1929e09f225b74f23b7a/include/pybind11/eigen.h#L274). 
In the previous version of `Wrench` class the constructor `Wrench::Wrench(Eigen::Index, Eigen::Index)` was not defined, for this reason `pybind11` was not able to automatically convert the `numpy` objects into `Eigen` objects (and vice-versa).

---

Related issue: https://github.com/pybind/pybind11/issues/1338
