### PR TITLE
Install texlive-core in gh-page workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
           conda config --remove channels defaults
 
           # Dependencies
-          mamba install doxygen toml pygments docutils jinja2
+          mamba install doxygen toml pygments docutils jinja2 texlive-core
 
       - name: Fetch m.css
         shell: bash -l {0}

--- a/docs/generate_website.py
+++ b/docs/generate_website.py
@@ -46,5 +46,7 @@ if __name__ == "__main__":
                                      input_files_path="./",
                                      output_files_path="./")
 
-        subprocess.Popen(["python3", args.mcss_path, "conf-" + key + ".py"],
-                         stdout=subprocess.PIPE)
+        try:
+            subprocess.check_call(["python3", args.mcss_path, "conf-" + key + ".py"])
+        except subprocess.CalledProcessError as error:
+            print(error)


### PR DESCRIPTION
The current documentation is broken since `m.css` is not able to find latex 

https://github.com/ami-iit/bipedal-locomotion-framework/runs/4235942651?check_suite_focus=true#step:6:3407

This should fix it. Before merging it I will check the artifact updated by the action 