### PR TITLE
Fix `create_ik` python function

### DIFF
--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -128,6 +128,9 @@ def create_ik(kindyn: blf.floating_base_estimators.KinDynComputationsDescriptor,
        variables_name = ["robot_velocity"]
        variables_size = [29]
 
+       [IK]
+       robot_velocity_variable_name = "robot_velocity"
+
        [COM_TASK]
        name = "com"
        type = "CoMTask"
@@ -161,6 +164,9 @@ def create_ik(kindyn: blf.floating_base_estimators.KinDynComputationsDescriptor,
 
     # initialize the variable handler
     assert variables_handler.initialize(param_handler.get_group("VARIABLES"))
+
+    # initialize the solver
+    assert solver.initialize(param_handler.get_group("IK"))
 
     # retrieve all the tasks
     task_groups_name = param_handler.get_parameter_vector_string("tasks")

--- a/docs/pages/python-additional-info.md
+++ b/docs/pages/python-additional-info.md
@@ -85,6 +85,10 @@ solver, tasks, variables_handler = utils.create_ik(kindyn=kindyn_descriptor, par
 An example of the configuration file is
 ~~~~~~~~~~~~~{.ini}
 tasks = ["COM_TASK", "LF_TASK"]
+
+[IK]
+robot_velocity_variable_name = "robot_velocity"
+
 [VARIABLES]
 variables_name = ["robot_velocity"]
 variables_size = [29]

--- a/src/IK/src/QPInverseKinematics.cpp
+++ b/src/IK/src/QPInverseKinematics.cpp
@@ -215,6 +215,14 @@ bool QPInverseKinematics::finalize(const System::VariablesHandler& handler)
 {
     constexpr auto logPrefix = "[QPInverseKinematics::finalize]";
 
+    if (!m_pimpl->isInitialized)
+    {
+        log()->error("{} Please call initialize() before finalize().", logPrefix);
+        return false;
+    }
+
+    m_pimpl->isFinalized = false;
+
     // clear the solver
     m_pimpl->solver.clearSolver();
 


### PR DESCRIPTION
In the original implementation of the `create_ik` function, I forgot to add 
```python
# initialize the solver
assert solver.initialize(param_handler.get_group("IK"))
```

this PR fixes the bug and I updated the associated documentation.

Furthermore the `QPInverseKinematics::finalize()` checks if the IK is initialized.

Associated issue: https://github.com/ami-iit/bipedal-locomotion-framework/issues/464