### PR TITLE
Add logging of IMU orientation for iCub3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 ### Added
+- Add the reading of the orientation of the head IMU in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/471)
+
 ### Changed
 ### Fix
 

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/interface/mas-remapper.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/interface/mas-remapper.xml
@@ -14,6 +14,9 @@ GNU Lesser General Public License v2.1 or any later version. -->
     <param name="ThreeAxisMagnetometersNames">
       (rfeimu_mag)
     </param>
+    <param name="OrientationSensorsNames">
+      (rfeimu_eul)
+    </param>
 
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -35,6 +35,7 @@ GNU Lesser General Public License v2.1 or any later version. -->
       <param name="accelerometers_list">("rfeimu_acc")</param>
       <param name="gyroscopes_list">("rfeimu_gyro")</param>
       <param name="magnetometers_list">("rfeimu_mag")</param>
+      <param name="orientation_sensors_list">("rfeimu_eul")</param>
     </group>
 
   </group>


### PR DESCRIPTION
This modification follows from the possibility to log also the orientation from the IMU on the head of iCub3 (https://github.com/ami-iit/robots-configuration/commit/4f3ce7f8197cadf849319d18aa860600a2b36afa).