### PR TITLE
Update YarpRobotLoggerDevice documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented in this file.
 - Add virtual destrutors in `System::Sink`, `System::Source`, `System::LinearTask`,
 `System::ITaskControlMode`, `TSID::TSIDLinearTask` and `IK::IKLinearTask` classes (https://github.com/ami-iit/bipedal-locomotion-framework/pull/480)
 - The joint torques is now correctly retrieved in QPTSID class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/482)
+- Fix `YarpRobotLoggerDevice` documentation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/472)
 
 ## [0.5.0] - 2021-11-30
 ### Added

--- a/devices/YarpRobotLoggerDevice/README.md
+++ b/devices/YarpRobotLoggerDevice/README.md
@@ -10,13 +10,13 @@ The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `
 
   Depending on your logger configuration file and on the data you want to collect you should run the main `yarprobotinterface` with a different option. In order to use the [defaul logger configuration files](./app/robots), use the following commands:
   - **iCubGenova04**
-  
+
     launch the `yarprobotinterface` with the `root_imu` device on the robot head
     ```
     yarprobotinterface --config icub_wbd_inertials.xml
     ```
   - **iCubGazeboV3**
-  
+
     open the robot model in gazebo and launch `whole-body-dynamics`
     ```
     YARP_ROBOT_NAME=iCubGazeboV3 yarprobotinterface --config launch-wholebodydynamics.xml

--- a/devices/YarpRobotLoggerDevice/README.md
+++ b/devices/YarpRobotLoggerDevice/README.md
@@ -6,9 +6,25 @@ The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `
 
 ## :running: How to use the device
 
-- Launch yarprobotinterface on the robot 
+- Launch `yarprobotinterface` on the robot.
+  Depending on your logger configuration file and on the data you want to collect you should run the main `yarprobotinterface` with a different option. In order to use the [defaul logger configuration files](./app/robots), use the following commands:
+  - **iCubGenova04**
+    launch the `yarprobotinterface` with the `root_imu` device on the robot head
+    ```
+    yarprobotinterface --config icub_wbd_inertials.xml
+    ```
+  - **iCubGazeboV3**
+    open the robot model in gazebo and launch `whole-body-dynamics`
+    ```
+    YARP_ROBOT_NAME=iCubGazeboV3 yarprobotinterface --config launch-wholebodydynamics.xml
+    ```
+    in case you started gazebo with the real-time clock option (`gazebo -slibgazebo_yarp_clock.so`) add `YARP_CLOCK=/clock` to the previous command.
+    ```
+    YARP_CLOCK=/clock YARP_ROBOT_NAME=iCubGazeboV3 yarprobotinterface --config launch-wholebodydynamics.xml
+    ```
 
-- Launch the logger device after properly setting the `YARP_ROBOT_NAME` environment variable
+- Launch the logger device.
+  In order to use the [defaul logger configuration files](./app/robots), set the `YARP_ROBOT_NAME` environment variable and launch the `yarprobotinterface` as follow
   ```
   yarprobotinterface --config launch-yarp-robot-logger.xml
   ```

--- a/devices/YarpRobotLoggerDevice/README.md
+++ b/devices/YarpRobotLoggerDevice/README.md
@@ -7,13 +7,16 @@ The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `
 ## :running: How to use the device
 
 - Launch `yarprobotinterface` on the robot.
+  
   Depending on your logger configuration file and on the data you want to collect you should run the main `yarprobotinterface` with a different option. In order to use the [defaul logger configuration files](./app/robots), use the following commands:
   - **iCubGenova04**
+    
     launch the `yarprobotinterface` with the `root_imu` device on the robot head
     ```
     yarprobotinterface --config icub_wbd_inertials.xml
     ```
   - **iCubGazeboV3**
+    
     open the robot model in gazebo and launch `whole-body-dynamics`
     ```
     YARP_ROBOT_NAME=iCubGazeboV3 yarprobotinterface --config launch-wholebodydynamics.xml
@@ -24,6 +27,7 @@ The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `
     ```
 
 - Launch the logger device.
+  
   In order to use the [defaul logger configuration files](./app/robots), set the `YARP_ROBOT_NAME` environment variable and launch the `yarprobotinterface` as follow
   ```
   yarprobotinterface --config launch-yarp-robot-logger.xml
@@ -44,7 +48,7 @@ The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `
   - `motor_currents`
   - `motor_velocities`
   - `motor_positions`
-- `PID` 
+- `PID`
 - `Motor_PWM`
 - `Accelerometer` struct containing data for each selected source.
 - `CartesianWrench` struct containing data for each selected source.

--- a/devices/YarpRobotLoggerDevice/README.md
+++ b/devices/YarpRobotLoggerDevice/README.md
@@ -18,7 +18,7 @@ The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `
 ## 💾 Data
 
  Depending on the configuration file, each dataset can contain:
- - `time` vector with the receive time stamps.
+ - `time` vector with the YARP clock time stamps.
  - `joint_state` that containins
    - `joints`: name of the joints
    - `joint_positions`

--- a/devices/YarpRobotLoggerDevice/README.md
+++ b/devices/YarpRobotLoggerDevice/README.md
@@ -15,7 +15,7 @@ The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `
 
 - Press Ctrl+c to close the device, and the dataset is stored as the device is closed.
 
-## Data
+## 💾 Data
 
  Depending on the configuration file, each dataset can contain:
  - `time` vector with the receive time stamps.

--- a/devices/YarpRobotLoggerDevice/README.md
+++ b/devices/YarpRobotLoggerDevice/README.md
@@ -1,47 +1,38 @@
-### iCubGenova04 strain2 FT-IMU logger
+# YARPRobotLoggerDevice
 
-A logger device based on `YarpSensorBridge` and `matioCpp` to record dataset from strain2 sensor boards mounted on the iCubGenova04 robot.
+The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `matioCpp` to record dataset from a YARP-based robot.
 
 
 
-### Launching
+## :running: How to use the device
 
-- Launch yarprobotinterface on the robot with `icub_wbd_inertials.xml`
+- Launch yarprobotinterface on the robot 
 
+- Launch the logger device after properly setting the `YARP_ROBOT_NAME` environment variable
   ```
-  yarprobotinterface --config icub_wbd_inertials.xml
-  ```
-
-- Launch the FT-IMU logger device,
-  ```
-  YARP_ROBOT_NAME=iCubGenova04 yarprobotinterface --config launch-ft-imu-logger.xml
+  yarprobotinterface --config launch-yarp-robot-logger.xml
   ```
 
 - Press Ctrl+c to close the device, and the dataset is stored as the device is closed.
 
- Each dataset contains,
+## Data
 
- - a `time` vector with the receive time stamps.
- - a struct for each strain-2 sensor attached on the robot (`l_foot_ft_imu`, `r_foot_ft_imu`, `r_leg_ft_imu`, `l_leg_ft_imu`) with each struct containing the corresponding FT sensor measurement, accelerometer, gyroscope and orientation sensor measurements.
+ Depending on the configuration file, each dataset can contain:
+ - `time` vector with the receive time stamps.
+ - `joint_state` that containins
+   - `joints`: name of the joints
+   - `joint_positions`
+   - `joint_velocities`
+   - `joint_torques`
+- `Motor_state` that contains
+  - `motor_currents`
+  - `motor_velocities`
+  - `motor_positions`
+- `PID` 
+- `Motor_PWM`
+- `Accelerometer` struct containing data for each selected source.
+- `CartesianWrench` struct containing data for each selected source.
+- `FT` struct containing data for each selected source.
+- `Gyros` struct containing data for each selected source.
+- `Orientation` struct containing data for each selected source as roll-pitch-yaw euler angles.
 
-Associated sensors,
-- `l_leg_ft_imu`
-    - FT: `l_leg_ft_sensor`
-    - acc: `l_upper_leg_ft_acc_3b12`
-    - gyro: `l_upper_leg_ft_gyro_3b12`
-    - orientation: `l_upper_leg_ft_eul_3b12`
-- `l_foot_ft_imu`
-    - FT: `l_foot_ft_sensor`
-    - acc: `l_foot_ft_acc_3b13`
-    - gyro: `l_foot_ft_gyro_3b13`
-    - orientation: `l_foot_ft_eul_3b13`
-- `r_leg_ft_imu`
-    - FT: `r_leg_ft_sensor`
-    - acc: `r_upper_leg_ft_acc_3b11`
-    - gyro: `r_upper_leg_ft_gyro_3b11`
-    - orientation: `r_upper_leg_ft_eul_3b11`
-- `r_foot_ft_imu`
-    - FT: `r_foot_ft_sensor`
-    - acc: `r_foot_ft_acc_3b14`
-    - gyro: `r_foot_ft_gyro_3b14`
-    - orientation: `r_foot_ft_eul_3b14`

--- a/devices/YarpRobotLoggerDevice/README.md
+++ b/devices/YarpRobotLoggerDevice/README.md
@@ -7,16 +7,16 @@ The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `
 ## :running: How to use the device
 
 - Launch `yarprobotinterface` on the robot.
-  
+
   Depending on your logger configuration file and on the data you want to collect you should run the main `yarprobotinterface` with a different option. In order to use the [defaul logger configuration files](./app/robots), use the following commands:
   - **iCubGenova04**
-    
+  
     launch the `yarprobotinterface` with the `root_imu` device on the robot head
     ```
     yarprobotinterface --config icub_wbd_inertials.xml
     ```
   - **iCubGazeboV3**
-    
+  
     open the robot model in gazebo and launch `whole-body-dynamics`
     ```
     YARP_ROBOT_NAME=iCubGazeboV3 yarprobotinterface --config launch-wholebodydynamics.xml
@@ -27,7 +27,7 @@ The **YARPRobotLoggerDevice** is a YARP device based on `YarpSensorBridge` and `
     ```
 
 - Launch the logger device.
-  
+
   In order to use the [defaul logger configuration files](./app/robots), set the `YARP_ROBOT_NAME` environment variable and launch the `yarprobotinterface` as follow
   ```
   yarprobotinterface --config launch-yarp-robot-logger.xml


### PR DESCRIPTION
The documentation for the `YarpRobotLoggerDevice` was not up-to-date, I have replaced it with a more general one with all the new features.

I have also noticed currently, as far as I see, the devices are not mentioned in the main `README.md`. Not sure if that's because they are still not stable, or it is simply missing.

cc @isorrentino 