### PR TITLE
Implement a first order smoother

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project are documented in this file.
 ### Added
 - Add the reading of the orientation of the head IMU in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/471)
 - Add the possibility to change the weight in TSID/IK (https://github.com/ami-iit/bipedal-locomotion-framework/pull/475)
+- Implement a `FirstOrderSmoother` class in `ContinuousDynamicalSystem` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/476)
+- Implement `getIntegrationStep` in `FixedIntegration` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/476)
+
 ### Changed
 - Use yarp clock instead of system clock in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/473)
 
 ### Fix
 - Fix the population of the jointAccelerations and baseAcceleration variables in QPTSID (https://github.com/ami-iit/bipedal-locomotion-framework/pull/478)
+- Fix the documentation in the `Advanceable` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/476)
 
 ## [0.5.0] - 2021-11-30
 ### Added

--- a/src/ContinuousDynamicalSystem/CMakeLists.txt
+++ b/src/ContinuousDynamicalSystem/CMakeLists.txt
@@ -11,12 +11,13 @@ if(FRAMEWORK_COMPILE_ContinuousDynamicalSystem)
   add_bipedal_locomotion_library(
     NAME                   ContinuousDynamicalSystem
     PUBLIC_HEADERS         ${H_PREFIX}/DynamicalSystem.h ${H_PREFIX}/LinearTimeInvariantSystem.h
-                           ${H_PREFIX}/FloatingBaseSystemKinematics.h ${H_PREFIX}/FloatingBaseDynamicsWithCompliantContacts.h ${H_PREFIX}/FixedBaseDynamics.h
+                           ${H_PREFIX}/FloatingBaseSystemKinematics.h ${H_PREFIX}/FloatingBaseDynamicsWithCompliantContacts.h ${H_PREFIX}/FixedBaseDynamics.h ${H_PREFIX}/FirstOrderSmoother.h
                            ${H_PREFIX}/Integrator.h  ${H_PREFIX}/FixedStepIntegrator.h ${H_PREFIX}/ForwardEuler.h
                            ${H_PREFIX}/CompliantContactWrench.h
     PRIVATE_HEADERS        ${H_PREFIX}/impl/traits.h
     SOURCES                src/LinearTimeInvariantSystem.cpp src/FloatingBaseSystemKinematics.cpp src/CompliantContactWrench.cpp src/FloatingBaseDynamicsWithCompliantContacts.cpp src/FixedBaseDynamics.cpp
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ContactModels
+                           src/FirstOrderSmoother.cpp
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ContactModels BipedalLocomotion::System
                            iDynTree::idyntree-high-level iDynTree::idyntree-model
                            Eigen3::Eigen BipedalLocomotion::TextLogging BipedalLocomotion::Math
     PRIVATE_LINK_LIBRARIES BipedalLocomotion::CommonConversions

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FirstOrderSmoother.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FirstOrderSmoother.h
@@ -1,0 +1,96 @@
+/**
+ * @file FirstOrderSmoother.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_FIRST_ORDER_SMOOTHER_H
+#define BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_FIRST_ORDER_SMOOTHER_H
+
+#include <memory>
+
+#include <BipedalLocomotion/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h>
+#include <BipedalLocomotion/ContinuousDynamicalSystem/ForwardEuler.h>
+#include <BipedalLocomotion/System/Advanceable.h>
+
+#include <Eigen/Dense>
+
+namespace BipedalLocomotion
+{
+namespace ContinuousDynamicalSystem
+{
+
+/**
+ * FirstOrderSmoother smoother implements a simple smoother based on a first order linear
+ * system. The system is described by the following ode
+ * \f[
+ * \dot{x} = a (-x + u)
+ * \f]
+ * where the \f$a\f$ is given by \f$a = 3.0/T_{s_5}\f$. \f$T_{s_5}\f$ is the settling time at 5%.
+ * The linear system is propagated with a Forward Euler integrator.
+ */
+class FirstOrderSmoother
+    : public BipedalLocomotion::System::Advanceable<Eigen::VectorXd, Eigen::VectorXd>
+{
+public:
+    /**
+     * Initialize the Dynamical system.
+     * @param handler pointer to the parameter handler.
+     * @note the following parameters are required
+     * |   Parameter Name  |   Type   |                   Description                    | Mandatory |
+     * |:-----------------:|:--------:|:------------------------------------------------:|:---------:|
+     * |  `sampling_time`  | `double` | Sampling time used to discrete the linear system |     Yes    |
+     * |  `settling_time`  | `double` | 5% settling time (The settling time, \f$T_s\f$, is the time required for the system output to fall within a certain percentage (i.e. 5%) of the steady-state value for a step input.) |    Yes    |
+     * @return true in case of success/false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
+
+    /**
+     * Set the state of the smoother.
+     * @param initialState initial state of the smoother
+     * @return true in case of success, false otherwise.
+     */
+    bool reset(Eigen::Ref<const Eigen::VectorXd> initialState);
+
+    /**
+     * @brief Perform one integration step using the input set by the FirstOrderSmoother::setInput
+     * method.
+     * @return True in case of success and false otherwise
+     */
+    bool advance() override;
+
+    /**
+     * Get the output of the smoother.
+     * @return a vector containing the outpur of the smoother
+     */
+    const Eigen::VectorXd& getOutput() const override;
+
+    /**
+     * @brief Set the input of the smoother
+     * @param input the vector representing the input of the smoother
+     * @return True in case of success and false otherwise
+     */
+    bool setInput(const Eigen::VectorXd& input) override;
+
+    /**
+     * Determines the validity of the object retrieved with getOutput()
+     * @return True if the object is valid, false otherwise.
+     */
+    bool isOutputValid() const override;
+
+private:
+    bool m_isInitialized{false};
+    bool m_isInitialStateSet{false};
+    bool m_isOutputValid{false};
+    double m_settlingTime{-1};
+    Eigen::VectorXd m_output;
+
+    std::shared_ptr<LinearTimeInvariantSystem> m_linearSystem;
+    ForwardEuler<LinearTimeInvariantSystem> m_integrator;
+};
+
+} // namespace ContinuousDynamicalSystem
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_FIRST_ORDER_SMOOTHER_H

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedStepIntegrator.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedStepIntegrator.h
@@ -37,6 +37,12 @@ public:
     bool setIntegrationStep(const double& dT);
 
     /**
+     * get the integration step time
+     * @return the integration step time
+     */
+    double getIntegrationStep() const;
+
+    /**
      * Integrate the dynamical system from initialTime to finalTime.
      * @note We assume a constant control input in the interval.
      * @param initialTime initial time of the integration.
@@ -58,6 +64,11 @@ template <class _Derived> bool FixedStepIntegrator<_Derived>::setIntegrationStep
     m_dT = dT;
 
     return true;
+}
+
+template <class _Derived> double FixedStepIntegrator<_Derived>::getIntegrationStep() const
+{
+    return m_dT;
 }
 
 template <class _Derived>

--- a/src/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
+++ b/src/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
@@ -1,0 +1,134 @@
+/**
+ * @file FirstOrderSmoother.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/ContinuousDynamicalSystem/FirstOrderSmoother.h>
+#include <BipedalLocomotion/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+using namespace BipedalLocomotion::ContinuousDynamicalSystem;
+
+bool FirstOrderSmoother::initialize(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> handler)
+{
+    constexpr auto logPrefix = "[FirstOrderSmoother::initialize]";
+    auto ptr = handler.lock();
+
+    if (ptr == nullptr)
+    {
+        log()->error("{} Invalid parameter handler.", logPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("settling_time", m_settlingTime))
+    {
+        log()->error("{} Unable to get the 'settling_time' parameter.", logPrefix);
+        return false;
+    }
+
+    double samplingTime{-1};
+    if (!ptr->getParameter("sampling_time", samplingTime))
+    {
+        log()->error("{} Unable to get the 'sampling_time' parameter.", logPrefix);
+        return false;
+    }
+    if (!m_integrator.setIntegrationStep(samplingTime))
+    {
+        log()->error("{} Unable to set the integration time step.", logPrefix);
+        return false;
+    }
+
+    m_linearSystem = std::make_shared<LinearTimeInvariantSystem>();
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool FirstOrderSmoother::reset(Eigen::Ref<const Eigen::VectorXd> initialPoint)
+{
+    constexpr auto logPrefix = "[FirstOrderSmoother::reset]";
+    m_isInitialStateSet = false;
+
+    if(!m_isInitialized)
+    {
+        log()->error("{} Please initialize the class before.", logPrefix);
+        return false;
+    }
+
+    // The following code is required to implement the following linear system
+    // dx = -a * x + a * u
+    // where a is given by 3.0 / settling_time
+    const int systemSize = initialPoint.size();
+    const Eigen::MatrixXd A = 3.0 / m_settlingTime //
+                              * Eigen::MatrixXd::Identity(systemSize, systemSize);
+
+    if(!m_linearSystem->setSystemMatrices(-A, A))
+    {
+        log()->error("{} Unable to set the linear system matrices.", logPrefix);
+        return false;
+    }
+    if (!m_linearSystem->setState(initialPoint))
+    {
+        log()->error("{} Unable to initialize the system.", logPrefix);
+        return false;
+    }
+    if (!m_integrator.setDynamicalSystem(m_linearSystem))
+    {
+        log()->error("{} Unable to initialize integrator.", logPrefix);
+        return false;
+    }
+
+    m_output = initialPoint;
+    m_isInitialStateSet = true;
+
+    return true;
+}
+
+bool FirstOrderSmoother::advance()
+{
+
+    m_isOutputValid = false;
+
+    if(!m_isInitialized || !m_isInitialStateSet)
+    {
+        log()->error("[FirstOrderSmoother::advance] Please call initialize() and reset() before "
+                     "advance.");
+        return false;
+    }
+
+    if (!m_integrator.integrate(0, m_integrator.getIntegrationStep()))
+    {
+        log()->error("[FirstOrderSmoother::advance] Unable to propagate the dynamical system.");
+        return false;
+    }
+
+    m_output = std::get<0>(m_linearSystem->getState());
+    m_isOutputValid = true;
+
+    return true;
+}
+
+bool FirstOrderSmoother::setInput(const Eigen::VectorXd& input)
+{
+    if (!m_isInitialized || !m_isInitialStateSet)
+    {
+        log()->error("[FirstOrderSmoother::setInput] Please call initialize() and reset() before "
+                     "advance.");
+        return false;
+    }
+
+    return m_linearSystem->setControlInput(input);
+}
+
+const Eigen::VectorXd& FirstOrderSmoother::getOutput() const
+{
+    return m_output;
+}
+
+bool FirstOrderSmoother::isOutputValid() const
+{
+    return m_isOutputValid;
+}

--- a/src/ContinuousDynamicalSystem/tests/CMakeLists.txt
+++ b/src/ContinuousDynamicalSystem/tests/CMakeLists.txt
@@ -12,3 +12,8 @@ add_bipedal_test(
   NAME IntegratorFloatingBaseSystemKinematicsTest
   SOURCES IntegratorFloatingBaseSystemKinematics.cpp
   LINKS BipedalLocomotion::ContinuousDynamicalSystem Eigen3::Eigen)
+
+add_bipedal_test(
+  NAME FirstOrderSmootherTest
+  SOURCES FirstOrderSmoother.cpp
+  LINKS BipedalLocomotion::ContinuousDynamicalSystem Eigen3::Eigen)

--- a/src/ContinuousDynamicalSystem/tests/FirstOrderSmoother.cpp
+++ b/src/ContinuousDynamicalSystem/tests/FirstOrderSmoother.cpp
@@ -1,0 +1,94 @@
+/**
+ * @file FirstOrderSmoother.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <limits>
+#include <memory>
+
+// Catch2
+#include <catch2/catch.hpp>
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/ContinuousDynamicalSystem/FirstOrderSmoother.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+using namespace BipedalLocomotion::ContinuousDynamicalSystem;
+
+TEST_CASE("First order smoother")
+{
+    constexpr double dT = 0.0001;
+    constexpr double settlingTime = 0.1;
+    constexpr double tolerance = 1e-2;
+
+    auto params = std::make_shared<BipedalLocomotion::ParametersHandler::StdImplementation>();
+    params->setParameter("settling_time", settlingTime);
+    params->setParameter("sampling_time", dT);
+
+    FirstOrderSmoother smoother;
+    REQUIRE(smoother.initialize(params));
+
+    Eigen::Vector2d initialState = Eigen::Vector2d::Zero();
+    Eigen::Vector2d input = Eigen::Vector2d::Ones();
+
+    REQUIRE(smoother.reset(initialState));
+    REQUIRE(smoother.setInput(input));
+
+    double settilingTimeSubSystem1 = std::numeric_limits<double>::infinity();
+    double settilingTimeSubSystem2 = std::numeric_limits<double>::infinity();
+    bool settilingSubSystem1 = false;
+    bool settilingSubSystem2 = false;
+
+    // the presented dynamical has the following close form solution in case of step response
+    auto closeFormSolution = [settlingTime](const double& t) -> Eigen::Vector2d {
+        const double a = 3.0 / settlingTime;
+        Eigen::Vector2d sol;
+        sol(0) = 1 - std::exp(-a * t);
+        sol(1) = 1 - std::exp(-a * t);
+        return sol;
+    };
+
+    for (unsigned int i = 0; i < 1000; i++)
+    {
+        const Eigen::Vector2d output = smoother.getOutput();
+
+        // check if the solution is similar to the expected one
+        REQUIRE(output.isApprox(closeFormSolution(dT * i), tolerance));
+
+        if (!settilingSubSystem1)
+        {
+            if ((output[0] > 0.95) && (output[0] < 1.05))
+            {
+                settilingTimeSubSystem1 = i * dT;
+                settilingSubSystem1 = true;
+            }
+        } else if ((output[0] < 0.95) || (output[0] > 1.05))
+        {
+            settilingTimeSubSystem1 = std::numeric_limits<double>::infinity();
+            settilingSubSystem1 = false;
+        }
+
+        if (!settilingSubSystem2)
+        {
+            if ((output[1] > 0.95) && (output[1] < 1.05))
+            {
+                settilingTimeSubSystem2 = i * dT;
+                settilingSubSystem2 = true;
+            }
+        } else if ((output[1] < 0.95) || (output[1] > 1.05))
+        {
+            settilingTimeSubSystem2 = std::numeric_limits<double>::infinity();
+            settilingSubSystem2 = false;
+        }
+
+        // advance the smoother
+        REQUIRE(smoother.advance());
+    }
+
+    // check the settling time
+    REQUIRE(settilingTimeSubSystem1 <= settlingTime);
+    REQUIRE(settilingTimeSubSystem2 <= settlingTime);
+}

--- a/src/System/include/BipedalLocomotion/System/Advanceable.h
+++ b/src/System/include/BipedalLocomotion/System/Advanceable.h
@@ -52,8 +52,9 @@ public:
     virtual const Output& getOutput() const = 0;
 
     /**
-     * @brief Get the object.
-     * @return a const reference of the requested object.
+     * @brief Set the input of the Advanceable
+     * @param input the input of the Advanceable
+     * @return True in case of success and false otherwise
      */
     virtual bool setInput(const Input& input) = 0;
 


### PR DESCRIPTION
This can be used to perform gain-scheduling as explained in https://github.com/ami-iit/bipedal-locomotion-framework/issues/474

This is the last block missing to use the blf IK in the walking module