### PR TITLE
Reduce code duplication in python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 - Use yarp clock instead of system clock in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/473)
+- Reduce code duplication in python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/484)
 
 ### Fix
 - Fix the population of the jointAccelerations and baseAcceleration variables in QPTSID (https://github.com/ami-iit/bipedal-locomotion-framework/pull/478)

--- a/bindings/python/Contacts/src/ContactDetectors.cpp
+++ b/bindings/python/Contacts/src/ContactDetectors.cpp
@@ -14,6 +14,7 @@
 #include <BipedalLocomotion/ContactDetectors/SchmittTriggerDetector.h>
 
 #include <BipedalLocomotion/bindings/Contacts/ContactDetectors.h>
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
 
 namespace BipedalLocomotion
 {
@@ -29,7 +30,8 @@ void CreateContactDetector(pybind11::module& module)
     using namespace BipedalLocomotion::System;
     using namespace BipedalLocomotion::ParametersHandler;
 
-    py::class_<Source<EstimatedContactList>>(module, "EstimatedContactListSource");
+    BipedalLocomotion::bindings::System::CreateSource<EstimatedContactList>(module,
+                                                                            "ContactDetector");
     py::class_<ContactDetector, Source<EstimatedContactList>>(module, "ContactDetector");
 }
 
@@ -81,18 +83,10 @@ void CreateSchmittTriggerDetector(pybind11::module& module)
 
     py::class_<SchmittTriggerDetector, ContactDetector>(module, "SchmittTriggerDetector")
         .def(py::init())
-        .def(
-            "initialize",
-            [](SchmittTriggerDetector& impl, std::shared_ptr<const IParametersHandler> handler)
-                -> bool { return impl.initialize(handler); },
-            py::arg("handler"))
-        .def("advance", &SchmittTriggerDetector::advance)
         .def("reset_contacts", &SchmittTriggerDetector::resetContacts)
-        .def("get_output", &SchmittTriggerDetector::getOutput)
         .def("get",
              py::overload_cast<const std::string&>(&SchmittTriggerDetector::get, py::const_),
              py::arg("contact_name"))
-        .def("is_output_valid", &SchmittTriggerDetector::isOutputValid)
         .def("set_timed_trigger_input",
              &SchmittTriggerDetector::setTimedTriggerInput,
              py::arg("contact_name"),
@@ -137,13 +131,6 @@ void CreateFixedFootDetector(pybind11::module& module)
 
     py::class_<FixedFootDetector, ContactDetector>(module, "FixedFootDetector")
         .def(py::init())
-        .def(
-            "initialize",
-            [](FixedFootDetector& impl, std::shared_ptr<const IParametersHandler> handler) -> bool {
-                return impl.initialize(handler);
-            },
-            py::arg("handler"))
-        .def("advance", &FixedFootDetector::advance)
         .def("get_fixed_foot", &FixedFootDetector::getFixedFoot)
         .def("set_contact_phase_list",
              &FixedFootDetector::setContactPhaseList,

--- a/bindings/python/FloatingBaseEstimators/src/FloatingBaseEstimators.cpp
+++ b/bindings/python/FloatingBaseEstimators/src/FloatingBaseEstimators.cpp
@@ -9,12 +9,14 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <iDynTree/Model/Model.h>
+
 #include <BipedalLocomotion/Conversions/ManifConversions.h>
 #include <BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h>
 #include <BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h>
 #include <BipedalLocomotion/Math/Constants.h>
-#include <iDynTree/Model/Model.h>
 
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
 
 namespace BipedalLocomotion
 {
@@ -234,7 +236,8 @@ void CreateFloatingBaseEstimator(pybind11::module& module)
         .def_readwrite("forward_kinematics_noise", &SensorsStdDev::forwardKinematicsNoise)
         .def_readwrite("encoders_noise", &SensorsStdDev::encodersNoise);
 
-    py::class_<Source<Output>>(module, "FloatingBaseEstimatorOutputSource");
+    BipedalLocomotion::bindings::System::CreateSource<Output>(module,
+                                                              "FloatingBaseEstimatorOutput");
 
     py::class_<FloatingBaseEstimator, Source<Output>> floatingBaseEstimator( //
         module,
@@ -255,7 +258,6 @@ void CreateFloatingBaseEstimator(pybind11::module& module)
              &FloatingBaseEstimator::setKinematics,
              py::arg("encoders"),
              py::arg("encoder_speeds"))
-        .def("advance", &FloatingBaseEstimator::advance)
         .def("reset_estimator",
              py::overload_cast<const InternalState&>(&FloatingBaseEstimator::resetEstimator),
              py::arg("new_state"))
@@ -264,8 +266,6 @@ void CreateFloatingBaseEstimator(pybind11::module& module)
                  &FloatingBaseEstimator::resetEstimator),
              py::arg("new_base_orientation"),
              py::arg("new_base_position"))
-        .def("get_output", &FloatingBaseEstimator::getOutput)
-        .def("is_output_valid", &FloatingBaseEstimator::isOutputValid)
         .def(
             "initialize",
             [](FloatingBaseEstimator& impl,

--- a/bindings/python/IK/src/IntegrationBasedIK.cpp
+++ b/bindings/python/IK/src/IntegrationBasedIK.cpp
@@ -13,6 +13,7 @@
 #include <BipedalLocomotion/System/Source.h>
 
 #include <BipedalLocomotion/bindings/IK/IntegrationBasedIK.h>
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
 #include <BipedalLocomotion/bindings/System/ILinearTaskSolver.h>
 
 namespace BipedalLocomotion
@@ -33,7 +34,8 @@ void CreateIntegrationBasedIK(pybind11::module& module)
         .def_readwrite("joint_velocity", &IntegrationBasedIKState::jointVelocity)
         .def_readwrite("base_velocity", &IntegrationBasedIKState::baseVelocity);
 
-    py::class_<Source<IntegrationBasedIKState>>(module, "IntegrationBasedIKStateSource");
+    BipedalLocomotion::bindings::System::CreateSource<IntegrationBasedIKState> //
+        (module, "IntegrationBasedIK");
 
     BipedalLocomotion::bindings::System::CreateILinearTaskSolver<IKLinearTask,
                                                                  IntegrationBasedIKState> //

--- a/bindings/python/Planners/src/DCMPlanner.cpp
+++ b/bindings/python/Planners/src/DCMPlanner.cpp
@@ -1,6 +1,6 @@
 /**
  * @file DCMPlanner.cpp
- * @authors DiegoFerigo
+ * @authors Diego Ferigo, Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
  */
@@ -10,8 +10,9 @@
 #include <pybind11/stl.h>
 
 #include <BipedalLocomotion/Planners/DCMPlanner.h>
-#include <BipedalLocomotion/System/Source.h>
+
 #include <BipedalLocomotion/bindings/Planners/DCMPlanner.h>
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
 
 namespace BipedalLocomotion
 {
@@ -34,7 +35,7 @@ void CreateDCMPlanner(pybind11::module& module)
         .def_readwrite("omega", &DCMPlannerState::omega)
         .def_readwrite("omega_dot", &DCMPlannerState::omegaDot);
 
-    py::class_<Source<DCMPlannerState>>(module, "DCMPlannerStateSource");
+    BipedalLocomotion::bindings::System::CreateSource<DCMPlannerState>(module, "DCMPlanner");
 
     py::class_<DCMPlanner, Source<DCMPlannerState>>(module, "DCMPlanner")
         .def("set_initial_state", &DCMPlanner::setInitialState, py::arg("state"))
@@ -43,6 +44,6 @@ void CreateDCMPlanner(pybind11::module& module)
              py::arg("contact_phase_list"));
 }
 
-}
-}
-}
+} // namespace Planners
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/Planners/src/SwingFootPlanner.cpp
+++ b/bindings/python/Planners/src/SwingFootPlanner.cpp
@@ -11,9 +11,9 @@
 
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotion/Planners/SwingFootPlanner.h>
-#include <BipedalLocomotion/System/Source.h>
 
 #include <BipedalLocomotion/bindings/Planners/SwingFootPlanner.h>
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
 
 namespace BipedalLocomotion
 {
@@ -54,20 +54,12 @@ void CreateSwingFootPlanner(pybind11::module& module)
                 s.mixedAcceleration.coeffs() = coeffs;
             });
 
-    py::class_<Source<SwingFootPlannerState>>(module, "SwingFootPlannerStateSource");
+    BipedalLocomotion::bindings::System::CreateSource<SwingFootPlannerState> //
+        (module, "SwingFootPlanner");
 
     py::class_<SwingFootPlanner, Source<SwingFootPlannerState>>(module, "SwingFootPlanner")
         .def(py::init())
-        .def(
-            "initialize",
-            [](SwingFootPlanner& impl, std::shared_ptr<const IParametersHandler> handler) -> bool {
-                return impl.initialize(handler);
-            },
-            py::arg("handler"))
-        .def("set_contact_list", &SwingFootPlanner::setContactList, py::arg("contact_list"))
-        .def("get_output", &SwingFootPlanner::getOutput)
-        .def("is_output_valid", &SwingFootPlanner::isOutputValid)
-        .def("advance", &SwingFootPlanner::advance);
+        .def("set_contact_list", &SwingFootPlanner::setContactList, py::arg("contact_list"));
 }
 
 } // namespace Planners

--- a/bindings/python/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/bindings/python/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -11,7 +11,7 @@
 
 #include <BipedalLocomotion/Planners/DCMPlanner.h>
 #include <BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h>
-#include <BipedalLocomotion/System/Source.h>
+
 #include <BipedalLocomotion/bindings/Planners/TimeVaryingDCMPlanner.h>
 
 namespace BipedalLocomotion
@@ -28,16 +28,7 @@ void CreateTimeVaryingDCMPlanner(pybind11::module& module)
 
     py::class_<TimeVaryingDCMPlanner, DCMPlanner>(module, "TimeVaryingDCMPlanner")
         .def(py::init())
-        .def(
-            "initialize",
-            [](TimeVaryingDCMPlanner& impl,
-               std::shared_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler>
-                   handler) -> bool { return impl.initialize(handler); },
-            py::arg("handler"))
         .def("compute_trajectory", &TimeVaryingDCMPlanner::computeTrajectory)
-        .def("get_output", &TimeVaryingDCMPlanner::getOutput)
-        .def("is_output_valid", &TimeVaryingDCMPlanner::isOutputValid)
-        .def("advance", &TimeVaryingDCMPlanner::advance)
         .def("set_contact_phase_list",
              &TimeVaryingDCMPlanner::setContactPhaseList,
              py::arg("contact_phase_list"))

--- a/bindings/python/Planners/src/UnicyclePlanner.cpp
+++ b/bindings/python/Planners/src/UnicyclePlanner.cpp
@@ -5,10 +5,12 @@
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
  */
 
-#include "BipedalLocomotion/Planners/UnicyclePlanner.h"
-#include "BipedalLocomotion/Contacts/ContactList.h"
-#include "BipedalLocomotion/ParametersHandler/IParametersHandler.h"
-#include "BipedalLocomotion/System/Advanceable.h"
+#include <BipedalLocomotion/Contacts/ContactList.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/Planners/UnicyclePlanner.h>
+#include <BipedalLocomotion/System/Advanceable.h>
+
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
@@ -91,24 +93,15 @@ void CreateUnicyclePlanner(pybind11::module& module)
                    ")";
         });
 
-    py::class_<Advanceable<UnicyclePlannerInput, UnicyclePlannerOutput>>( //
+    BipedalLocomotion::bindings::System::CreateAdvanceable<UnicyclePlannerInput,
+                                                           UnicyclePlannerOutput>( //
         module,
-        "UnicyclePlannerAdvanceable");
+        "UnicyclePlanner");
 
     py::class_<UnicyclePlanner, Advanceable<UnicyclePlannerInput, UnicyclePlannerOutput>>( //
         module,
         "UnicyclePlanner")
-        .def(py::init())
-        .def(
-            "initialize",
-            [](UnicyclePlanner& impl, std::shared_ptr<const IParametersHandler> handler) -> bool {
-                return impl.initialize(handler);
-            },
-            py::arg("handler"))
-        .def("get_output", &UnicyclePlanner::getOutput)
-        .def("is_output_valid", &UnicyclePlanner::isOutputValid)
-        .def("set_input", &UnicyclePlanner::setInput, py::arg("input"))
-        .def("advance", &UnicyclePlanner::advance);
+        .def(py::init());
 }
 
 } // namespace BipedalLocomotion::bindings::Planners

--- a/bindings/python/System/include/BipedalLocomotion/bindings/System/Advanceable.h
+++ b/bindings/python/System/include/BipedalLocomotion/bindings/System/Advanceable.h
@@ -1,0 +1,80 @@
+/**
+ * @file Advanceable.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_ADVANCEABLE_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_ADVANCEABLE_H
+
+#include <string>
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/System/Advanceable.h>
+#include <BipedalLocomotion/System/Sink.h>
+#include <BipedalLocomotion/System/Source.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace System
+{
+
+template <class Input, class Output>
+void CreateAdvanceable(pybind11::module& module, const std::string& pythonClassName)
+{
+    namespace py = ::pybind11;
+    const std::string advanceableName = "_" + pythonClassName + "Advanceable";
+    py::class_<::BipedalLocomotion::System::Advanceable<Input, Output>> //
+        (module, advanceableName.c_str())
+            .def(
+                "initialize",
+                [](::BipedalLocomotion::System::Advanceable<Input, Output>& impl,
+                   std::shared_ptr<const ::BipedalLocomotion::ParametersHandler::IParametersHandler>
+                       handler) -> bool { return impl.initialize(handler); },
+                py::arg("handler"))
+            .def("get_output", &::BipedalLocomotion::System::Advanceable<Input, Output>::getOutput)
+            .def("is_output_valid",
+                 &::BipedalLocomotion::System::Advanceable<Input, Output>::isOutputValid)
+            .def("set_input",
+                 &::BipedalLocomotion::System::Advanceable<Input, Output>::setInput,
+                 py::arg("input"))
+            .def("advance", &::BipedalLocomotion::System::Advanceable<Input, Output>::advance)
+            .def("close", &::BipedalLocomotion::System::Advanceable<Input, Output>::close);
+}
+
+template <class Input> void CreateSink(pybind11::module& module, const std::string& pythonClassName)
+{
+    using Output = ::BipedalLocomotion::System::EmptySignal;
+    CreateAdvanceable<Input, Output>(module, pythonClassName);
+
+    namespace py = ::pybind11;
+    const std::string sinkName = "_" + pythonClassName + "Sink";
+    py::class_<::BipedalLocomotion::System::Sink<Input>,
+               ::BipedalLocomotion::System::Advanceable<Input, Output>> //
+        (module, sinkName.c_str());
+}
+
+template <class Output>
+void CreateSource(pybind11::module& module, const std::string& pythonClassName)
+{
+    using Input = ::BipedalLocomotion::System::EmptySignal;
+    CreateAdvanceable<Input, Output>(module, pythonClassName);
+
+    namespace py = ::pybind11;
+    const std::string sourceName = "_" + pythonClassName + "Source";
+    py::class_<::BipedalLocomotion::System::Source<Output>,
+               ::BipedalLocomotion::System::Advanceable<Input, Output>> //
+        (module, sourceName.c_str());
+}
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_ADVANCEABLE_H

--- a/bindings/python/TSID/src/QPTSID.cpp
+++ b/bindings/python/TSID/src/QPTSID.cpp
@@ -11,7 +11,7 @@
 
 #include <BipedalLocomotion/TSID/QPFixedBaseTSID.h>
 #include <BipedalLocomotion/TSID/QPTSID.h>
-#include <BipedalLocomotion/System/Source.h>
+
 #include <BipedalLocomotion/bindings/TSID/QPTSID.h>
 
 namespace BipedalLocomotion

--- a/bindings/python/TSID/src/TaskSpaceInverseDynamics.cpp
+++ b/bindings/python/TSID/src/TaskSpaceInverseDynamics.cpp
@@ -13,6 +13,7 @@
 #include <BipedalLocomotion/TSID/TaskSpaceInverseDynamics.h>
 
 #include <BipedalLocomotion/bindings/System/ILinearTaskSolver.h>
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
 #include <BipedalLocomotion/bindings/TSID/TaskSpaceInverseDynamics.h>
 
 namespace BipedalLocomotion
@@ -34,7 +35,7 @@ void CreateTaskSpaceInverseDynamics(pybind11::module& module)
         .def_readwrite("joint_torques", &TSIDState::jointTorques)
         .def_readwrite("contact_wrenches", &TSIDState::contactWrenches);
 
-    py::class_<::BipedalLocomotion::System::Source<TSIDState>>(module, "TSIDStateSource");
+    BipedalLocomotion::bindings::System::CreateSource<TSIDState>(module, "ILinearTaskSolverTSID");
 
     BipedalLocomotion::bindings::System::CreateILinearTaskSolver<TSIDLinearTask,
                                                                  TSIDState> //


### PR DESCRIPTION
This PR restructure the implementation of the bindings. In the long run, it should reduce the line of code required to add a new advanceable. 

Nothing change in the usage of the bindings