### PR TITLE
Ask for osqp-eigen 0.6.4.100

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   matioCpp_TAG: v0.1.0
   LieGroupControllers_TAG: v0.1.1
   osqp_TAG: v0.6.2
-  OsqpEigen_TAG: v0.6.3
+  OsqpEigen_TAG: 6ea453d3c8e9aa1414d83c9f1d877564586556eb
   tomlplusplus_TAG: v2.5.0
   UnicyclePlanner_TAG: d3f6c80afe21a9958da769c8dd8a2bbfee5ea922
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 - Use yarp clock instead of system clock in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/473)
 - Reduce code duplication in python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/484)
 - Use `TextLogger` in `YarpRobotLoggerDevice` instead of `yarp` commands (https://github.com/ami-iit/bipedal-locomotion-framework/pull/486)
+- Ask for `osqp-eigen 0.6.4.100`(https://github.com/ami-iit/bipedal-locomotion-framework/pull/490)
 
 ### Fix
 - Fix the population of the jointAccelerations and baseAcceleration variables in QPTSID (https://github.com/ami-iit/bipedal-locomotion-framework/pull/478)

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -39,9 +39,9 @@ find_package(manif 0.0.4 QUIET)
 checkandset_dependency(manif)
 dependency_classifier(manif MINIMUM_VERSION 0.0.4 IS_USED ${FRAMEWORK_USE_manif} PUBLIC)
 
-find_package(OsqpEigen 0.6.3 QUIET)
+find_package(OsqpEigen 0.6.4.100 QUIET)
 checkandset_dependency(OsqpEigen)
-dependency_classifier(OsqpEigen MINIMUM_VERSION 0.6.3 IS_USED ${FRAMEWORK_USE_OsqpEigen})
+dependency_classifier(OsqpEigen MINIMUM_VERSION 0.6.4.100 IS_USED ${FRAMEWORK_USE_OsqpEigen})
 
 find_package(Python3 3.6 COMPONENTS Interpreter Development QUIET)
 checkandset_dependency(Python3 MINIMUM_VERSION 3.6 COMPONENTS Interpreter Development)
@@ -161,7 +161,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_matioCppConversions
 
 framework_dependent_option(FRAMEWORK_COMPILE_TSID
   "Compile TSID library?" ON
-  "FRAMEWORK_COMPILE_System;FRAMEWORK_USE_LieGroupControllers;FRAMEWORK_COMPILE_ManifConversions;FRAMEWORK_USE_manif;FRAMEWORK_COMPILE_Contact" OFF)
+  "FRAMEWORK_COMPILE_System;FRAMEWORK_USE_LieGroupControllers;FRAMEWORK_COMPILE_ManifConversions;FRAMEWORK_USE_manif;FRAMEWORK_COMPILE_Contact;FRAMEWORK_USE_OsqpEigen" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_IK
   "Compile IK library?" ON

--- a/src/IK/src/QPInverseKinematics.cpp
+++ b/src/IK/src/QPInverseKinematics.cpp
@@ -464,10 +464,22 @@ bool QPInverseKinematics::advance()
     }
 
     // solve the QP
-    if (!m_pimpl->solver.solve())
+    if (m_pimpl->solver.solveProblem() != OsqpEigen::ErrorExitFlag::NoError)
     {
         log()->error("{} Unable to to solve the problem.", logPrefix);
         return false;
+    }
+
+    if (m_pimpl->solver.getStatus() != OsqpEigen::Status::Solved
+        && m_pimpl->solver.getStatus() != OsqpEigen::Status::SolvedInaccurate)
+    {
+        log()->error("{} osqp was not able to find a feasible solution.", logPrefix);
+        return false;
+    }
+
+    if (m_pimpl->solver.getStatus() == OsqpEigen::Status::SolvedInaccurate)
+    {
+        log()->debug("{} The solver found an inaccurate feasible solution.", logPrefix);
     }
 
     // retrieve the solution


### PR DESCRIPTION
With this PR, `osqp-eigen 0.6.4.100` is required to compile the IK and TSID components. Thanks to this modification it is now possible to get the optimal solution from the solver even if it is not accurate. 