### PR TITLE
Fix deprecated `YARP` functions in `YarpUtilities` component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   vcpkg_robotology_TAG: v0.7.0
-  YCM_TAG: v0.12.1
+  YCM_TAG: v0.13.0
   YARP_TAG: v3.5.0
   iDynTree_TAG: v3.1.0
   Catch2_TAG: v2.13.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 env:
   vcpkg_robotology_TAG: v0.7.0
   YCM_TAG: v0.12.1
-  YARP_TAG: v3.4.2
+  YARP_TAG: v3.5.0
   iDynTree_TAG: v3.1.0
   Catch2_TAG: v2.13.4
   Qhull_TAG: 2020.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 - Ask for `osqp-eigen 0.6.4.100`(https://github.com/ami-iit/bipedal-locomotion-framework/pull/490)
 - Use enum underlying type to convert `TextLogging` verbosity level to `spdlog` verbosity level (https://github.com/ami-iit/bipedal-locomotion-framework/pull/495)
 - `yarp-telemetry` is now a dependency of the `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/487)
+- Fix deprecated `YARP` functions in `YarpUtilities` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/491)
 
 ### Fix
 - Fix the population of the jointAccelerations and baseAcceleration variables in QPTSID (https://github.com/ami-iit/bipedal-locomotion-framework/pull/478)

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -24,7 +24,7 @@ checkandset_dependency(YARP MINIMUM_VERSION 3.5.0)
 dependency_classifier(YARP MINIMUM_VERSION 3.5.0 IS_USED ${FRAMEWORK_USE_YARP} PUBLIC)
 
 find_package(Qhull 8.0.0 QUIET)
-checkandset_dependency(Qhull 8.0.0)
+checkandset_dependency(Qhull MINIMUM_VERSION 8.0.0)
 dependency_classifier(Qhull MINIMUM_VERSION 8.0.0 IS_USED ${FRAMEWORK_USE_Qhull} PUBLIC)
 
 find_package(casadi QUIET)
@@ -36,11 +36,11 @@ checkandset_dependency(cppad)
 dependency_classifier(cppad PUBLIC IS_USED ${FRAMEWORK_USE_cppad})
 
 find_package(manif 0.0.4 QUIET)
-checkandset_dependency(manif)
+checkandset_dependency(manif MINIMUM_VERSION 0.0.4)
 dependency_classifier(manif MINIMUM_VERSION 0.0.4 IS_USED ${FRAMEWORK_USE_manif} PUBLIC)
 
 find_package(OsqpEigen 0.6.4.100 QUIET)
-checkandset_dependency(OsqpEigen)
+checkandset_dependency(OsqpEigen MINIMUM_VERSION 0.6.4.100)
 dependency_classifier(OsqpEigen MINIMUM_VERSION 0.6.4.100 IS_USED ${FRAMEWORK_USE_OsqpEigen})
 
 find_package(Python3 3.6 COMPONENTS Interpreter Development QUIET)
@@ -54,7 +54,7 @@ checkandset_dependency(matioCpp)
 dependency_classifier(matioCpp IS_USED ${FRAMEWORK_USE_matioCpp} PUBLIC)
 
 find_package(LieGroupControllers 0.1.1 QUIET)
-checkandset_dependency(LieGroupControllers)
+checkandset_dependency(LieGroupControllers MINIMUM_VERSION 0.1.1)
 dependency_classifier(LieGroupControllers MINIMUM_VERSION 0.1.1 IS_USED ${FRAMEWORK_USE_LieGroupControllers} PUBLIC)
 
 find_package(OpenCV QUIET)
@@ -70,11 +70,11 @@ checkandset_dependency(realsense2)
 dependency_classifier(realsense2 IS_USED ${FRAMEWORK_USE_realsense2} PUBLIC)
 
 find_package(nlohmann_json 3.7.3 QUIET)
-checkandset_dependency(nlohmann_json)
+checkandset_dependency(nlohmann_json MINIMUM_VERSION 3.7.3)
 dependency_classifier(nlohmann_json MINIMUM_VERSION 3.7.3 IS_USED ${FRAMEWORK_USE_nlohmann_json})
 
 find_package(tomlplusplus 2.4.0 QUIET)
-checkandset_dependency(tomlplusplus)
+checkandset_dependency(tomlplusplus MINIMUM_VERSION 2.4.0)
 dependency_classifier(tomlplusplus MINIMUM_VERSION 2.4.0 IS_USED ${FRAMEWORK_USE_tomlplusplus} PUBLIC)
 
 find_package(YARP_telemetry QUIET)

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -19,9 +19,9 @@ dependency_classifier(spdlog MINIMUM_VERSION 1.5.0 IS_USED TRUE PUBLIC)
 
 ########################## Optional dependencies ##############################
 
-find_package(YARP QUIET)
-checkandset_dependency(YARP)
-dependency_classifier(YARP IS_USED ${FRAMEWORK_USE_YARP} PUBLIC)
+find_package(YARP 3.5.0 QUIET)
+checkandset_dependency(YARP MINIMUM_VERSION 3.5.0)
+dependency_classifier(YARP MINIMUM_VERSION 3.5.0 IS_USED ${FRAMEWORK_USE_YARP} PUBLIC)
 
 find_package(Qhull 8.0.0 QUIET)
 checkandset_dependency(Qhull 8.0.0)

--- a/cmake/valgrind-linux.supp
+++ b/cmake/valgrind-linux.supp
@@ -101,3 +101,68 @@
    fun:_dl_init
    obj:/usr/lib/x86_64-linux-gnu/ld-2.31.so
 }
+
+{
+   <ubuntu-20.04-_dl_init-libgobject-libglib>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:realloc
+   fun:g_realloc
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   fun:g_type_register_fundamental
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/usr/lib/x86_64-linux-gnu/ld-2.31.so
+}
+
+{
+   <ubuntu-20.04-_dl_init-libgobject-libglib>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:g_malloc0
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   fun:g_type_register_fundamental
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/usr/lib/x86_64-linux-gnu/ld-2.31.so
+}
+
+{
+   <ubuntu-20.04-_dl_init-libgobject-libglib>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:realloc
+   fun:g_realloc
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   fun:g_type_register_static
+   fun:g_param_type_register_static
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/usr/lib/x86_64-linux-gnu/ld-2.31.so
+}
+
+{
+   <ubuntu-20.04-_dl_init-libgobject-libglib>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:g_malloc0
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/usr/lib/x86_64-linux-gnu/ld-2.31.so
+}

--- a/cmake/valgrind-linux.supp
+++ b/cmake/valgrind-linux.supp
@@ -99,5 +99,5 @@
    fun:call_init.part.0
    fun:call_init
    fun:_dl_init
-   obj:/usr/lib/x86_
+   obj:/usr/lib/x86_64-linux-gnu/ld-2.31.so
 }

--- a/cmake/valgrind-linux.supp
+++ b/cmake/valgrind-linux.supp
@@ -85,3 +85,19 @@
    fun:_ZNK3tbb10interface78internal15task_arena_base16internal_executeERNS1_13delegate_baseE
 }
 
+{
+   <ubuntu-20.04-_dl_init-libgobject-libglib>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:g_malloc0
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   fun:g_type_register_fundamental
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6400.6
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/usr/lib/x86_
+}

--- a/src/YarpUtilities/include/BipedalLocomotion/YarpUtilities/Helper.tpp
+++ b/src/YarpUtilities/include/BipedalLocomotion/YarpUtilities/Helper.tpp
@@ -31,11 +31,11 @@
      false ))))
 
 #define YARP_UTILITES_GET_CHECKER_NAME(type)                                                  \
-    ((std::is_same<type, int>::value) ? &yarp::os::Value::isInt :                             \
-    ((std::is_same<type, double>::value) ? &yarp::os::Value::isDouble :                       \
+    ((std::is_same<type, int>::value) ? &yarp::os::Value::isInt32 :                           \
+    ((std::is_same<type, double>::value) ? &yarp::os::Value::isFloat64 :                      \
     ((std::is_same<type, std::string>::value) ? &yarp::os::Value::isString :                  \
     ((std::is_same<type, bool>::value) ? &yarp::os::Value::isBool :                           \
-     &yarp::os::Value::isDouble ))))
+     &yarp::os::Value::isFloat64 ))))
 
 // clang-format on
 

--- a/src/YarpUtilities/src/Helper.cpp
+++ b/src/YarpUtilities/src/Helper.cpp
@@ -38,12 +38,12 @@ void YarpUtilities::populateBottleWithStrings(yarp::os::Bottle& bottle,
 
 template <> int YarpUtilities::convertValue<int>(const yarp::os::Value& value)
 {
-    return value.asInt();
+    return value.asInt32();
 }
 
 template <> double YarpUtilities::convertValue<double>(const yarp::os::Value& value)
 {
-    return value.asDouble();
+    return value.asFloat64();
 }
 
 template <> std::string YarpUtilities::convertValue<std::string>(const yarp::os::Value& value)

--- a/src/YarpUtilities/tests/YarpUtilitiesTest.cpp
+++ b/src/YarpUtilities/tests/YarpUtilitiesTest.cpp
@@ -82,7 +82,7 @@ TEST_CASE("Get int vector from searchable", "[std::vector<int>]")
     auto list = yarpValue.asList();
 
     for (const auto& v : value)
-        list->addInt(v);
+        list->addInt32(v);
 
     property.put(key, yarpValue);
 
@@ -159,7 +159,7 @@ TEST_CASE("Get iDynTree vector from searchable", "[iDynTree::VectorDynSize]")
     for (unsigned int i = 0; i < 6; i++)
     {
         double seriesElement = 0.5 * std::pow(0.5, i);
-        list->addDouble(seriesElement);
+        list->addFloat64(seriesElement);
         value[i] = seriesElement;
     }
     property.put(key, yarpValue);
@@ -183,7 +183,7 @@ TEST_CASE("Get YARP vector from searchable", "[yarp::sig::Vector]")
     for (unsigned int i = 0; i < 6; i++)
     {
         double seriesElement = 0.5 * std::pow(0.5, i);
-        list->addDouble(seriesElement);
+        list->addFloat64(seriesElement);
         value[i] = seriesElement;
     }
     property.put(key, yarpValue);


### PR DESCRIPTION
[`Yarp 3.5.0`](https://github.com/robotology/yarp/releases/tag/v3.5.0) has been released a while ago. This PR modifies the code `YarpUtilities` component to substitute the deprecated methods in favour of new methods
- `isInt()` is deprecated in favour of `isInt32()`
- `isDouble()` is deprecated in favour of `isFloat64()`
- `asInt()` is deprecated in favour of `asInt32()`
- `asDouble()` is deprecated in favour of `asFloat64()`
