### PR TITLE
Use enum underlying type to convert TextLogging verbosity level to spdlog verbosity level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - Reduce code duplication in python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/484)
 - Use `TextLogger` in `YarpRobotLoggerDevice` instead of `yarp` commands (https://github.com/ami-iit/bipedal-locomotion-framework/pull/486)
 - Ask for `osqp-eigen 0.6.4.100`(https://github.com/ami-iit/bipedal-locomotion-framework/pull/490)
+- Use enum underlying type to convert `TextLogging` verbosity level to `spdlog` verbosity level (https://github.com/ami-iit/bipedal-locomotion-framework/pull/495)
 
 ### Fix
 - Fix the population of the jointAccelerations and baseAcceleration variables in QPTSID (https://github.com/ami-iit/bipedal-locomotion-framework/pull/478)

--- a/src/TextLogging/include/BipedalLocomotion/TextLogging/Logger.h
+++ b/src/TextLogging/include/BipedalLocomotion/TextLogging/Logger.h
@@ -12,6 +12,7 @@
 #include <spdlog/fmt/ostr.h>
 
 #include <spdlog/spdlog.h>
+#include <type_traits>
 
 namespace BipedalLocomotion
 {
@@ -35,15 +36,15 @@ namespace BipedalLocomotion
 {
 namespace TextLogging
 {
-enum class Verbosity
+enum class Verbosity : std::underlying_type<spdlog::level::level_enum>::type
 {
-    Trace,
-    Debug,
-    Info,
-    Warn,
-    Err,
-    Critical,
-    Off,
+    Trace = static_cast<std::underlying_type<spdlog::level::level_enum>::type>(spdlog::level::level_enum::trace),
+    Debug = static_cast<std::underlying_type<spdlog::level::level_enum>::type>(spdlog::level::level_enum::debug),
+    Info = static_cast<std::underlying_type<spdlog::level::level_enum>::type>(spdlog::level::level_enum::info),
+    Warn = static_cast<std::underlying_type<spdlog::level::level_enum>::type>(spdlog::level::level_enum::warn),
+    Err = static_cast<std::underlying_type<spdlog::level::level_enum>::type>(spdlog::level::level_enum::err),
+    Critical = static_cast<std::underlying_type<spdlog::level::level_enum>::type>(spdlog::level::level_enum::critical),
+    Off = static_cast<std::underlying_type<spdlog::level::level_enum>::type>(spdlog::level::level_enum::off),
 };
 
 /**

--- a/src/TextLogging/src/Logger.cpp
+++ b/src/TextLogging/src/Logger.cpp
@@ -20,23 +20,9 @@ TextLogging::Logger* const log()
 
 void TextLogging::setVerbosity(const Verbosity verbosity)
 {
-    const std::unordered_map<TextLogging::Verbosity, spdlog::level::level_enum> map{
-        {TextLogging::Verbosity::Trace, spdlog::level::level_enum::trace},
-        {TextLogging::Verbosity::Debug, spdlog::level::level_enum::debug},
-        {TextLogging::Verbosity::Info, spdlog::level::level_enum::info},
-        {TextLogging::Verbosity::Warn, spdlog::level::level_enum::warn},
-        {TextLogging::Verbosity::Err, spdlog::level::level_enum::err},
-        {TextLogging::Verbosity::Critical, spdlog::level::level_enum::critical},
-        {TextLogging::Verbosity::Off, spdlog::level::level_enum::off},
-    };
-
-    if (map.find(verbosity) == map.end())
-    {
-        log()->error("Failed to change verbosity to level {}", verbosity);
-        return;
-    }
-
-    log()->set_level(map.at(verbosity));
+    // get the verbosity underling value and convert it in spdlog enum type
+    const auto value = static_cast<std::underlying_type<Verbosity>::type>(verbosity);
+    log()->set_level(static_cast<spdlog::level::level_enum>(value));
 }
 
 } // namespace BipedalLocomotion


### PR DESCRIPTION
This should fix https://github.com/ami-iit/bipedal-locomotion-framework/pull/492#issuecomment-1008736884