### PR TITLE
Implement python bindings for the classes that handle the clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 ### Added
+- Implement the python bindings for the clock machinery and for the yarp clock (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)
+
 ### Changed
+- An error it will be returned if the user tries to change the clock type once the `clock()` has been already called once (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)
+
 ### Fix
 
 ## [0.6.0] - 2022-12-10

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(Conversions)
 include(ConfigureFileWithCMakeIf)
 
 set(FRAMEWORK_COMPILE_RobotInterfaceBindings FRAMEWORK_COMPILE_RobotInterface AND FRAMEWORK_COMPILE_YarpImplementation)
+set(FRAMEWORK_COMPILE_YarpBindingsSystem FRAMEWORK_COMPILE_System AND FRAMEWORK_COMPILE_YarpImplementation)
 
 configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/bipedal_locomotion_framework.cpp.in
   ${CMAKE_CURRENT_BINARY_DIR}/bipedal_locomotion_framework.cpp

--- a/bindings/python/System/CMakeLists.txt
+++ b/bindings/python/System/CMakeLists.txt
@@ -4,10 +4,12 @@
 
 if(FRAMEWORK_COMPILE_System)
 
+  set(H_PREFIX include/BipedalLocomotion/bindings/System)
+
   add_bipedal_locomotion_python_module(
     NAME System
-    SOURCES src/VariablesHandler.cpp src/LinearTask.cpp src/Module.cpp src/ITaskControllerManager.cpp
-    HEADERS include/BipedalLocomotion/bindings/System/VariablesHandler.h include/BipedalLocomotion/bindings/System/LinearTask.h include/BipedalLocomotion/bindings/System/ITaskControllerManager.h include/BipedalLocomotion/bindings/System/ILinearTaskSolver.h
+    SOURCES src/VariablesHandler.cpp src/LinearTask.cpp src/Module.cpp src/ITaskControllerManager.cpp src/IClock.cpp src/Clock.cpp
+    HEADERS ${H_PREFIX}/VariablesHandler.h ${H_PREFIX}/LinearTask.h ${H_PREFIX}/ITaskControllerManager.h ${H_PREFIX}/ILinearTaskSolver.h ${H_PREFIX}/IClock.h ${H_PREFIX}/Clock.h
     LINK_LIBRARIES BipedalLocomotion::System
     TESTS tests/test_variables_handler.py
     )

--- a/bindings/python/System/CMakeLists.txt
+++ b/bindings/python/System/CMakeLists.txt
@@ -7,11 +7,22 @@ if(FRAMEWORK_COMPILE_System)
   set(H_PREFIX include/BipedalLocomotion/bindings/System)
 
   add_bipedal_locomotion_python_module(
-    NAME System
+    NAME SystemBindings
     SOURCES src/VariablesHandler.cpp src/LinearTask.cpp src/Module.cpp src/ITaskControllerManager.cpp src/IClock.cpp src/Clock.cpp
     HEADERS ${H_PREFIX}/VariablesHandler.h ${H_PREFIX}/LinearTask.h ${H_PREFIX}/ITaskControllerManager.h ${H_PREFIX}/ILinearTaskSolver.h ${H_PREFIX}/IClock.h ${H_PREFIX}/Clock.h
     LINK_LIBRARIES BipedalLocomotion::System
     TESTS tests/test_variables_handler.py
     )
+
+  if(FRAMEWORK_COMPILE_YarpImplementation)
+
+    add_bipedal_locomotion_python_module(
+      NAME  SystemYarpImplementationBindings
+      SOURCES src/YarpClock.cpp src/YarpModule.cpp
+      HEADERS ${H_PREFIX}/YarpClock.h ${H_PREFIX}/YarpModule.h
+      LINK_LIBRARIES BipedalLocomotion::SystemYarpImplementation
+      )
+
+  endif()
 
 endif()

--- a/bindings/python/System/include/BipedalLocomotion/bindings/System/Clock.h
+++ b/bindings/python/System/include/BipedalLocomotion/bindings/System/Clock.h
@@ -1,0 +1,29 @@
+/**
+ * @file Clock.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_CLOCK_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_CLOCK_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+
+void CreateClock(pybind11::module& module);
+
+namespace System
+{
+
+void CreateClockBuilder(pybind11::module& module);
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_CLOCK_H

--- a/bindings/python/System/include/BipedalLocomotion/bindings/System/IClock.h
+++ b/bindings/python/System/include/BipedalLocomotion/bindings/System/IClock.h
@@ -1,0 +1,72 @@
+/**
+ * @file IClock.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_ICLOCK_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_ICLOCK_H
+
+#include <pybind11/pybind11.h>
+#include <pybind11/chrono.h>
+
+#include <BipedalLocomotion/System/IClock.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace System
+{
+
+template <class IClockBase = BipedalLocomotion::System::IClock>
+class IClockTrampoline : public IClockBase
+{
+public:
+    using IClockBase::IClockBase;
+
+    std::chrono::duration<double> now() override
+    {
+        PYBIND11_OVERLOAD_PURE(std::chrono::duration<double>, IClockBase, now);
+    }
+
+    void sleepFor(const std::chrono::duration<double>& sleepDuration) override
+    {
+        PYBIND11_OVERLOAD_PURE_NAME(void, IClockBase, "sleep_for", sleepFor);
+    }
+
+    void sleepUntil(const std::chrono::duration<double>& time) override
+    {
+        PYBIND11_OVERLOAD_PURE_NAME(void, IClockBase, "sleep_until", seepUntil);
+    }
+
+    void yield() override
+    {
+        PYBIND11_OVERLOAD_PURE(void, IClockBase, yeld);
+    }
+};
+
+template <class ClockFactoryBase = BipedalLocomotion::System::ClockFactory>
+class ClockFactoryTrampoline : public ClockFactoryBase
+{
+public:
+    using ClockFactoryBase::ClockFactoryBase;
+
+    ::BipedalLocomotion::System::IClock& createClock() override
+    {
+        PYBIND11_OVERLOAD_PURE_NAME(::BipedalLocomotion::System::IClock&,
+                                    ClockFactoryBase,
+                                    "create_clock",
+                                    createClock);
+    }
+};
+
+void CreateIClock(pybind11::module& module);
+void CreateClockFactory(pybind11::module& module);
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_ICLOCK_H

--- a/bindings/python/System/include/BipedalLocomotion/bindings/System/Module.h
+++ b/bindings/python/System/include/BipedalLocomotion/bindings/System/Module.h
@@ -18,7 +18,6 @@ namespace System
 {
 
 void CreateModule(pybind11::module& module);
-
 } // namespace System
 } // namespace bindings
 } // namespace BipedalLocomotion

--- a/bindings/python/System/include/BipedalLocomotion/bindings/System/YarpClock.h
+++ b/bindings/python/System/include/BipedalLocomotion/bindings/System/YarpClock.h
@@ -1,0 +1,27 @@
+/**
+ * @file YarpClock.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_YARP_CLOCK_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_YARP_CLOCK_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace System
+{
+
+void CreateYarpClock(pybind11::module& module);
+void CreateYarpClockFactory(pybind11::module& module);
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_YARP_CLOCK_H

--- a/bindings/python/System/include/BipedalLocomotion/bindings/System/YarpModule.h
+++ b/bindings/python/System/include/BipedalLocomotion/bindings/System/YarpModule.h
@@ -1,0 +1,26 @@
+/**
+ * @file YarpModule.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_YARP_MODULE_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_YARP_MODULE_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace System
+{
+
+void CreateYarpModule(pybind11::module& module);
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_YARP_MODULE_H

--- a/bindings/python/System/src/Clock.cpp
+++ b/bindings/python/System/src/Clock.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file Clock.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/cast.h>
+#include <pybind11/chrono.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/System/Clock.h>
+#include <BipedalLocomotion/bindings/System/IClock.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+
+void CreateClock(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    // Reference an existing object, but do not take ownership.
+    // https://pybind11.readthedocs.io/en/stable/advanced/functions.html
+    module.def("clock", &::BipedalLocomotion::clock, py::return_value_policy::reference);
+}
+
+namespace System
+{
+
+void CreateClockBuilder(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    using namespace BipedalLocomotion::System;
+
+    py::class_<ClockBuilder>(module, "ClockBuilder")
+        .def(py::init<>())
+        .def_static("set_factory", &ClockBuilder::setFactory, py::arg("factory"));
+}
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/System/src/IClock.cpp
+++ b/bindings/python/System/src/IClock.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file IClock.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/cast.h>
+#include <pybind11/chrono.h>
+#include <pybind11/pybind11.h>
+
+#include <BipedalLocomotion/System/IClock.h>
+#include <BipedalLocomotion/bindings/System/IClock.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace System
+{
+
+void CreateIClock(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    using namespace BipedalLocomotion::System;
+
+    py::class_<IClock, //
+               IClockTrampoline<>>(module, "IClock")
+        .def("now", &IClock::now)
+        .def("sleep_for", &IClock::sleepFor, py::arg("sleep_duration"))
+        .def("sleep_until", &IClock::sleepUntil, py::arg("time"))
+        .def("yield", &IClock::yield);
+}
+
+void CreateClockFactory(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    using namespace BipedalLocomotion::System;
+
+    py::class_<ClockFactory, //
+               ClockFactoryTrampoline<>, std::shared_ptr<ClockFactory>>(module, "ClockFactory");
+}
+
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/System/src/Module.cpp
+++ b/bindings/python/System/src/Module.cpp
@@ -1,5 +1,5 @@
 /**
- * @file VariablesHandler.cpp
+ * @file Module.cpp
  * @authors Giulio Romualdi
  * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
@@ -7,10 +7,12 @@
 
 #include <pybind11/pybind11.h>
 
+#include <BipedalLocomotion/bindings/System/Clock.h>
+#include <BipedalLocomotion/bindings/System/IClock.h>
+#include <BipedalLocomotion/bindings/System/ITaskControllerManager.h>
 #include <BipedalLocomotion/bindings/System/LinearTask.h>
 #include <BipedalLocomotion/bindings/System/Module.h>
 #include <BipedalLocomotion/bindings/System/VariablesHandler.h>
-#include <BipedalLocomotion/bindings/System/ITaskControllerManager.h>
 
 namespace BipedalLocomotion
 {
@@ -25,6 +27,9 @@ void CreateModule(pybind11::module& module)
     CreateVariablesHandler(module);
     CreateLinearTask(module);
     CreateITaskControllerManager(module);
+    CreateIClock(module);
+    CreateClockFactory(module);
+    CreateClockBuilder(module);
 }
 } // namespace System
 } // namespace bindings

--- a/bindings/python/System/src/YarpClock.cpp
+++ b/bindings/python/System/src/YarpClock.cpp
@@ -1,0 +1,45 @@
+/**
+ * @file YarpClock.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/cast.h>
+#include <pybind11/chrono.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/System/YarpClock.h>
+#include <BipedalLocomotion/bindings/System/YarpClock.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace System
+{
+
+void CreateYarpClock(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    py::class_<::BipedalLocomotion::System::YarpClock,
+               ::BipedalLocomotion::System::IClock>(module, "YarpClock");
+}
+
+void CreateYarpClockFactory(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    py::class_<::BipedalLocomotion::System::YarpClockFactory,
+               ::BipedalLocomotion::System::ClockFactory,
+               std::shared_ptr<::BipedalLocomotion::System::YarpClockFactory>>(module,
+                                                                               "YarpClockFactory")
+        .def(py::init<>());
+    ;
+}
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/System/src/YarpModule.cpp
+++ b/bindings/python/System/src/YarpModule.cpp
@@ -1,0 +1,26 @@
+/**
+ * @file YarpModule.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include <BipedalLocomotion/bindings/System/YarpClock.h>
+#include <BipedalLocomotion/bindings/System/YarpModule.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace System
+{
+void CreateYarpModule(pybind11::module& module)
+{
+    CreateYarpClock(module);
+    CreateYarpClockFactory(module);
+}
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/bipedal_locomotion_framework.cpp.in
+++ b/bindings/python/bipedal_locomotion_framework.cpp.in
@@ -25,6 +25,10 @@
 #include <BipedalLocomotion/bindings/System/Clock.h>
 @endcmakeif FRAMEWORK_COMPILE_System
 
+@cmakeif FRAMEWORK_COMPILE_YarpBindingsSystem
+#include <BipedalLocomotion/bindings/System/YarpModule.h>
+@endcmakeif FRAMEWORK_COMPILE_YarpBindingsSystem
+
 @cmakeif FRAMEWORK_COMPILE_Contact
 #include <BipedalLocomotion/bindings/Contacts/Module.h>
 @endcmakeif FRAMEWORK_COMPILE_Contact
@@ -87,6 +91,10 @@ PYBIND11_MODULE(bindings, m)
     bindings::System::CreateModule(systemModule);
     bindings::CreateClock(m);
     @endcmakeif FRAMEWORK_COMPILE_System
+
+    @cmakeif FRAMEWORK_COMPILE_YarpBindingsSystem
+    bindings::System::CreateYarpModule(systemModule);
+    @endcmakeif FRAMEWORK_COMPILE_YarpBindingsSystem
 
     @cmakeif FRAMEWORK_COMPILE_Contact
     py::module contactsModule = m.def_submodule("contacts");

--- a/bindings/python/bipedal_locomotion_framework.cpp.in
+++ b/bindings/python/bipedal_locomotion_framework.cpp.in
@@ -22,6 +22,7 @@
 
 @cmakeif FRAMEWORK_COMPILE_System
 #include <BipedalLocomotion/bindings/System/Module.h>
+#include <BipedalLocomotion/bindings/System/Clock.h>
 @endcmakeif FRAMEWORK_COMPILE_System
 
 @cmakeif FRAMEWORK_COMPILE_Contact
@@ -84,6 +85,7 @@ PYBIND11_MODULE(bindings, m)
     @cmakeif FRAMEWORK_COMPILE_System
     py::module systemModule = m.def_submodule("system");
     bindings::System::CreateModule(systemModule);
+    bindings::CreateClock(m);
     @endcmakeif FRAMEWORK_COMPILE_System
 
     @cmakeif FRAMEWORK_COMPILE_Contact

--- a/src/System/include/BipedalLocomotion/System/Clock.h
+++ b/src/System/include/BipedalLocomotion/System/Clock.h
@@ -30,6 +30,9 @@ class ClockBuilder
      * Pointer to factory used to build the clock
      */
     inline static std::shared_ptr<ClockFactory> m_factory{std::make_shared<StdClockFactory>()};
+    inline static bool m_clockAlreadyCalledOnce{false}; /**< True if the clock() has been already
+                                                           called once. If True it will not be
+                                                           possible to set a new Factory */
 
 public:
     /**

--- a/src/System/src/Clock.cpp
+++ b/src/System/src/Clock.cpp
@@ -12,12 +12,23 @@ BipedalLocomotion::System::IClock& BipedalLocomotion::clock()
 {
     // m_factory is always initialized.
     assert(BipedalLocomotion::System::ClockBuilder::m_factory);
+    BipedalLocomotion::System::ClockBuilder::m_clockAlreadyCalledOnce = true;
     return BipedalLocomotion::System::ClockBuilder::m_factory->createClock();
 }
 
 bool BipedalLocomotion::System::ClockBuilder::setFactory(std::shared_ptr<ClockFactory> factory)
 {
     constexpr auto logPrefix = "[ClockBuilder::setFactory]";
+
+    if (m_clockAlreadyCalledOnce)
+    {
+        log()->error("{} The clock has been already called. Since the clock() returns a singleton "
+                     "it is not possible to set the factory anymore. Please call 'setFactory()' at "
+                     "the beginning of your application to avoid this problem.",
+                     logPrefix);
+        return false;
+    }
+
     if (factory == nullptr)
     {
         log()->error("{} The factory is not valid.", logPrefix);


### PR DESCRIPTION
This PR implements:
1. The python bindings for the Clock machinery and for the yarp clock

Furthermore, since the clock is implemented as a singleton, an error it will be returned if the user tries to change the clock type once the `clock()` has been already called once. Notice that `BipedalLocomotion::clock()` instantiate the singleton the first time is called (See Meyers' singleton implementation).

For instance, in python, we will have 
```
In [1]: import bipedal_locomotion_framework.bindings as blf

In [2]: blf.clock().now()
Out[2]: datetime.timedelta(days=19010, seconds=63353, microseconds=503687)

In [3]: blf.system.ClockBuilder.set_factory(blf.system.YarpClockFactory())
[2022-01-18 18:35:55.945] [thread: 66773] [blf] [error] [ClockBuilder::setFactory] The clock has been already called. Since the clock() returns a singleton it is not possible to set the factory anymore. Please call 'setFactory()' at the beginning of your application to avoid this problem.
Out[3]: False
```

```
In [1]: import bipedal_locomotion_framework.bindings as blf

In [2]: blf.system.ClockBuilder.set_factory(blf.system.YarpClockFactory())
Out[2]: True

In [3]: blf.system.ClockBuilder.set_factory(blf.system.YarpClockFactory())
Out[3]: True

In [4]: blf.clock().now()
Out[4]: datetime.timedelta(days=19010, seconds=63392, microseconds=416123)
```

Thanks to this PR it will be possible to easily synchronize yarp process also in python.

Last but not least the PR implements the `trampoline` pybind11 functionality to extend the clock class directly in python https://pybind11.readthedocs.io/en/stable/advanced/classes.html#combining-virtual-functions-and-inheritance. In other words  a python developer can implement its own clock by inheriting from the c++ binded  class 

cc @Giulero 