### PR TITLE
Add possibility to reduce rotation flips in aruco marker pose estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project are documented in this file.
 - Add the possibility to force the internal state of the `SchmittTrigger` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/684)
 - Add the possibility to update the contact list in the swing foot planner when the contact is not active and the new orientation is different from the previous one (https://github.com/ami-iit/bipedal-locomotion-framework/pull/688)
 - Add the possibility to set the boundary condition for the velocity and acceleration of the `SO3Planner` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/688)
+- Add possibility to reduce rotation flips in aruco marker pose estimation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/503)
 
 ### Fixed
 - Fix RobotDynamicsEstimator compilation dependencies (https://github.com/ami-iit/bipedal-locomotion-framework/pull/665)

--- a/src/Perception/include/BipedalLocomotion/Perception/Features/ArucoDetector.h
+++ b/src/Perception/include/BipedalLocomotion/Perception/Features/ArucoDetector.h
@@ -78,6 +78,31 @@ public:
      * - "marker_length" marker length in m
      * - "camera_matrix" 9d vector representing the camera calbration matrix in row major order
      * - "distortion_coefficients" 5d vector containing camera distortion coefficients
+     * - "use_solve_pnp_outlier_rejection" solve for marker pose using PnP method instead of default
+     *                                     aruco pose estimation, this method allows to eliminate
+     *                                     outliers in estimated rotations, in the form of rotation flips,
+     *                                     up to a certain degree by considering ambiguous solutions as outliers
+     *                                     and removing associated detections from the set of detected markers.
+     *                                     If using this option, please cite the work,
+     *                                     "Infinitesimal Plane-Based Pose Estimation"
+     *                                     (https://link.springer.com/article/10.1007/s11263-014-0725-5)
+     *                                     and also cite,
+     *                                     "Absolute humanoid localization and mapping based on IMU
+     *                                      Lie group and fiducial markers"
+     *                                     (https://ieeexplore.ieee.org/document/9035005)
+     *
+     * - "ambiguity_threshold_reprojection_error_ratio" threshold ratio of reprojection error for
+     *                                                  outlier rejection to resolve
+     *                                                  rotation ambiguity using solvePnP method.
+     *                                                  This is done based on reprojection error ratio
+     *                                                  between two solutions obtained from sovlePnP.
+     *                                                  Pose estimation for planar landmarks (homography) usually results in
+     *                                                  two rotation solutions (with one-solution having z axis flipped in opposite direction).
+     *                                                  The rotation with a lower reprojection error is a suitable solution
+     *                                                  and we use a reprojection error ratio test to decide if two rotation solutions
+     *                                                  are close to each other: higher the ratio, highly distinct rotations.
+     *                                                  If the resulting ratio is small, then we mark the estimated pose as an outlier.
+     *                                                  However, setting high threshold values makes successful marker detection less frequent.
      * @param[in] handlerWeak weak pointer to a ParametersHandler::IParametersHandler interface
      * @tparameter Derived particular implementation of the IParameterHandler
      * @return True in case of success, false otherwise.

--- a/src/Perception/tests/Perception/Features/ArucoDetectorTest.cpp
+++ b/src/Perception/tests/Perception/Features/ArucoDetectorTest.cpp
@@ -17,14 +17,51 @@
 using namespace BipedalLocomotion::Perception;
 using namespace BipedalLocomotion::ParametersHandler;
 
-TEST_CASE("Aruco Detector")
+std::shared_ptr<IParametersHandler> populateConfig()
 {
     std::shared_ptr<IParametersHandler> parameterHandler = std::make_shared<StdImplementation>();
     parameterHandler->setParameter("marker_dictionary", "4X4_50");
     parameterHandler->setParameter("marker_length", 0.806);
     parameterHandler->setParameter("camera_matrix", std::vector<double>{922.309448242188,0,664.546813964844,0,922.194458007813,348.770141601563,0,0,1});
     parameterHandler->setParameter("distortion_coefficients", std::vector<double>{0.0, 0.0, 0.0, 0.0, 0.0});
+    return parameterHandler;
+}
 
+TEST_CASE("Aruco Detector")
+{
+    auto parameterHandler = populateConfig();
+    // // Instantiate the estimator
+    ArucoDetector detector;
+    REQUIRE(detector.initialize(parameterHandler));
+
+    auto imgName = getSampleImagePath();
+    auto inputImg = cv::imread(imgName);
+
+    REQUIRE(detector.setImage(inputImg, 0.1));
+    REQUIRE(detector.advance());
+
+    cv::Mat outputImage;
+    REQUIRE(detector.getImageWithDetectedMarkers(outputImage,
+                                                 /*drawFrames=*/ true,
+                                                 /*axisLengthForDrawing=*/ 0.3));
+
+    // Marker 2 is detected in the sample image
+    ArucoMarkerData marker2;
+    REQUIRE(detector.getDetectedMarkerData(/*id=*/ 2, marker2));
+    REQUIRE(marker2.id == 2);
+
+     /* // uncomment this block to view the output image
+       cv::imshow("outputImage", outputImage);
+       cv::waitKey();
+     */
+
+}
+
+TEST_CASE("Aruco Detector - SolvePnP")
+{
+    auto parameterHandler = populateConfig();
+    parameterHandler->setParameter("use_solve_pnp_outlier_rejection", true);
+    parameterHandler->setParameter("ambiguity_threshold_reprojection_error_ratio", 5.0);
     // // Instantiate the estimator
     ArucoDetector detector;
     REQUIRE(detector.initialize(parameterHandler));


### PR DESCRIPTION
Rotation flip is a known problem in aruco marker pose estimation resulting in outlier pose measurements from the `ArucoDetector`
This PR tries to handle the problem based on a reprojection error ratio test.
The logic is based on the works:
- [Infinitesimal Plane-Based Pose Estimation](https://link.springer.com/article/10.1007/s11263-014-0725-5), reference repository https://github.com/tobycollins/IPPE

This logic has been successfully used in the work: [Absolute humanoid localization and mapping based on IMU Lie group and fiducial markers](https://ieeexplore.ieee.org/document/9035005)

The user can now choose between the default aruco pose estimation and a `solvePnP` based estimation along with the reprojection error ratio test. The latter reduces the number of outliers in the form of rotation flips, however, reduces the number of detections as well since we mark the occurrence of an outlier as a no detection.

cc @traversaro @HosameldinMohamed @Giulero 