### PR TITLE
Introduce the IWeightProvider and the ConstantWeightProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 ### Added
 - Implement the python bindings for the clock machinery and for the yarp clock (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)
+- Implement the `IWeightProvider` interface and the `ConstantWeightProvider` class in the System component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/506)
 
 ### Changed
 - An error it will be returned if the user tries to change the clock type once the `clock()` has been already called once (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)
 - Log the arms external wrenches on the YarpRobotLogger for iCubGenova09 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/502)
+- IK and TSID now uses the weight provider to specify the weight associated to a task (https://github.com/ami-iit/bipedal-locomotion-framework/pull/506)
 
 ### Fix
 - Remove outdated includes in YarpRobotLoggerDevice.cpp (https://github.com/ami-iit/bipedal-locomotion-framework/pull/502)

--- a/bindings/python/System/CMakeLists.txt
+++ b/bindings/python/System/CMakeLists.txt
@@ -8,8 +8,8 @@ if(FRAMEWORK_COMPILE_System)
 
   add_bipedal_locomotion_python_module(
     NAME SystemBindings
-    SOURCES src/VariablesHandler.cpp src/LinearTask.cpp src/Module.cpp src/ITaskControllerManager.cpp src/IClock.cpp src/Clock.cpp
-    HEADERS ${H_PREFIX}/VariablesHandler.h ${H_PREFIX}/LinearTask.h ${H_PREFIX}/ITaskControllerManager.h ${H_PREFIX}/ILinearTaskSolver.h ${H_PREFIX}/IClock.h ${H_PREFIX}/Clock.h
+    SOURCES src/VariablesHandler.cpp src/LinearTask.cpp src/Module.cpp src/ITaskControllerManager.cpp src/IClock.cpp src/Clock.cpp src/WeightProvider.cpp
+    HEADERS ${H_PREFIX}/VariablesHandler.h ${H_PREFIX}/LinearTask.h ${H_PREFIX}/ITaskControllerManager.h ${H_PREFIX}/ILinearTaskSolver.h ${H_PREFIX}/IClock.h ${H_PREFIX}/Clock.h ${H_PREFIX}/WeightProvider.h
     LINK_LIBRARIES BipedalLocomotion::System
     TESTS tests/test_variables_handler.py
     )

--- a/bindings/python/System/include/BipedalLocomotion/bindings/System/ILinearTaskSolver.h
+++ b/bindings/python/System/include/BipedalLocomotion/bindings/System/ILinearTaskSolver.h
@@ -36,30 +36,24 @@ void CreateILinearTaskSolver(pybind11::module& module, const std::string& python
              py::arg("task_name"),
              py::arg("priority"),
              py::arg("weight") = Eigen::VectorXd())
-        .def("set_task_weight",
-             &::BipedalLocomotion::System::ILinearTaskSolver<_Task, _State>::setTaskWeight,
+        .def("set_task_weight_provider",
+             &::BipedalLocomotion::System::ILinearTaskSolver<_Task, _State>::setTaskWeightProvider,
              py::arg("task_name"),
-             py::arg("weight"))
-        .def(
-            "get_task_weight",
+             py::arg("weight_provider"))
+        .def("get_task_weight_provider",
             [](const ::BipedalLocomotion::System::ILinearTaskSolver<_Task, _State>& impl,
                const std::string& taskName) {
-                auto task = impl.getTask(taskName).lock();
-                if (task == nullptr)
-                {
-                    const std::string msg = "Failed to get the weight for the task named " //
-                                            + taskName + ".";
-                    throw py::value_error(msg);
-                }
-                Eigen::VectorXd weight(task->size());
 
-                if (!impl.getTaskWeight(taskName, weight))
+                auto provider = impl.getTaskWeightProvider(taskName).lock();
+
+                if (provider == nullptr)
                 {
-                    const std::string msg = "Failed to get the weight for the task named " //
-                                            + taskName + ".";
+                    const std::string msg = "Failed to get the weight Provider for the task named "
+                        + taskName + ".";
                     throw py::value_error(msg);
                 }
-                return weight;
+
+                return provider;
             },
             py::arg("task_name"))
         .def("get_task_names",

--- a/bindings/python/System/include/BipedalLocomotion/bindings/System/WeightProvider.h
+++ b/bindings/python/System/include/BipedalLocomotion/bindings/System/WeightProvider.h
@@ -1,0 +1,28 @@
+/**
+ * @file WeightProvider.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_WEIGHT_PROVIDER_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_WEIGHT_PROVIDER_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+
+namespace System
+{
+
+void CreateIWeightProvider(pybind11::module& module);
+void CreateConstantWeightProvider(pybind11::module& module);
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_SYSTEM_WEIGHT_PROVIDER_H

--- a/bindings/python/System/src/Module.cpp
+++ b/bindings/python/System/src/Module.cpp
@@ -13,6 +13,7 @@
 #include <BipedalLocomotion/bindings/System/LinearTask.h>
 #include <BipedalLocomotion/bindings/System/Module.h>
 #include <BipedalLocomotion/bindings/System/VariablesHandler.h>
+#include <BipedalLocomotion/bindings/System/WeightProvider.h>
 
 namespace BipedalLocomotion
 {
@@ -30,6 +31,8 @@ void CreateModule(pybind11::module& module)
     CreateIClock(module);
     CreateClockFactory(module);
     CreateClockBuilder(module);
+    CreateIWeightProvider(module);
+    CreateConstantWeightProvider(module);
 }
 } // namespace System
 } // namespace bindings

--- a/bindings/python/System/src/WeightProvider.cpp
+++ b/bindings/python/System/src/WeightProvider.cpp
@@ -1,0 +1,56 @@
+/**
+ * @file WeightProvider.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <memory>
+#include <pybind11/cast.h>
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/System/ConstantWeightProvider.h>
+#include <BipedalLocomotion/System/IWeightProvider.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace System
+{
+
+void CreateIWeightProvider(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    using namespace BipedalLocomotion::System;
+
+    py::class_<IWeightProvider, std::shared_ptr<IWeightProvider>>(module, "IWeightProvider")
+        .def("get_weight", &IWeightProvider::getWeight);
+}
+
+void CreateConstantWeightProvider(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    using namespace BipedalLocomotion::System;
+
+    py::class_<ConstantWeightProvider,
+               IWeightProvider,
+               std::shared_ptr<ConstantWeightProvider>>(module, "ConstantWeightProvider")
+        .def(py::init())
+        .def(py::init<Eigen::Ref<const Eigen::VectorXd>>(), py::arg("weight"))
+        .def("initialize",
+             [](ConstantWeightProvider& impl,
+                std::shared_ptr<ParametersHandler::IParametersHandler> handler) -> bool {
+                 return impl.initialize(handler);
+             })
+        .def_readwrite("weight", &ConstantWeightProvider::weight);
+}
+
+} // namespace System
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/src/IK/include/BipedalLocomotion/IK/QPInverseKinematics.h
+++ b/src/IK/include/BipedalLocomotion/IK/QPInverseKinematics.h
@@ -18,6 +18,7 @@
 #include <BipedalLocomotion/IK/IntegrationBasedIK.h>
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotion/System/Advanceable.h>
+#include <BipedalLocomotion/System/IWeightProvider.h>
 
 namespace BipedalLocomotion
 {
@@ -76,22 +77,23 @@ public:
                  std::optional<Eigen::Ref<const Eigen::VectorXd>> weight = {}) override;
 
     /**
-     * Set the weight associated to an already existing task
+     * Set the weightProvider associated to an already existing task
      * @param taskName name associated to the task
-     * @param weight new Weight associated to the task.
+     * @param weightProvider new Weight provider associated to the task.
      * @return true if the weight has been updated
      */
-    bool setTaskWeight(const std::string& taskName,
-                       Eigen::Ref<const Eigen::VectorXd> weight) override;
+    bool
+    setTaskWeightProvider(const std::string& taskName,
+                          std::shared_ptr<const System::IWeightProvider> weightProvider) override;
 
     /**
-     * Get the weight associated to an already existing task
+     * Get the weightProvider associated to an already existing task
      * @param taskName name associated to the task
-     * @param weight the weight associated to the task.
-     * @return true in case of success and false otherwise
+     * @return a weak pointer to the weightProvider. If the task does not exist the pointer is not
+     * lockable
      */
-    bool getTaskWeight(const std::string& taskName,
-                       Eigen::Ref<Eigen::VectorXd> weight) const override;
+    std::weak_ptr<const System::IWeightProvider>
+    getTaskWeightProvider(const std::string& taskName) const override;
 
     /**
      * Finalize the IK.

--- a/src/System/CMakeLists.txt
+++ b/src/System/CMakeLists.txt
@@ -16,8 +16,10 @@ if(FRAMEWORK_COMPILE_System)
                            ${H_PREFIX}/SharedResource.h ${H_PREFIX}/AdvanceableRunner.h
                            ${H_PREFIX}/QuitHandler.h
                            ${H_PREFIX}/Barrier.h
+                           ${H_PREFIX}/IWeightProvider.h ${H_PREFIX}/ConstantWeightProvider.h
     SOURCES                src/VariablesHandler.cpp src/LinearTask.cpp
                            src/StdClock.cpp src/Clock.cpp src/QuitHandler.cpp src/Barrier.cpp
+                           src/ConstantWeightProvider.cpp
     PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler Eigen3::Eigen
     SUBDIRECTORIES         tests YarpImplementation
     )

--- a/src/System/include/BipedalLocomotion/System/ConstantWeightProvider.h
+++ b/src/System/include/BipedalLocomotion/System/ConstantWeightProvider.h
@@ -1,0 +1,64 @@
+/**
+ * @file ConstantWeightProvider.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SYSTEM_CONSTANT_WEIGHT_PROVIDER_H
+#define BIPEDAL_LOCOMOTION_SYSTEM_CONSTANT_WEIGHT_PROVIDER_H
+
+#include <memory>
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/System/IWeightProvider.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <Eigen/src/Core/Matrix.h>
+
+
+namespace BipedalLocomotion
+{
+namespace System
+{
+
+/**
+ * ConstantWeightProvider describes the provider for a constant weight.
+ */
+struct ConstantWeightProvider : public IWeightProvider
+{
+
+    Eigen::VectorXd weight; /**< Vector representing the diagonal matrix of a weight */
+
+    /**
+     * Default construct
+     */
+    ConstantWeightProvider() = default;
+
+    /**
+     * Constrict from a vector representing the diagonal matrix of a weight
+     * @param weight a vector representing the diagonal matrix of a weight
+     */
+    ConstantWeightProvider(Eigen::Ref<const Eigen::VectorXd> weight);
+
+    /**
+     * Get the weight associated to the provider
+     * @return A vector representing the diagonal matrix of the weight
+     */
+    Eigen::Ref<const Eigen::VectorXd> getWeight() const final;
+
+    /**
+     * Initialize constant weight provider.
+     * @param handler pointer to the parameter handler.
+     * @note The following parameters are required:
+     * |  Parameter Name  |        Type      |                          Description                              | Mandatory |
+     * |:----------------:|:----------------:|:-----------------------------------------------------------------:|:---------:|
+     * |    `weight`      | `vector<double>` |  Vector representing the diagonal matrix of a constant weight     |    Yes    |
+     * @return true in case of success/false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
+};
+} // namespace System
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SYSTEM_CONSTANT_WEIGHT_PROVIDER_H

--- a/src/System/include/BipedalLocomotion/System/ILinearTaskSolver.h
+++ b/src/System/include/BipedalLocomotion/System/ILinearTaskSolver.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_SYSTEM_ILINEAR_TASK_SOLVER_H
 #define BIPEDAL_LOCOMOTION_SYSTEM_ILINEAR_TASK_SOLVER_H
 
+#include "BipedalLocomotion/System/IWeightProvider.h"
 #include <memory>
 #include <optional>
 #include <string>
@@ -58,23 +59,23 @@ public:
         = 0;
 
     /**
-     * Set the weight associated to an already existing task
+     * Set the weightProvider associated to an already existing task
      * @param taskName name associated to the task
-     * @param weight new Weight associated to the task.
+     * @param weightProvider new Weight provider associated to the task.
      * @return true if the weight has been updated
      */
-    virtual bool setTaskWeight(const std::string& taskName,
-                               Eigen::Ref<const Eigen::VectorXd> weight) = 0;
+    virtual bool setTaskWeightProvider(const std::string& taskName,
+                                       std::shared_ptr<const IWeightProvider> weightProvider)
+        = 0;
 
     /**
-     * Get the weight associated to an already existing task
+     * Get the weightProvider associated to an already existing task
      * @param taskName name associated to the task
-     * @param weight the weight associated to the task.
-     * @return true in case of success and false otherwise
+     * @return a weak pointer to the weightProvider. If the task does not exist the pointer is not
+     * lockable
      */
-    virtual bool getTaskWeight(const std::string& taskName,
-                               Eigen::Ref<Eigen::VectorXd> weight) const = 0;
-
+    virtual std::weak_ptr<const IWeightProvider>
+    getTaskWeightProvider(const std::string& taskName) const = 0;
 
     /**
      * Get a vector containing the name of the tasks.

--- a/src/System/include/BipedalLocomotion/System/IWeightProvider.h
+++ b/src/System/include/BipedalLocomotion/System/IWeightProvider.h
@@ -1,0 +1,39 @@
+/**
+ * @file IWeightProvider.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SYSTEM_IWEIGHT_PROVIDER_H
+#define BIPEDAL_LOCOMOTION_SYSTEM_IWEIGHT_PROVIDER_H
+
+#include <Eigen/Dense>
+
+namespace BipedalLocomotion
+{
+namespace System
+{
+
+/**
+ * IWeightProvider describes the interface for a provider that produces the weight for a
+ * BipedalLocomotion::System::ILinearTaskSolver
+ */
+struct IWeightProvider
+{
+
+    /**
+     * Get the weight associated to the provider
+     * @return A vector representing the diagonal matrix of the weight
+     */
+    virtual Eigen::Ref<const Eigen::VectorXd> getWeight() const = 0;
+
+    /**
+     * Destructor.
+     */
+    virtual ~IWeightProvider() = default;
+};
+} // namespace System
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SYSTEM_IWEIGHT_PROVIDER_H

--- a/src/System/src/ConstantWeightProvider.cpp
+++ b/src/System/src/ConstantWeightProvider.cpp
@@ -1,0 +1,42 @@
+/**
+ * @file ConstantWeightProvider.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/System/ConstantWeightProvider.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+using namespace BipedalLocomotion::System;
+using namespace BipedalLocomotion::ParametersHandler;
+
+ConstantWeightProvider::ConstantWeightProvider(Eigen::Ref<const Eigen::VectorXd> weight)
+    : weight(weight)
+{
+}
+
+bool ConstantWeightProvider::initialize(std::weak_ptr<const IParametersHandler> handler)
+{
+    constexpr auto logPrefix = "[ConstantWeightProvider::initialize]";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} Invalid parameter handler.", logPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("weight", weight))
+    {
+        log()->error("{} Unable to get the parameter named 'weight'.", logPrefix);
+        return false;
+    }
+
+    return true;
+}
+
+Eigen::Ref<const Eigen::VectorXd> ConstantWeightProvider::getWeight() const
+{
+    return weight;
+}

--- a/src/TSID/include/BipedalLocomotion/TSID/QPTSID.h
+++ b/src/TSID/include/BipedalLocomotion/TSID/QPTSID.h
@@ -15,6 +15,7 @@
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotion/TSID/TaskSpaceInverseDynamics.h>
 #include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/System/IWeightProvider.h>
 
 namespace BipedalLocomotion
 {
@@ -72,22 +73,23 @@ public:
                  std::optional<Eigen::Ref<const Eigen::VectorXd>> weight = {}) override;
 
     /**
-     * Set the weight associated to an already existing task
+     * Set the weightProvider associated to an already existing task
      * @param taskName name associated to the task
-     * @param weight new Weight associated to the task.
+     * @param weightProvider new Weight provider associated to the task.
      * @return true if the weight has been updated
      */
-    bool setTaskWeight(const std::string& taskName,
-                       Eigen::Ref<const Eigen::VectorXd> weight) override;
+    bool
+    setTaskWeightProvider(const std::string& taskName,
+                          std::shared_ptr<const System::IWeightProvider> weightProvider) override;
 
     /**
-     * Get the weight associated to an already existing task
+     * Get the weightProvider associated to an already existing task
      * @param taskName name associated to the task
-     * @param weight the weight associated to the task.
-     * @return true in case of success and false otherwise
+     * @return a weak pointer to the weightProvider. If the task does not exist the pointer is not
+     * lockable
      */
-    bool getTaskWeight(const std::string& taskName,
-                       Eigen::Ref<Eigen::VectorXd> weight) const override;
+    std::weak_ptr<const System::IWeightProvider>
+    getTaskWeightProvider(const std::string& taskName) const override;
 
     /**
      * Get a vector containing the name of the tasks.

--- a/src/TSID/tests/QPFixedBaseTSIDTest.cpp
+++ b/src/TSID/tests/QPFixedBaseTSIDTest.cpp
@@ -6,9 +6,11 @@
  */
 
 // Catch2
+#include "BipedalLocomotion/System/ConstantWeightProvider.h"
 #include <catch2/catch.hpp>
 
 // std
+#include <memory>
 #include <random>
 
 // BipedalLocomotion
@@ -125,13 +127,17 @@ TSIDAndTasks createTSID(std::shared_ptr<IParametersHandler> handler,
                             weightRegularization));
 
     Eigen::VectorXd newWeight = 10 * weightRegularization;
-    REQUIRE(out.tsid->setTaskWeight("regularization_task", newWeight));
-
-    Eigen::VectorXd weight(newWeight.size());
-    REQUIRE(out.tsid->getTaskWeight("regularization_task", weight));
-    REQUIRE(weight.isApprox(newWeight));
-    REQUIRE(out.tsid->setTaskWeight("regularization_task", weightRegularization));
-
+    REQUIRE(out.tsid->setTaskWeightProvider("regularization_task",
+                                            std::make_shared<
+                                                BipedalLocomotion::System::ConstantWeightProvider>(
+                                                newWeight)));
+    auto provider = out.tsid->getTaskWeightProvider("regularization_task").lock();
+    REQUIRE(provider);
+    REQUIRE(provider->getWeight().isApprox(newWeight));
+    REQUIRE(out.tsid->setTaskWeightProvider("regularization_task",
+                                            std::make_shared<
+                                                BipedalLocomotion::System::ConstantWeightProvider>(
+                                                weightRegularization)));
 
     REQUIRE(out.tsid->finalize(variables));
 


### PR DESCRIPTION
Thanks to this PR it will be possible to define different providers for the weight in the Ik and TSID. As a consequence, it will be possible to implement a provider that allows performing weight scheduling.

The associated python bindings have been updated accordingly. 