### PR TITLE
Add installation of pip metadata files for when blf python bindings are installed only via CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 - Implement the python bindings for the clock machinery and for the yarp clock (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)
 - Implement the `IWeightProvider` interface and the `ConstantWeightProvider` class in the System component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/506)
+- Add installation of pip metadata files for when blf python bindings are installed only via CMake (https://github.com/ami-iit/bipedal-locomotion-framework/pull/508)
 
 ### Changed
 - An error it will be returned if the user tries to change the clock type once the `clock()` has been already called once (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -37,8 +37,32 @@ if(FRAMEWORK_COMPILE_PYTHON_BINDINGS)
          OUTPUT "${BLF_PYTHON_PACKAGE}/__init__.py"
          CONTENT "from .bindings import *${NEW_LINE}from . import utils${NEW_LINE}")
 
-     # Install the __init__.py file
+    # Install the __init__.py file
     install(FILES "${BLF_PYTHON_PACKAGE}/__init__.py"
             DESTINATION ${PYTHON_INSTDIR})
+
+    # Install pip metadata files to ensure that blf installed via CMake is listed by pip list
+    # See https://packaging.python.org/specifications/recording-installed-packages/
+    # and https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata
+    option(BLF_PYTHON_PIP_METADATA_INSTALL "Use CMake to install Python pip metadata. Set to off if some other tool already installs it." ON)
+    mark_as_advanced(BLF_PYTHON_PIP_METADATA_INSTALL)
+    set(BLF_PYTHON_PIP_METADATA_INSTALLER "cmake" CACHE STRING "Specify the string to identify the pip Installer. Default: cmake, change this if you are using another tool.")
+    mark_as_advanced(BLF_PYTHON_PIP_METADATA_INSTALLER)
+    if(BLF_PYTHON_PIP_METADATA_INSTALL)
+      get_filename_component(PYTHON_METADATA_PARENT_DIR ${PYTHON_INSTDIR} DIRECTORY)
+      if(WIN32)
+        set(NEW_LINE "\n\r")
+      else()
+        set(NEW_LINE "\n")
+      endif()
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/METADATA "")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Metadata-Version: 2.1${NEW_LINE}")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Name: bipedal_locomotion_framework${NEW_LINE}")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Version: ${BipedalLocomotionFramework_VERSION}${NEW_LINE}")
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/INSTALLER "${BLF_PYTHON_PIP_METADATA_INSTALLER}${NEW_LINE}")
+      install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/METADATA" "${CMAKE_CURRENT_BINARY_DIR}/INSTALLER"
+        DESTINATION ${PYTHON_METADATA_PARENT_DIR}/bipedal_locomotion_framework-${BipedalLocomotionFramework_VERSION}.dist-info)
+    endif()
 
 endif()


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/issues/1012 for a discussion of the problem. This is not particularly problematic for blf as blf is not on PyPI, but anyhow seeing the output of `pip list --verbose` with `cmake` as a tool (see https://github.com/robotology/robotology-superbuild/issues/1012#issuecomment-1032880753) is always cool. :D 