### PR TITLE
Implement the python bindings for the VectorsCollection message and the associated buffered port

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -82,7 +82,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_IK:BOOL=OFF -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
     - name: Build [Windows]
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -37,7 +37,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog catch2 nlohmann_json manif manifpy pybind11 numpy pytest scipy opencv pcl tomlplusplus unicycle-footstep-planner
+        mamba install idyntree "yarp>=3.5.0" libmatio matio-cpp lie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog catch2 nlohmann_json manif manifpy pybind11 numpy pytest scipy opencv pcl tomlplusplus unicycle-footstep-planner
 
     - name: Linux-only Dependencies [Linux]
       if: contains(matrix.os, 'ubuntu')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to this project are documented in this file.
 - Implement the python bindings for the clock machinery and for the yarp clock (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)
 - Implement the `IWeightProvider` interface and the `ConstantWeightProvider` class in the System component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/506)
 - Add installation of pip metadata files for when blf python bindings are installed only via CMake (https://github.com/ami-iit/bipedal-locomotion-framework/pull/508)
+- Implement the python bindings for the VectorsCollection message and the associated buffered port (https://github.com/ami-iit/bipedal-locomotion-framework/pull/511)
 
 ### Changed
 - An error it will be returned if the user tries to change the clock type once the `clock()` has been already called once (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)
 - Log the arms external wrenches on the YarpRobotLogger for iCubGenova09 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/502)
 - IK and TSID now uses the weight provider to specify the weight associated to a task (https://github.com/ami-iit/bipedal-locomotion-framework/pull/506)
+- The `Planners`, `System`, `RobotInterface` and `YarpImplementation` components are no more mandatory to compile the python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/511)
 
 ### Fix
 - Remove outdated includes in YarpRobotLoggerDevice.cpp (https://github.com/ami-iit/bipedal-locomotion-framework/pull/502)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -17,8 +17,19 @@ add_subdirectory(YarpUtilities)
 
 include(ConfigureFileWithCMakeIf)
 
-set(FRAMEWORK_COMPILE_RobotInterfaceBindings FRAMEWORK_COMPILE_RobotInterface AND FRAMEWORK_COMPILE_YarpImplementation)
-set(FRAMEWORK_COMPILE_YarpBindingsSystem FRAMEWORK_COMPILE_System AND FRAMEWORK_COMPILE_YarpImplementation)
+if (FRAMEWORK_COMPILE_RobotInterface AND FRAMEWORK_COMPILE_YarpImplementation)
+  set(FRAMEWORK_COMPILE_BINDINGS_RobotInterface ON)
+else ()
+  set(FRAMEWORK_COMPILE_BINDINGS_RobotInterface OFF)
+endif()
+mark_as_advanced(FRAMEWORK_COMPILE_BINDINGS_RobotInterface)
+
+if (FRAMEWORK_COMPILE_System AND FRAMEWORK_COMPILE_YarpImplementation)
+  set(FRAMEWORK_COMPILE_BINDINGS_YarpSystem ON)
+else ()
+  set(FRAMEWORK_COMPILE_BINDINGS_YarpSystem OFF)
+endif()
+mark_as_advanced(FRAMEWORK_COMPILE_BINDINGS_YarpSystem)
 
 configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/bipedal_locomotion_framework.cpp.in
   ${CMAKE_CURRENT_BINARY_DIR}/bipedal_locomotion_framework.cpp

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(IK)
 add_subdirectory(TSID)
 add_subdirectory(TextLogging)
 add_subdirectory(Conversions)
+add_subdirectory(YarpUtilities)
 
 include(ConfigureFileWithCMakeIf)
 

--- a/bindings/python/YarpUtilities/CMakeLists.txt
+++ b/bindings/python/YarpUtilities/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+if(FRAMEWORK_COMPILE_YarpUtilities)
+
+  set(H_PREFIX include/BipedalLocomotion/bindings/YarpUtilities)
+
+  add_bipedal_locomotion_python_module(
+    NAME YarpUtilitiesBindings
+    SOURCES src/VectorsCollection.cpp src/Module.cpp
+    HEADERS ${H_PREFIX}/VectorsCollection.h ${H_PREFIX}/BufferedPort.h ${H_PREFIX}/Module.h
+    LINK_LIBRARIES BipedalLocomotion::VectorsCollection ${YARP_LIBRARIES} BipedalLocomotion::YarpUtilities
+    )
+
+endif()

--- a/bindings/python/YarpUtilities/include/BipedalLocomotion/bindings/YarpUtilities/BufferedPort.h
+++ b/bindings/python/YarpUtilities/include/BipedalLocomotion/bindings/YarpUtilities/BufferedPort.h
@@ -1,0 +1,44 @@
+/**
+ * @file BufferedPort.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_YARP_UTILITES_BUFFERED_PORT_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_YARP_UTILITES_BUFFERED_PORT_H
+
+#include <string>
+
+#include <pybind11/detail/common.h>
+#include <pybind11/pybind11.h>
+
+#include <yarp/os/BufferedPort.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace YarpUtilities
+{
+
+template <typename T> void CreateBufferedPort(pybind11::module& module, const std::string& name)
+{
+    namespace py = ::pybind11;
+    py::class_<::yarp::os::BufferedPort<T>>(module, name.c_str())
+        .def(py::init())
+        .def("open",
+             py::overload_cast<const std::string&>(&::yarp::os::BufferedPort<T>::open),
+             py::arg("name"))
+        .def("close", &::yarp::os::BufferedPort<T>::close)
+    .def("prepare",
+         &::yarp::os::BufferedPort<T>::prepare,
+         py::return_value_policy::reference_internal)
+    .def("write", &::yarp::os::BufferedPort<T>::write, py::arg("force_strict") = false);
+}
+
+} // namespace YarpUtilities
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_YARP_UTILITES_BUFFERED_PORT_H

--- a/bindings/python/YarpUtilities/include/BipedalLocomotion/bindings/YarpUtilities/Module.h
+++ b/bindings/python/YarpUtilities/include/BipedalLocomotion/bindings/YarpUtilities/Module.h
@@ -1,0 +1,26 @@
+/**
+ * @file Module.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_YARP_UTILITES_MODULE_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_YARP_UTILITES_MODULE_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace YarpUtilities
+{
+
+void CreateModule(pybind11::module& module);
+
+} // namespace YarpUtilities
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_YARP_UTILITES_MODULE_H

--- a/bindings/python/YarpUtilities/include/BipedalLocomotion/bindings/YarpUtilities/VectorsCollection.h
+++ b/bindings/python/YarpUtilities/include/BipedalLocomotion/bindings/YarpUtilities/VectorsCollection.h
@@ -1,0 +1,26 @@
+/**
+ * @file VectorsCollection.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_YARP_UTILITES_VECTORS_COLLECTION_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_YARP_UTILITES_VECTORS_COLLECTION_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace YarpUtilities
+{
+
+void CreateVectorsCollection(pybind11::module& module);
+
+} // namespace YarpUtilities
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_YARP_UTILITES_VECTORS_COLLECTION_H

--- a/bindings/python/YarpUtilities/src/Module.cpp
+++ b/bindings/python/YarpUtilities/src/Module.cpp
@@ -1,0 +1,26 @@
+/**
+ * @file Module.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include <BipedalLocomotion/bindings/YarpUtilities/VectorsCollection.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace YarpUtilities
+{
+void CreateModule(pybind11::module& module)
+{
+    module.doc() = "YarpUtilities module.";
+
+    CreateVectorsCollection(module);
+}
+} // namespace IK
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/YarpUtilities/src/VectorsCollection.cpp
+++ b/bindings/python/YarpUtilities/src/VectorsCollection.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file VectorsCollection.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/YarpUtilities/VectorsCollection.h>
+
+#include <BipedalLocomotion/bindings/YarpUtilities/VectorsCollection.h>
+#include <BipedalLocomotion/bindings/YarpUtilities/BufferedPort.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace YarpUtilities
+{
+void CreateVectorsCollection(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    using namespace ::BipedalLocomotion::YarpUtilities;
+
+    py::class_<VectorsCollection>(module, "VectorsCollection")
+        .def(py::init())
+        .def_readwrite("vectors", &VectorsCollection::vectors)
+        .def("__repr__", &VectorsCollection::toString)
+        .def("to_string", &VectorsCollection::toString);
+
+    CreateBufferedPort<VectorsCollection>(module, "BufferedPortVectorsCollection");
+}
+} // namespace YarpUtilities
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/bipedal_locomotion_framework.cpp.in
+++ b/bindings/python/bipedal_locomotion_framework.cpp.in
@@ -25,9 +25,9 @@
 #include <BipedalLocomotion/bindings/System/Clock.h>
 @endcmakeif FRAMEWORK_COMPILE_System
 
-@cmakeif FRAMEWORK_COMPILE_YarpBindingsSystem
+@cmakeif FRAMEWORK_COMPILE_BINDINGS_YarpSystem
 #include <BipedalLocomotion/bindings/System/YarpModule.h>
-@endcmakeif FRAMEWORK_COMPILE_YarpBindingsSystem
+@endcmakeif FRAMEWORK_COMPILE_BINDINGS_YarpSystem
 
 @cmakeif FRAMEWORK_COMPILE_Contact
 #include <BipedalLocomotion/bindings/Contacts/Module.h>
@@ -37,9 +37,9 @@
 #include <BipedalLocomotion/bindings/Planners/Module.h>
 @endcmakeif FRAMEWORK_COMPILE_Planners
 
-@cmakeif FRAMEWORK_COMPILE_RobotInterfaceBindings
+@cmakeif FRAMEWORK_COMPILE_BINDINGS_RobotInterface
 #include <BipedalLocomotion/bindings/RobotInterface/Module.h>
-@endcmakeif FRAMEWORK_COMPILE_RobotInterfaceBindings
+@endcmakeif FRAMEWORK_COMPILE_BINDINGS_RobotInterface
 
 @cmakeif FRAMEWORK_COMPILE_FloatingBaseEstimators
 #include <BipedalLocomotion/bindings/FloatingBaseEstimators/Module.h>
@@ -96,9 +96,9 @@ PYBIND11_MODULE(bindings, m)
     bindings::CreateClock(m);
     @endcmakeif FRAMEWORK_COMPILE_System
 
-    @cmakeif FRAMEWORK_COMPILE_YarpBindingsSystem
+    @cmakeif FRAMEWORK_COMPILE_BINDINGS_YarpSystem
     bindings::System::CreateYarpModule(systemModule);
-    @endcmakeif FRAMEWORK_COMPILE_YarpBindingsSystem
+    @endcmakeif FRAMEWORK_COMPILE_BINDINGS_YarpSystem
 
     @cmakeif FRAMEWORK_COMPILE_Contact
     py::module contactsModule = m.def_submodule("contacts");
@@ -110,10 +110,10 @@ PYBIND11_MODULE(bindings, m)
     bindings::Planners::CreateModule(plannersModule);
     @endcmakeif FRAMEWORK_COMPILE_Planners
 
-    @cmakeif FRAMEWORK_COMPILE_RobotInterfaceBindings
+    @cmakeif FRAMEWORK_COMPILE_BINDINGS_RobotInterface
     py::module robotInterfaceModule = m.def_submodule("robot_interface");
     bindings::RobotInterface::CreateModule(robotInterfaceModule);
-    @endcmakeif FRAMEWORK_COMPILE_RobotInterfaceBindings
+    @endcmakeif FRAMEWORK_COMPILE_BINDINGS_RobotInterface
 
     @cmakeif FRAMEWORK_COMPILE_FloatingBaseEstimators
     py::module floatingBaseEstimatorModule = m.def_submodule("floating_base_estimators");

--- a/bindings/python/bipedal_locomotion_framework.cpp.in
+++ b/bindings/python/bipedal_locomotion_framework.cpp.in
@@ -57,6 +57,10 @@
 #include <BipedalLocomotion/bindings/Conversions/Module.h>
 @endcmakeif FRAMEWORK_COMPILE_ManifConversions
 
+@cmakeif FRAMEWORK_COMPILE_YarpUtilities
+#include <BipedalLocomotion/bindings/YarpUtilities/Module.h>
+@endcmakeif FRAMEWORK_COMPILE_YarpUtilities
+
 // Create the Python module
 PYBIND11_MODULE(bindings, m)
 {
@@ -130,4 +134,9 @@ PYBIND11_MODULE(bindings, m)
     py::module conversionsModule = m.def_submodule("conversions");
     bindings::Conversions::CreateModule(conversionsModule);
     @endcmakeif FRAMEWORK_COMPILE_ManifConversions
+
+    @cmakeif FRAMEWORK_COMPILE_YarpUtilities
+    py::module yarpUtilitiesModule = m.def_submodule("yarp_utilities");
+    bindings::YarpUtilities::CreateModule(yarpUtilitiesModule);
+    @endcmakeif FRAMEWORK_COMPILE_YarpUtilities
 }

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -181,7 +181,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_JointPositionTrackingApplication
 
 framework_dependent_option(FRAMEWORK_COMPILE_PYTHON_BINDINGS
   "Do you want to generate and compile the Python bindings?" ON
-  "FRAMEWORK_USE_Python3;FRAMEWORK_USE_pybind11;FRAMEWORK_COMPILE_Planners;FRAMEWORK_COMPILE_System;FRAMEWORK_COMPILE_RobotInterface;FRAMEWORK_COMPILE_YarpImplementation" OFF)
+  "FRAMEWORK_USE_Python3;FRAMEWORK_USE_pybind11;FRAMEWORK_COMPILE_Math" OFF)
 
 framework_dependent_option(FRAMEWORK_TEST_PYTHON_BINDINGS
   "Do you want to test the Python bindings?" ON


### PR DESCRIPTION
Thanks to this PR it is possible to use the `VectorsCollection` message also in python. As a consequence, a python process can log data in the [`YarpRobotLoggerDevice`](https://github.com/ami-iit/bipedal-locomotion-framework/tree/master/devices/YarpRobotLoggerDevice).

This is a minimum python example (you should run `yarpserver`)

```python
import bipedal_locomotion_framework.bindings as blf
import yarp

network = yarp.Network()

network.init()
port = blf.yarp_utilities.BufferedPortVectorsCollection()
port.open("/foo")

data = port.prepare()
data.vectors = {"v1": [1, 2, 3.4], "v2": [12, 3, 2, 4, 3]}

port.write()
port.close()
```

⚠️ : It is not possible to modify directly the content of `data.vectors`. Indeed trying to add an entity to the dictionary does not work
```python
>>> data.vectors["v3"] = [1,2.3,45]
>>> data.vectors
{'v1': [1.0, 2.0, 3.4], 'v2': [12.0, 3.0, 2.0, 4.0, 3.0]}
```
This is due to a well-known limitation in pybind11 https://github.com/pybind/pybind11/issues/175. A possible solution is to make _opaque_ the std container has explained [here](https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html?highlight=opaque#making-opaque-types). However there seems that this choice will affect all the similar containers in the module and I would like to avoid this.

---

⚠️ `blf.yarp_utilities.BufferedPortVectorsCollection` is a  pybind11 object created by blf. So **it is not** an instance of the YARP SWIG bindings object.