### PR TITLE
Always use \n as new line when generating files with CMake

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -4,12 +4,7 @@
 
 if(FRAMEWORK_COMPILE_PYTHON_BINDINGS)
 
-    # define new line accordingly to the operating system
-    if (WIN32)
-       set(NEW_LINE "\n\r")
-    else()
-       set(NEW_LINE "\n")
-    endif()
+    set(NEW_LINE "\n")
 
     option(FRAMEWORK_DETECT_ACTIVE_PYTHON_SITEPACKAGES
         "Do you want BLF to detect and use the active site-package directory? (it could be a system dir)"


### PR DESCRIPTION
As reported in https://github.com/conda-forge/opencv-feedstock/issues/302, `\n\r` do not represent a single newline in Windows (even as in that case it would be `\r\n`). Anyhow, `\n` seems to be working fine, so let's just use that one.