### PR TITLE
YarpLoggerDevice: ported to robometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Add the possibility to log the YarpTextLogging in the YarpRobotLogger (https://github.com/ami-iit/bipedal-locomotion-framework/pull/541)
 - Enable the logging FTs and IMU logging of iCubGenova09 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/546/)
 ### Changed
+- Ported `YarpLoggerDevice` to `robometry`(https://github.com/ami-iit/bipedal-locomotion-framework/pull/533)
 - bipedal locomotion framework now depends on YARP 3.7.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/541)
 ### Fix
 - Avoid to use deprecated function cv::aruco::drawAxis in ArucoDetector to fix compilation with OpenCV 4.6.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/552)

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -78,9 +78,9 @@ find_package(tomlplusplus 2.4.0 QUIET)
 checkandset_dependency(tomlplusplus MINIMUM_VERSION 2.4.0)
 dependency_classifier(tomlplusplus MINIMUM_VERSION 2.4.0 IS_USED ${FRAMEWORK_USE_tomlplusplus} PUBLIC)
 
-find_package(YARP_telemetry 0.5.1 QUIET)
-checkandset_dependency(YARP_telemetry MINIMUM_VERSION 0.5.1)
-dependency_classifier(YARP_telemetry MINIMUM_VERSION 0.5.1 IS_USED ${FRAMEWORK_USE_YARP_telemetry})
+find_package(robometry 1.1.0 QUIET)
+checkandset_dependency(robometry MINIMUM_VERSION 1.1.0)
+dependency_classifier(robometry MINIMUM_VERSION 1.1.0 IS_USED ${FRAMEWORK_USE_robometry})
 
 # required only for some tests
 find_package(icub-models 1.23.3 QUIET)
@@ -222,7 +222,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_CalibrationDeltaUpdaterApplication
 
 framework_dependent_option(FRAMEWORK_COMPILE_YarpRobotLoggerDevice
   "Do you want to generate and compile the YarpRobotLoggerDevice?" ON
-  "FRAMEWORK_COMPILE_RobotInterface;FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_YarpUtilities;FRAMEWORK_USE_YARP_telemetry" OFF)
+  "FRAMEWORK_COMPILE_RobotInterface;FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_YarpUtilities;FRAMEWORK_USE_robometry" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_VectorsCollectionWrapper
   "Do you want to generate and compile the VectorsCollectionWrapper?" ON

--- a/devices/YarpRobotLoggerDevice/CMakeLists.txt
+++ b/devices/YarpRobotLoggerDevice/CMakeLists.txt
@@ -15,7 +15,7 @@ if(FRAMEWORK_COMPILE_YarpRobotLoggerDevice)
       YARP::YARP_os
       YARP::YARP_dev
       YARP::YARP_profiler
-      YARP::YARP_telemetry
+      robometry::robometry
       BipedalLocomotion::TextLogging
       BipedalLocomotion::System
       BipedalLocomotion::YarpUtilities

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -22,7 +22,8 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/telemetry/experimental/BufferManager.h>
+
+#include <robometry/BufferManager.h>
 
 #include <BipedalLocomotion/RobotInterface/YarpSensorBridge.h>
 #include <BipedalLocomotion/RobotInterface/YarpCameraBridge.h>
@@ -102,7 +103,7 @@ private:
     bool m_streamFTSensors{false};
     bool m_streamTemperatureSensors{false};
 
-    yarp::telemetry::experimental::BufferManager<> m_bufferManager;
+    robometry::BufferManager m_bufferManager;
 
     void lookForNewLogs();
     void recordVideo(const std::string& cameraName, VideoWriter& writer);
@@ -117,7 +118,7 @@ private:
     bool setupExogenousInputs(std::weak_ptr<const ParametersHandler::IParametersHandler> params);
 
     bool saveVideo(const std::string& fileName,
-                   const yarp::telemetry::experimental::SaveCallbackSaveMethod& method);
+                   const robometry::SaveCallbackSaveMethod& method);
 };
 
 } // namespace BipedalLocomotion

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -27,8 +27,8 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/profiler/NetworkProfiler.h>
 
-#include <yarp/telemetry/experimental/BufferConfig.h>
-#include <yarp/telemetry/experimental/BufferManager.h>
+#include <robometry/BufferConfig.h>
+#include <robometry/BufferManager.h>
 
 #include <cstdio>
 #include <fstream>
@@ -229,7 +229,7 @@ bool YarpRobotLoggerDevice::setupTelemetry(
         return false;
     }
 
-    yarp::telemetry::experimental::BufferConfig config;
+    robometry::BufferConfig config;
     config.yarp_robot_name = std::getenv("YARP_ROBOT_NAME");
     config.filename = "robot_logger_device";
     config.auto_save = true;
@@ -542,7 +542,7 @@ bool YarpRobotLoggerDevice::attachAll(const yarp::dev::PolyDriverList& poly)
             ok = ok
                  && m_bufferManager.setSaveCallback(
                      [this](const std::string& filePrefix,
-                            const yarp::telemetry::experimental::SaveCallbackSaveMethod& method)
+                            const robometry::SaveCallbackSaveMethod& method)
                          -> bool { return this->saveVideo(filePrefix, method); });
         }
 
@@ -882,7 +882,7 @@ void YarpRobotLoggerDevice::run()
 
 bool YarpRobotLoggerDevice::saveVideo(
     const std::string& fileName,
-    const yarp::telemetry::experimental::SaveCallbackSaveMethod& method)
+    const robometry::SaveCallbackSaveMethod& method)
 {
     for (const auto& camera : m_rgbCamerasList)
     {
@@ -895,7 +895,7 @@ bool YarpRobotLoggerDevice::saveVideo(
         // rename the file associated to the camera
         std::rename(oldName.c_str(), temp.c_str());
 
-        if (method == yarp::telemetry::experimental::SaveCallbackSaveMethod::periodic)
+        if (method == robometry::SaveCallbackSaveMethod::periodic)
         {
             const auto& cameraInfo
                 = m_cameraBridge->getMetaData().bridgeOptions.rgbImgDimensions.find(camera);


### PR DESCRIPTION
`robometry` is the new name of `YARP_telemetry`, see https://github.com/robotology/robometry/pull/173

please review code