### PR TITLE
Fix linking idyntree-model target deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 ### Changed
 ### Fix
+- Fix linking target deprecation of iDynTree::idyntree-modelio (https://github.com/ami-iit/bipedal-locomotion-framework/pull/551)
 
 ## [0.7.0] - 2022-06-21
 ### Added

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -19,6 +19,6 @@ if(FRAMEWORK_COMPILE_FloatingBaseEstimators)
     SOURCES                src/ModelComputationsHelper.cpp src/FloatingBaseEstimator.cpp src/InvariantEKFBaseEstimator.cpp src/LeggedOdometry.cpp
     SUBDIRECTORIES         tests/FloatingBaseEstimators
     PUBLIC_HEADERS         ${H_PREFIX}/FloatingBaseEstimatorParams.h ${H_PREFIX}/FloatingBaseEstimatorIO.h ${H_PREFIX}/FloatingBaseEstimator.h ${H_PREFIX}/InvariantEKFBaseEstimator.h ${H_PREFIX}/LeggedOdometry.h ${H_PREFIX}/ModelComputationsHelper.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen BipedalLocomotion::Contacts iDynTree::idyntree-modelio-urdf BipedalLocomotion::TextLogging
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen BipedalLocomotion::Contacts iDynTree::idyntree-modelio BipedalLocomotion::TextLogging
     PRIVATE_LINK_LIBRARIES MANIF::manif)
 endif()

--- a/src/Estimators/tests/FloatingBaseEstimators/CMakeLists.txt
+++ b/src/Estimators/tests/FloatingBaseEstimators/CMakeLists.txt
@@ -8,7 +8,7 @@ if(FRAMEWORK_USE_icub-models)
   add_bipedal_test(
     NAME BareBonesBaseEstimator
     SOURCES FloatingBaseEstimatorTest.cpp
-    LINKS BipedalLocomotion::FloatingBaseEstimators BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions Eigen3::Eigen iDynTree::idyntree-modelio-urdf icub-models::icub-models)
+    LINKS BipedalLocomotion::FloatingBaseEstimators BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions Eigen3::Eigen iDynTree::idyntree-modelio icub-models::icub-models)
 
 
   add_bipedal_test(


### PR DESCRIPTION
This could be useful if we bump the iDynTree required version, although I am not able to find for which version of iDynTree this change was introduced, going through it's CHANGELOG.