### PR TITLE
ArucoDetector: Avoid to use deprecated function aruco::drawAxis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 ### Changed
 ### Fix
+- Avoid to use deprecated function cv::aruco::drawAxis in ArucoDetector to fix compilation with OpenCV 4.6.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/552)
 
 ## [0.7.0] - 2022-06-21
 ### Added
@@ -38,7 +39,6 @@ All notable changes to this project are documented in this file.
 
 ### Fix
 - Remove outdated includes in YarpRobotLoggerDevice.cpp (https://github.com/ami-iit/bipedal-locomotion-framework/pull/502)
-- Avoid to use deprecated function cv::aruco::drawAxis in ArucoDetector to fix compilation with OpenCV 4.6.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/552)
 
 ## [0.6.0] - 2022-01-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project are documented in this file.
 
 ### Fix
 - Remove outdated includes in YarpRobotLoggerDevice.cpp (https://github.com/ami-iit/bipedal-locomotion-framework/pull/502)
+- Avoid to use deprecated function cv::aruco::drawAxis in ArucoDetector to fix compilation with OpenCV 4.6.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/552)
 
 ## [0.6.0] - 2022-01-10
 ### Added

--- a/src/Perception/src/ArucoDetector.cpp
+++ b/src/Perception/src/ArucoDetector.cpp
@@ -275,12 +275,12 @@ bool ArucoDetector::getImageWithDetectedMarkers(cv::Mat& outputImg,
     {
         for (std::size_t idx = 0; idx < nrDetectedMarkers; idx++)
         {
-            cv::aruco::drawAxis(outputImg,
-                                m_pimpl->cameraMatrix,
-                                m_pimpl->distCoeff,
-                                m_pimpl->currentDetectedMarkersRotVecs[idx],
-                                m_pimpl->currentDetectedMarkersTransVecs[idx],
-                                axisLengthForDrawing);
+            cv::drawFrameAxes(outputImg,
+                              m_pimpl->cameraMatrix,
+                              m_pimpl->distCoeff,
+                              m_pimpl->currentDetectedMarkersRotVecs[idx],
+                              m_pimpl->currentDetectedMarkersTransVecs[idx],
+                              axisLengthForDrawing);
         }
     }
 


### PR DESCRIPTION
This should permit to compile without problems on OpenCV 4.6.0 .