### PR TITLE
Fix the compatibility with fmt v9.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/install/deps
-        key: source-deps-${{ runner.os }}-os-${{ matrix.os }}-build-type-${{ matrix.build_type }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-iDynTree-${{ env.iDynTree_TAG }}-catch2-${{ env.Catch2_TAG }}-qhull-${{ env.Qhull_TAG }}-casADi-${{ env.CasADi_TAG }}-manif-${{ env.manif_TAG }}-matioCpp-${{ env.matioCpp_TAG }}-LieGroupControllers-${{ env.LieGroupControllers_TAG }}-osqp-${{ env.osqp_TAG }}-osqp-eigen-${{ env.OsqpEigen_TAG }}-tomlplusplus-${{ env.tomlplusplus_TAG }}-unicycle-${{ env.UnicyclePlanner_TAG }}-icub-models-${{ env.icub_models_TAG }}-robometry-${{ env.telemetry_TAG }}
+        key: blf-source-deps-${{ runner.os }}-os-${{ matrix.os }}-build-type-${{ matrix.build_type }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-iDynTree-${{ env.iDynTree_TAG }}-catch2-${{ env.Catch2_TAG }}-qhull-${{ env.Qhull_TAG }}-casADi-${{ env.CasADi_TAG }}-manif-${{ env.manif_TAG }}-matioCpp-${{ env.matioCpp_TAG }}-LieGroupControllers-${{ env.LieGroupControllers_TAG }}-osqp-${{ env.osqp_TAG }}-osqp-eigen-${{ env.OsqpEigen_TAG }}-tomlplusplus-${{ env.tomlplusplus_TAG }}-unicycle-${{ env.UnicyclePlanner_TAG }}-icub-models-${{ env.icub_models_TAG }}-robometry-${{ env.telemetry_TAG }}
 
 
     - name: Source-based Dependencies [Windows]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 ### Fix
 - Fix the dependency required to compile the YarpRobotLogger device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/554)
+- Fix the compatibility with fmt v9.0.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/556)
 
 ## [0.8.0] - 2022-07-29
 ### Added

--- a/src/TextLogging/CMakeLists.txt
+++ b/src/TextLogging/CMakeLists.txt
@@ -8,5 +8,5 @@ add_bipedal_locomotion_library(
                          include/BipedalLocomotion/TextLogging/LoggerBuilder.h
                          include/BipedalLocomotion/TextLogging/DefaultLogger.h
   SOURCES                src/Logger.cpp src/LoggerBuilder.cpp src/DefaultLogger.cpp
-  PUBLIC_LINK_LIBRARIES  spdlog::spdlog
+  PUBLIC_LINK_LIBRARIES  spdlog::spdlog Eigen3::Eigen
   SUBDIRECTORIES         YarpImplementation)

--- a/src/TextLogging/include/BipedalLocomotion/TextLogging/Logger.h
+++ b/src/TextLogging/include/BipedalLocomotion/TextLogging/Logger.h
@@ -14,6 +14,19 @@
 #include <spdlog/spdlog.h>
 #include <type_traits>
 
+// This is required only for FMT > v9.0.0
+#if (defined(FMT_VERSION) && FMT_VERSION > 90000)
+#include <Eigen/Dense>
+template <typename _Derived>
+struct fmt::formatter<Eigen::DenseBase<_Derived>> : ostream_formatter
+{
+};
+template <typename _Derived>
+struct fmt::formatter<Eigen::Transpose<_Derived>> : ostream_formatter
+{
+};
+#endif
+
 namespace BipedalLocomotion
 {
 namespace TextLogging


### PR DESCRIPTION
If `spdlog` uses a system-wide installation of `fmt` and the `fmt` version is at least 9.0.0, the current implementation of the logger does not work with eigen object. 
This caused the homebrew CI failure https://github.com/robotology/robotology-superbuild/issues/1234

This PR implements what is suggested in https://fmt.dev/latest/api.html#std-ostream-support for `Dense` and `Transpose` eigen matrices. Additional `formatter` could be defined in the future if required. 

Once this PR is merged it will be possible to reactivate the compilation of blf in the macOS CI of the superbuild.