### PR TITLE
Implement the IK::R3Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 - Implement `PortInput` and `PortOutput`in `System` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/555)
 - Implement `toManifTwist` in `Conversions` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/557)
 - Add the default value for the desired spatial and angular velocity to the `IK::SO3Task` and `IK::SE3Task` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/557)
+- Implement the `IK::R3Task` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/559)
 
 ### Changed
 - Now `Advanceable` inherits from `PortInput` and `PortOutput` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/555)

--- a/bindings/python/IK/CMakeLists.txt
+++ b/bindings/python/IK/CMakeLists.txt
@@ -8,8 +8,8 @@ if(FRAMEWORK_COMPILE_IK)
 
   add_bipedal_locomotion_python_module(
     NAME IKBindings
-    SOURCES src/IntegrationBasedIK.cpp src/QPInverseKinematics.cpp src/CoMTask.cpp src/SE3Task.cpp src/SO3Task.cpp src/JointTrackingTask.cpp src/AngularMomentumTask.cpp src/Module.cpp src/IKLinearTask.cpp
-    HEADERS ${H_PREFIX}/IntegrationBasedIK.h ${H_PREFIX}/QPInverseKinematics.h ${H_PREFIX}/CoMTask.h ${H_PREFIX}/SE3Task.h ${H_PREFIX}/SO3Task.h ${H_PREFIX}/JointTrackingTask.h ${H_PREFIX}/AngularMomentumTask.h ${H_PREFIX}/Module.h ${H_PREFIX}/IKLinearTask.h
+    SOURCES src/IntegrationBasedIK.cpp src/QPInverseKinematics.cpp src/CoMTask.cpp src/R3Task.cpp src/SE3Task.cpp src/SO3Task.cpp src/JointTrackingTask.cpp src/AngularMomentumTask.cpp src/Module.cpp src/IKLinearTask.cpp
+    HEADERS ${H_PREFIX}/IntegrationBasedIK.h ${H_PREFIX}/QPInverseKinematics.h ${H_PREFIX}/CoMTask.h ${H_PREFIX}/R3Task.h ${H_PREFIX}/SE3Task.h ${H_PREFIX}/SO3Task.h ${H_PREFIX}/JointTrackingTask.h ${H_PREFIX}/AngularMomentumTask.h ${H_PREFIX}/Module.h ${H_PREFIX}/IKLinearTask.h
     LINK_LIBRARIES BipedalLocomotion::IK MANIF::manif
     TESTS tests/test_QP_inverse_kinematics.py
     TESTS_RUNTIME_CONDITIONS FRAMEWORK_USE_icub-models

--- a/bindings/python/IK/include/BipedalLocomotion/bindings/IK/R3Task.h
+++ b/bindings/python/IK/include/BipedalLocomotion/bindings/IK/R3Task.h
@@ -1,0 +1,26 @@
+/**
+ * @file R3Task.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_IK_R3_TASK_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_IK_R3_TASK_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace IK
+{
+
+void CreateR3Task(pybind11::module& module);
+
+} // namespace IK
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_IK_R3_TASK_H

--- a/bindings/python/IK/src/R3Task.cpp
+++ b/bindings/python/IK/src/R3Task.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file R3Task.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/IK/IKLinearTask.h>
+#include <BipedalLocomotion/IK/R3Task.h>
+#include <BipedalLocomotion/System/ITaskControllerManager.h>
+
+#include <BipedalLocomotion/bindings/IK/R3Task.h>
+
+#include <manif/manif.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace IK
+{
+
+void CreateR3Task(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+    using namespace BipedalLocomotion::IK;
+
+    py::class_<R3Task,
+               std::shared_ptr<R3Task>,
+               IKLinearTask,
+               BipedalLocomotion::System::ITaskControllerManager>(module, "R3Task")
+        .def(py::init())
+        .def("set_kin_dyn", &R3Task::setKinDyn, py::arg("kin_dyn"))
+        .def("set_set_point",
+             &R3Task::setSetPoint,
+             py::arg("I_p_F"),
+             py::arg("velocity") = Eigen::Vector3d::Zero());
+}
+
+} // namespace IK
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/src/IK/CMakeLists.txt
+++ b/src/IK/CMakeLists.txt
@@ -8,8 +8,8 @@ if(FRAMEWORK_COMPILE_IK)
 
   add_bipedal_locomotion_library(
     NAME                   IK
-    PUBLIC_HEADERS         ${H_PREFIX}/SE3Task.h ${H_PREFIX}/SO3Task.h ${H_PREFIX}/JointTrackingTask.h ${H_PREFIX}/CoMTask.h ${H_PREFIX}/IntegrationBasedIK.h ${H_PREFIX}/QPInverseKinematics.h ${H_PREFIX}/IKLinearTask.h ${H_PREFIX}/AngularMomentumTask.h
-    SOURCES                src/SE3Task.cpp src/SO3Task.cpp src/JointTrackingTask.cpp src/CoMTask.cpp src/QPInverseKinematics.cpp src/AngularMomentumTask.cpp
+    PUBLIC_HEADERS         ${H_PREFIX}/R3Task.h ${H_PREFIX}/SE3Task.h ${H_PREFIX}/SO3Task.h ${H_PREFIX}/JointTrackingTask.h ${H_PREFIX}/CoMTask.h ${H_PREFIX}/IntegrationBasedIK.h ${H_PREFIX}/QPInverseKinematics.h ${H_PREFIX}/IKLinearTask.h ${H_PREFIX}/AngularMomentumTask.h
+    SOURCES                src/R3Task.cpp src/SE3Task.cpp src/SO3Task.cpp src/JointTrackingTask.cpp src/CoMTask.cpp src/QPInverseKinematics.cpp src/AngularMomentumTask.cpp
     PUBLIC_LINK_LIBRARIES  Eigen3::Eigen
                            BipedalLocomotion::ParametersHandler BipedalLocomotion::System
                            LieGroupControllers::LieGroupControllers

--- a/src/IK/include/BipedalLocomotion/IK/R3Task.h
+++ b/src/IK/include/BipedalLocomotion/IK/R3Task.h
@@ -1,0 +1,165 @@
+/**
+ * @file R3Task.h
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_IK_R3_TASK_H
+#define BIPEDAL_LOCOMOTION_IK_R3_TASK_H
+
+#include <memory>
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/IK/IKLinearTask.h>
+#include <BipedalLocomotion/System/ITaskControllerManager.h>
+
+#include <iDynTree/KinDynComputations.h>
+
+#include <LieGroupControllers/ProportionalController.h>
+
+namespace BipedalLocomotion
+{
+namespace IK
+{
+
+/**
+ * R3Task is a concrete implementation of the Task. Please use this element if you
+ * want to control the position of a given frame rigidly attached to the robot.
+ * The task assumes perfect control of the robot velocity \f$\nu\f$ that contains the base
+ * linear and angular velocity expressed in mixed representation and the joint velocities.
+ * The task represents the following equation
+ * \f[
+ * J_l \nu = v ^ *
+ * \f]
+ * where \f$J_l\f$ is the linear part robot jacobian and \f$v ^ *\f$ is the desired velocity.
+ * The desired velocity is chosen such that the frame position will asymptotically converge to the
+ * desired trajectory and is computed with a standard Proportional controller in \f$R^3\f$.
+ * @note Please refer to https://github.com/ami-iit/lie-group-controllers if you are interested in
+ * the implementation of the PD controllers.
+ * @note R3Task can be used to control also a subset of coordinates.
+ * Please refer to `mask` parameter in IK::R3Task::initialize method.
+ */
+class R3Task : public IKLinearTask, public BipedalLocomotion::System::ITaskControllerManager
+{
+public:
+    using Mode = System::ITaskControllerManager::Mode;
+
+private:
+    LieGroupControllers::ProportionalControllerR3d m_R3Controller; /**< P Controller in R3 */
+
+    System::VariablesHandler::VariableDescription m_robotVelocityVariable; /**< Variable
+                                                                                  describing the
+                                                                                  robot velocity
+                                                                                  (base + joint) */
+
+    iDynTree::FrameIndex m_frameIndex; /**< Frame controlled by the OptimalControlElement */
+
+    static constexpr std::size_t m_linearVelocitySize{3}; /**< Size of the linear velocity vector. */
+    static constexpr std::size_t m_spatialVelocitySize{6}; /**< Size of the spatial velocity vector. */
+
+    bool m_isInitialized{false}; /**< True if the task has been initialized. */
+    bool m_isValid{false}; /**< True if the task is valid. */
+
+    std::shared_ptr<iDynTree::KinDynComputations> m_kinDyn; /**< Pointer to a KinDynComputations
+                                                               object */
+
+    /** Mask used to select the DoFs controlled by the task */
+    std::array<bool, m_linearVelocitySize> m_mask{true, true, true};
+    std::size_t m_DoFs{m_linearVelocitySize}; /**< DoFs associated to the entire task */
+
+    Eigen::MatrixXd m_jacobian; /**< Jacobian matrix in MIXED representation */
+
+    /** State of the proportional controller implemented in the task */
+    Mode m_controllerMode{Mode::Enable};
+
+public:
+    /**
+     * Initialize the task.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                      | Mandatory |
+     * |:----------------------------------:|:--------:|:--------------------------------------------------------------------------------------:|:---------:|
+     * |   `robot_velocity_variable_name`   | `string` |   Name of the variable contained in `VariablesHandler` describing the robot velocity   |    Yes    |
+     * |            `frame_name`            | `string` |                       Name of the frame controlled by the SE3Task                      |    Yes    |
+     * |             `kp_linear`            | `double` |                             Gain of the position controller                            |    Yes    |
+     * |               `mask`               | `vector<bool>` |  Mask representing the linear DoFs controlled. E.g. [1,0,1] will enable the control on the x and z coordinates only. (Default value, [1,1,1])   |    No    |
+     * @return True in case of success, false otherwise.
+     * Where the generalized robot velocity is a vector containing the base spatial-velocity
+     * (expressed in mixed representation) and the joint velocities.
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Set the kinDynComputations object.
+     * @param kinDyn pointer to a kinDynComputations object.
+     * @return True in case of success, false otherwise.
+     */
+    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+
+    /**
+     * Set the set of variables required by the task. The variables are stored in the
+     * System::VariablesHandler.
+     * @param variablesHandler reference to a variables handler.
+     * @note The handler must contain a variable named as the parameter
+     * `robot_velocity_variable_name` stored in the parameter handler. The variable represents the
+     * generalized velocity of the robot. Where the generalized robot velocity is a vector
+     * containing the base spatial-velocity (expressed in mixed representation) and the joints
+     * velocity.
+     * @return True in case of success, false otherwise.
+     */
+    bool setVariablesHandler(const System::VariablesHandler& variablesHandler) override;
+
+    /**
+     * Update the content of the element.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the desired set-point of the trajectory.
+     * @param I_p_F position of the origin of the frame with respect to the inertial frame.
+     * @param linear velocity of the frame. The default value is set to zero.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSetPoint(Eigen::Ref<const Eigen::Vector3d> I_p_F,
+                     Eigen::Ref<const Eigen::Vector3d> velocity = Eigen::Vector3d::Zero());
+
+    /**
+     * Get the size of the task. (I.e the number of rows of the vector b)
+     * @return the size of the task.
+     */
+    std::size_t size() const override;
+
+    /**
+     * The SE3Task is an equality task.
+     * @return the size of the task.
+     */
+    Type type() const override;
+
+    /**
+     * Determines the validity of the objects retrieved with getA() and getB()
+     * @return True if the objects are valid, false otherwise.
+     */
+    bool isValid() const override;
+
+    /**
+     * Set the task controller mode. Please use this method to disable/enable the Proportional
+     * controller implemented in this task.
+     * @param state state of the controller
+     */
+    void setTaskControllerMode(Mode mode) override;
+
+    /**
+     * Get the task controller mode.
+     * @return the state of the controller
+     */
+    Mode getTaskControllerMode() const override;
+};
+
+} // namespace IK
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_IK_SE3_TASK_H

--- a/src/IK/src/R3Task.cpp
+++ b/src/IK/src/R3Task.cpp
@@ -1,0 +1,265 @@
+/**
+ * @file R3Task.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/Conversions/ManifConversions.h>
+#include <BipedalLocomotion/IK/R3Task.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/Model/Model.h>
+
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+using namespace BipedalLocomotion::IK;
+
+bool R3Task::setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    if ((kinDyn == nullptr) || (!kinDyn->isValid()))
+    {
+        log()->error("[R3Task::setKinDyn] Invalid kinDyn object.");
+        return false;
+    }
+
+    m_kinDyn = kinDyn;
+    return true;
+}
+
+bool R3Task::setVariablesHandler(const System::VariablesHandler& variablesHandler)
+{
+    if (!m_isInitialized)
+    {
+        log()->error("[R3Task::setVariablesHandler] The task is not initialized. Please call "
+                     "initialize method.");
+        return false;
+    }
+
+    // get the variable
+    if (!variablesHandler.getVariable(m_robotVelocityVariable.name,
+                                      m_robotVelocityVariable))
+    {
+        log()->error("[R3Task::setVariablesHandler] Unable to get the variable named {}.",
+                     m_robotVelocityVariable.name);
+        return false;
+    }
+
+    // get the variable
+    if (m_robotVelocityVariable.size != m_kinDyn->getNrOfDegreesOfFreedom() + m_spatialVelocitySize)
+    {
+        log()->error("[R3Task::setVariablesHandler] The size of the robot velocity variable is "
+                     "different from the one expected. Expected size: {}. Given size: {}.",
+                     m_kinDyn->getNrOfDegreesOfFreedom() + m_spatialVelocitySize,
+                     m_robotVelocityVariable.size);
+        return false;
+    }
+
+    // resize the matrices
+    m_A.resize(m_DoFs, variablesHandler.getNumberOfVariables());
+    m_A.setZero();
+    m_b.resize(m_DoFs);
+    m_jacobian.resize(m_spatialVelocitySize, m_robotVelocityVariable.size);
+
+    return true;
+}
+
+bool R3Task::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[R3Task::initialize] ";
+
+    std::string frameName = "Unknown";
+    constexpr auto descriptionPrefix = "IK-R3Task - Frame name: ";
+
+    std::string maskDescription = "";
+    auto boolToString = [](bool b) { return b ? " true" : " false"; };
+    for(const auto flag : m_mask)
+    {
+        maskDescription += boolToString(flag);
+    }
+
+
+    if (m_kinDyn == nullptr || !m_kinDyn->isValid())
+    {
+        log()->error("{} [{} {}] KinDynComputations object is not valid.",
+                     errorPrefix,
+                     descriptionPrefix,
+                     frameName);
+        return false;
+    }
+
+    if (m_kinDyn->getFrameVelocityRepresentation()
+        != iDynTree::FrameVelocityRepresentation::MIXED_REPRESENTATION)
+    {
+        log()->error("{} [{} {}] The task supports only quantities expressed in MIXED "
+                     "representation. Please provide a KinDynComputations with Frame velocity "
+                     "representation set to MIXED_REPRESENTATION.",
+                     errorPrefix,
+                     descriptionPrefix,
+                     frameName);
+        return false;
+    }
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} [{} {}] The parameter handler is not valid.",
+                     errorPrefix,
+                     descriptionPrefix,
+                     frameName);
+        return false;
+    }
+
+    if (!ptr->getParameter("robot_velocity_variable_name", m_robotVelocityVariable.name))
+    {
+        log()->error("{} [{} {}] Error while retrieving the robot velocity variable.",
+                     errorPrefix,
+                     descriptionPrefix,
+                     frameName);
+        return false;
+    }
+
+    if (!ptr->getParameter("frame_name", frameName)
+        || (m_frameIndex = m_kinDyn->model().getFrameIndex(frameName))
+               == iDynTree::FRAME_INVALID_INDEX)
+    {
+        log()->error("{} [{} {}] Error while retrieving the frame that should be controlled.",
+                     errorPrefix,
+                     descriptionPrefix,
+                     frameName);
+        return false;
+    }
+
+    // set the gains for the controllers
+    double kpLinear;
+    if (!ptr->getParameter("kp_linear", kpLinear))
+    {
+        log()->error("{} [{} {}] Unable to get the proportional linear gain.",
+                     errorPrefix,
+                     descriptionPrefix,
+                     frameName);
+        return false;
+    }
+    m_R3Controller.setGains(kpLinear);
+
+    std::vector<bool> mask;
+    if (!ptr->getParameter("mask", mask) || (mask.size() != m_linearVelocitySize))
+    {
+        log()->info("{} [{} {}] Unable to find the mask parameter. The default value is used:{}.",
+                    errorPrefix,
+                    descriptionPrefix,
+                    frameName,
+                    maskDescription);
+    }
+    else
+    {
+        // covert an std::vector in a std::array
+        std::copy(mask.begin(), mask.end(), m_mask.begin());
+        // compute the DoFs associated to the task
+        m_DoFs = std::count(m_mask.begin(), m_mask.end(), true);
+
+        // Update the mask description
+        maskDescription.clear();
+        for(const auto flag : m_mask)
+        {
+            maskDescription += boolToString(flag);
+        }
+    }
+
+    m_description = descriptionPrefix + frameName + " Mask:" + maskDescription + ".";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool R3Task::update()
+{
+    using namespace BipedalLocomotion::Conversions;
+    using namespace iDynTree;
+
+    m_isValid = false;
+
+    auto getControllerState = [&](const auto& controller) {
+        if (m_controllerMode == Mode::Enable)
+            return controller.getControl().coeffs();
+        else
+            return controller.getFeedForward().coeffs();
+    };
+
+    // set the state
+    m_R3Controller.setState(toEigen(m_kinDyn->getWorldTransform(m_frameIndex).getPosition()));
+
+    // update the controller
+    m_R3Controller.computeControlLaw();
+
+    // store the jacobian associated to the given frame
+    if (!m_kinDyn->getFrameFreeFloatingJacobian(m_frameIndex, m_jacobian))
+    {
+        log()->error("[R3Task::update] Unable to get the jacobian.");
+        return m_isValid;
+    }
+
+    if (m_DoFs == m_linearVelocitySize)
+    {
+        m_b = getControllerState(m_R3Controller);
+        iDynTree::toEigen(this->subA(m_robotVelocityVariable)) = m_jacobian.topRows<3>();
+    } else
+    {
+        // take only the required components
+        std::size_t index = 0;
+
+        // linear components
+        for (std::size_t i = 0; i < 3; i++)
+        {
+            if (m_mask[i])
+            {
+                m_b(index) = getControllerState(m_R3Controller)(i);
+                iDynTree::toEigen(this->subA(m_robotVelocityVariable)).row(index)
+                    = m_jacobian.row(i);
+                index++;
+            }
+        }
+    }
+
+    m_isValid = true;
+
+    return m_isValid;
+}
+
+bool R3Task::setSetPoint(Eigen::Ref<const Eigen::Vector3d> I_p_F,
+                         Eigen::Ref<const Eigen::Vector3d> velocity)
+{
+
+    bool ok = true;
+    ok = ok && m_R3Controller.setDesiredState(I_p_F);
+    ok = ok && m_R3Controller.setFeedForward(velocity);
+
+    return ok;
+}
+
+std::size_t R3Task::size() const
+{
+    return m_DoFs;
+}
+
+R3Task::Type R3Task::type() const
+{
+    return Type::equality;
+}
+
+bool R3Task::isValid() const
+{
+    return m_isValid;
+}
+
+void R3Task::setTaskControllerMode(Mode mode)
+{
+    m_controllerMode = mode;
+}
+
+R3Task::Mode R3Task::getTaskControllerMode() const
+{
+    return m_controllerMode;
+}

--- a/src/IK/tests/CMakeLists.txt
+++ b/src/IK/tests/CMakeLists.txt
@@ -3,6 +3,11 @@
 # BSD-3-Clause license.
 
 add_bipedal_test(
+  NAME R3TaskIK
+  SOURCES R3TaskTest.cpp
+  LINKS BipedalLocomotion::IK BipedalLocomotion::ManifConversions)
+
+add_bipedal_test(
   NAME SE3TaskIK
   SOURCES SE3TaskTest.cpp
   LINKS BipedalLocomotion::IK BipedalLocomotion::ManifConversions)

--- a/src/IK/tests/R3TaskTest.cpp
+++ b/src/IK/tests/R3TaskTest.cpp
@@ -1,0 +1,211 @@
+/**
+ * @file R3TaskTest.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+// Catch2
+#include <catch2/catch.hpp>
+
+// BipedalLocomotion
+#include <BipedalLocomotion/Conversions/ManifConversions.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/IK/R3Task.h>
+
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/Model/ModelTestUtils.h>
+
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+using namespace BipedalLocomotion::IK;
+
+TEST_CASE("SE3 Task")
+{
+    constexpr double kp = 1.0;
+    const std::string robotVelocity = "robotVelocity";
+
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    parameterHandler->setParameter("robot_velocity_variable_name",
+                                   robotVelocity);
+
+    parameterHandler->setParameter("kp_linear", kp);
+
+    // set the velocity representation
+    REQUIRE(kinDyn->setFrameVelocityRepresentation(
+        iDynTree::FrameVelocityRepresentation::MIXED_REPRESENTATION));
+
+    for (std::size_t numberOfJoints = 6; numberOfJoints < 40; numberOfJoints += 15)
+    {
+        // create the model
+        const iDynTree::Model model = iDynTree::getRandomModel(numberOfJoints);
+        REQUIRE(kinDyn->loadRobotModel(model));
+
+        const auto worldBasePos = iDynTree::getRandomTransform();
+        const auto baseVel = iDynTree::getRandomTwist();
+        iDynTree::VectorDynSize jointsPos(model.getNrOfDOFs());
+        iDynTree::VectorDynSize jointsVel(model.getNrOfDOFs());
+        iDynTree::Vector3 gravity;
+
+        for (auto& joint : jointsPos)
+        {
+            joint = iDynTree::getRandomDouble();
+        }
+
+        for (auto& joint : jointsVel)
+        {
+            joint = iDynTree::getRandomDouble();
+        }
+
+        for (auto& element : gravity)
+        {
+            element = iDynTree::getRandomDouble();
+        }
+
+        REQUIRE(kinDyn->setRobotState(worldBasePos, jointsPos, baseVel, jointsVel, gravity));
+
+        // Instantiate the handler
+        VariablesHandler variablesHandler;
+        variablesHandler.addVariable("dummy1", 10);
+        variablesHandler.addVariable(robotVelocity, model.getNrOfDOFs() + 6);
+        variablesHandler.addVariable("dummy2", 15);
+
+        const std::string controlledFrame = model.getFrameName(numberOfJoints);
+        parameterHandler->setParameter("frame_name", controlledFrame);
+
+        DYNAMIC_SECTION("Model with " << numberOfJoints << " joints - [All DoF]")
+        {
+            R3Task task;
+            REQUIRE(task.setKinDyn(kinDyn));
+            REQUIRE(task.initialize(parameterHandler));
+            REQUIRE(task.setVariablesHandler(variablesHandler));
+            REQUIRE(task.size() == 3);
+
+            const auto desiredPosition = manif::R3d::Random();
+            const auto desiredVelocity = manif::R3d::Tangent::Random();
+
+            REQUIRE(task.setSetPoint(desiredPosition.coeffs(), desiredVelocity.coeffs()));
+
+            REQUIRE(task.update());
+            REQUIRE(task.isValid());
+
+            // get A and b
+            Eigen::Ref<const Eigen::MatrixXd> A = task.getA();
+            Eigen::Ref<const Eigen::VectorXd> b = task.getB();
+
+            // check the matrix A
+            REQUIRE(A.middleCols(variablesHandler.getVariable("dummy1").offset,
+                                 variablesHandler.getVariable("dummy1").size)
+                    .isZero());
+
+            REQUIRE(A.middleCols(variablesHandler.getVariable("dummy2").offset,
+                                 variablesHandler.getVariable("dummy2").size)
+                    .isZero());
+
+            Eigen::MatrixXd jacobian(6, model.getNrOfDOFs() + 6);
+            REQUIRE(kinDyn->getFrameFreeFloatingJacobian(controlledFrame, jacobian));
+
+            REQUIRE(A.middleCols(variablesHandler.getVariable(robotVelocity).offset,
+                                 variablesHandler.getVariable(robotVelocity).size)
+                    .isApprox(jacobian.topRows<3>()));
+
+            // check the vector b
+            LieGroupControllers::ProportionalControllerR3d R3Controller;
+            R3Controller.setGains(kp);
+
+            R3Controller.setFeedForward(desiredVelocity);
+            R3Controller.setDesiredState(desiredPosition);
+
+            R3Controller.setState(
+                iDynTree::toEigen(kinDyn->getWorldTransform(controlledFrame).getPosition()));
+
+            R3Controller.computeControlLaw();
+
+            REQUIRE(b.isApprox(R3Controller.getControl().coeffs()));
+        }
+
+
+        DYNAMIC_SECTION("Model with " << numberOfJoints << " joints - [mask]")
+        {
+            const auto mask = std::vector<bool>{true, false, true};
+            const auto DoFs = std::count(mask.begin(), mask.end(), true);
+
+            parameterHandler->setParameter("mask", mask);
+
+            R3Task task;
+            REQUIRE(task.setKinDyn(kinDyn));
+            REQUIRE(task.initialize(parameterHandler));
+            REQUIRE(task.setVariablesHandler(variablesHandler));
+            REQUIRE(task.size() == DoFs);
+
+            const auto desiredPosition = manif::R3d::Random();
+            const auto desiredVelocity = manif::R3d::Tangent::Random();
+
+            REQUIRE(task.setSetPoint(desiredPosition.coeffs(), desiredVelocity.coeffs()));
+
+            REQUIRE(task.update());
+            REQUIRE(task.isValid());
+
+            // get A and b
+            Eigen::Ref<const Eigen::MatrixXd> A = task.getA();
+            Eigen::Ref<const Eigen::VectorXd> b = task.getB();
+
+            // check the matrix A
+            REQUIRE(A.middleCols(variablesHandler.getVariable("dummy1").offset,
+                                 variablesHandler.getVariable("dummy1").size)
+                    .isZero());
+
+            REQUIRE(A.middleCols(variablesHandler.getVariable("dummy2").offset,
+                                 variablesHandler.getVariable("dummy2").size)
+                    .isZero());
+
+            Eigen::MatrixXd jacobian(6, model.getNrOfDOFs() + 6);
+            REQUIRE(kinDyn->getFrameFreeFloatingJacobian(controlledFrame, jacobian));
+
+            // extract the
+            Eigen::MatrixXd jacobianWithMask(DoFs, model.getNrOfDOFs() + 6);
+            std::size_t index = 0;
+            for (std::size_t i = 0; i < 3; i++)
+            {
+                if (mask[i])
+                {
+                    jacobianWithMask.row(index) = jacobian.row(i);
+                    index++;
+                }
+            }
+
+            REQUIRE(A.middleCols(variablesHandler.getVariable(robotVelocity).offset,
+                                 variablesHandler.getVariable(robotVelocity).size)
+                    .isApprox(jacobianWithMask));
+
+            // check the vector b
+            LieGroupControllers::ProportionalControllerR3d R3Controller;
+            R3Controller.setGains(kp);
+
+            R3Controller.setFeedForward(desiredVelocity);
+            R3Controller.setDesiredState(desiredPosition);
+
+            R3Controller.setState(
+                iDynTree::toEigen(kinDyn->getWorldTransform(controlledFrame).getPosition()));
+
+            R3Controller.computeControlLaw();
+
+            Eigen::VectorXd expectedB(DoFs);
+            index = 0;
+            for(int i = 0; i < 3; i++)
+            {
+                if(mask[i])
+                {
+                    expectedB(index) = R3Controller.getControl().coeffs()[i];
+                    index++;
+                }
+            }
+
+            REQUIRE(b.isApprox(expectedB));
+        }
+    }
+}


### PR DESCRIPTION
This task can be used to stabilize the desired frame position. As the `CoMTask` and the `SE3Task` the user can pass a mask to deactivate some directions.
For instance `mask = [false, false, true]` will enable the controller only on the z-coordinate. 

The PR implements also the associated bindings @paolo-viceconte @RiccardoZuppetti 