### PR TITLE
Add the possibility to log only a subset of text logging ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 
 ### Changed
+- Add the possibility to log only a subset of text logging ports in `YarpRobotLogger` device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/561)
 
 ### Fix
 

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -8,6 +8,7 @@ BSD-3-Clause license. -->
   <param name="sampling_period_in_s">0.01</param>
   <param name="rgb_cameras_fps">(20, 10, 10)</param>
   <param name="port_prefix">/yarp-robot-logger</param>
+  <param name="text_logging_subnames">("icub-head")</param>
 
   <group name="Telemetry">
     <param name="save_period">600.0</param>

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -102,10 +102,12 @@ private:
     bool m_streamCartesianWrenches{false};
     bool m_streamFTSensors{false};
     bool m_streamTemperatureSensors{false};
+    std::vector<std::string> m_textLoggingSubnames;
 
     robometry::BufferManager m_bufferManager;
 
     void lookForNewLogs();
+    bool hasSubstring(const std::string& str, const std::vector<std::string>& substrings) const;
     void recordVideo(const std::string& cameraName, VideoWriter& writer);
     void unpackIMU(Eigen::Ref<const analog_sensor_t> signal,
                    Eigen::Ref<accelerometer_t> accelerometer,

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -102,12 +102,20 @@ YarpRobotLoggerDevice::~YarpRobotLoggerDevice() = default;
 
 bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
 {
+    constexpr auto logPrefix = "[YarpRobotLoggerDevice::open]";
     auto params = std::make_shared<ParametersHandler::YarpImplementation>(config);
 
     double devicePeriod{0.01};
     if (params->getParameter("sampling_period_in_s", devicePeriod))
     {
         this->setPeriod(devicePeriod);
+    }
+
+    if (!params->getParameter("text_logging_subnames", m_textLoggingSubnames))
+    {
+        log()->info("{} Unable to get the 'text_logging_subnames' parameter for the telemetry. All "
+                    "the ports related to the text logging will be considered.",
+                    logPrefix);
     }
 
     if (!this->setupRobotSensorBridge(params->getGroup("RobotSensorBridge")))
@@ -580,6 +588,19 @@ void YarpRobotLoggerDevice::unpackIMU(Eigen::Ref<const analog_sensor_t> signal,
     gyro = signal.segment<3>(6);
 }
 
+bool YarpRobotLoggerDevice::hasSubstring(const std::string& str,
+                                         const std::vector<std::string>& substrings) const
+{
+    for (const auto& substring : substrings)
+    {
+        if (str.find(substring) != std::string::npos)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void YarpRobotLoggerDevice::lookForNewLogs()
 {
     yarp::profiler::NetworkProfiler::ports_name_set yarpPorts;
@@ -607,10 +628,12 @@ void YarpRobotLoggerDevice::lookForNewLogs()
         yarp::profiler::NetworkProfiler::getPortsList(yarpPorts);
         for (const auto& port : yarpPorts)
         {
-            // check if the port has not be already connected if exits and its resposive
-            // and is a text logging port
+            // check if the port has not be already connected if exits, its resposive
+            // it is a text logging port and it should be logged
             if ((port.name.rfind(textLoggingPortPrefix, 0) == 0)
                 && (m_textLoggingPortNames.find(port.name) == m_textLoggingPortNames.end())
+                && (m_textLoggingSubnames.empty()
+                    || this->hasSubstring(port.name, m_textLoggingSubnames))
                 && yarp::os::Network::exists(port.name))
             {
                 m_textLoggingPortNames.insert(port.name);

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -637,7 +637,7 @@ void YarpRobotLoggerDevice::lookForNewLogs()
                 && yarp::os::Network::exists(port.name))
             {
                 m_textLoggingPortNames.insert(port.name);
-                yarp::os::Network::connect(port.name, m_textLoggingPortName);
+                yarp::os::Network::connect(port.name, m_textLoggingPortName, "udp");
             }
         }
 


### PR DESCRIPTION
Back in time, we (@S-Dafarra and I) noticed that storing the text with the logger is time-consuming. This PR gives the user the possibility to log only a subset of text logging ports by specifying substrings that need to be contained in the port name. 
If one of those substrings is found then the port is logged.

In order to do so, I introduced `text_logging_subnames` parameter. This parameter is optional. If not passed all the logs are saved

This is an example of configuration

```ini
text_logging_subnames    ("icub-head/yarprobotinterface", "walking-module")
``` 