### PR TITLE
Implement constructMultipleAnalogSensorsClient and constructMultipleAnalogSensorsRemapper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project are documented in this file.
 ## [unreleased]
 ### Added
 - Add the possibility to set the exogenous feedback for the `IK::SE3Task` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/567)
+- Implement `RobotInterface::constructMultipleAnalogSensorsClient()` and `RobotInterface::constructMultipleAnalogsensorsRemapper()` methods (https://github.com/ami-iit/bipedal-locomotion-framework/pull/568)
 
 ### Changed
 - Add the possibility to log only a subset of text logging ports in `YarpRobotLogger` device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/561)
 - Accept boolean as integer while getting an element from searchable in `YarpUtilities` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/566)
 
 ### Fix
+- Fix typo in the `RobotInterface::constructGenericSensorClient()` documentation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/568)
 
 ## [0.9.0] - 2022-09-09
 ### Added

--- a/bindings/python/RobotInterface/src/Polydriver.cpp
+++ b/bindings/python/RobotInterface/src/Polydriver.cpp
@@ -54,6 +54,13 @@ void CreatePolyDriverDescriptor(pybind11::module& module)
             return constructGenericSensorClient(handler);
         },
         py::arg("handler"));
+
+    module.def(
+        "construct_multiple_analog_sensors_client",
+        [](std::shared_ptr<IParametersHandler> handler) -> PolyDriverDescriptor {
+            return constructMultipleAnalogSensorsClient(handler);
+        },
+        py::arg("handler"));
 }
 
 } // namespace RobotInterface

--- a/bindings/python/RobotInterface/src/Polydriver.cpp
+++ b/bindings/python/RobotInterface/src/Polydriver.cpp
@@ -61,6 +61,13 @@ void CreatePolyDriverDescriptor(pybind11::module& module)
             return constructMultipleAnalogSensorsClient(handler);
         },
         py::arg("handler"));
+
+    module.def(
+        "construct_multiple_analog_sensors_remapper",
+        [](std::shared_ptr<IParametersHandler> handler) -> PolyDriverDescriptor {
+            return constructMultipleAnalogSensorsRemapper(handler);
+        },
+        py::arg("handler"));
 }
 
 } // namespace RobotInterface

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -73,7 +73,7 @@ PolyDriverDescriptor constructRemoteControlBoardRemapper(
  * |       `description`       | `string` |          Description of the genericSensorClient. It is the device name                       |    Yes    |
  * |     `remote_port_name`    | `string` |                           Name of the port associate to the remote                           |    Yes    |
  * |       `local_prefix`      | `string` |                     Prefix of the local port (e.g. the application name)                     |    Yes    |
- * | `local_port_name_suffix`  | `string` |  Suffix of the local port. The local port name is `/<local_prefix><local_port_name_suffix>`  |    Yes    |
+ * | `local_port_name_postfix` | `string` | Postfix of the local port. The local port name is `/<local_prefix><local_port_name_postfix>` |    Yes    |
  * @note The genericSensorClient device is implement in [whole-body-estimators](https://github.com/robotology/whole-body-estimators/tree/cc8ffb83375a2d410b225f4fa67aee4a29074b42/devices/genericSensorClient).
  * @return A PolyDriverDescriptor. If one of the parameters is missing an invalid PolyDriverDescriptor is returned.
  */
@@ -89,7 +89,7 @@ PolyDriverDescriptor constructGenericSensorClient(
  * |       `description`       | `string` |      Description of the multiple analog sensor client. It is the device name                 |    Yes    |
  * |     `remote_port_name`    | `string` |                           Name of the port associate to the remote                           |    Yes    |
  * |       `local_prefix`      | `string` |                     Prefix of the local port (e.g. the application name)                     |    Yes    |
- * | `local_port_name_suffix`  | `string` |  Suffix of the local port. The local port name is `/<local_prefix><local_port_name_suffix>`  |    Yes    |
+ * | `local_port_name_postfix` | `string` | Postfix of the local port. The local port name is `/<local_prefix><local_port_name_postfix>` |    Yes    |
  * |           `timeout`       | `double` |         Timeout in seconds after which the device reports an error if no measurement was received. (Default value 0.01)      |     No    |
  * |   `external_connection`   |  `bool`  | If set to true, the connection to the rpc port of the MAS server is skipped and it is possible to connect to the data source externally after being opened. (Default value `false`)      |     No    |
  * |   `carrier`    | `string` |  The carrier used for the connection with the server. (Default value `tcp`)      |     No    |

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -99,6 +99,24 @@ PolyDriverDescriptor constructGenericSensorClient(
 PolyDriverDescriptor constructMultipleAnalogSensorsClient(
     std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
 
+/**
+ * Helper function that can be used to build a `MultipleAnalogSensorsRemapper` device.
+ * @param handler pointer to a parameter handler interface.
+ * @note the following parameters are required by the function
+ * |                Parameter Name           |       Type       |                                          Description                                    | Mandatory |
+ * |:---------------------------------------:|:----------------:|:---------------------------------------------------------------------------------------:|:---------:|
+ * |       `three_axis_gyroscopes_names`     | `vector<string>` |     Vector containing the names of the gyroscopes (Default empty vector)                |     No    |
+ * | `three_axis_linear_accelerometers_names`| `vector<string>` |  Vector containing the names of the accelerometers (Default empty vector)               |     No    |
+ * |    `three_axis_magnetometers_names`     | `vector<string>` |    Vector containing the names of the magnetometers (Default empty vector)              |     No    |
+ * |       `orientation_sensors_names`       | `vector<string>` |    Vector containing the names of the orientation sensors (Default empty vector)        |     No    |
+ * | `six_axis_force_torque_sensors_names`   | `vector<string>` |    Vector containing the names of the FT sensors (Default empty vector)                 |     No    |
+ * |      `temperature_sensors_names`        | `vector<string>` |    Vector containing the names of the temperature sensors (Default empty vector)        |     No    |
+ * @note The `MultipleAnalogSensorsRemapper` device is implement in [yarp](https://www.yarp.it/git-master/classMultipleAnalogSensorsRemapper.html).
+ * @return A PolyDriverDescriptor. In case of error an invalid `PolyDriverDescriptor` is returned.
+ */
+PolyDriverDescriptor constructMultipleAnalogSensorsRemapper(
+    std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
 } // namespace RobotInterface
 } // namespace BipedalLocomotion
 

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -83,16 +83,16 @@ PolyDriverDescriptor constructGenericSensorClient(
 /**
  * Helper function that can be used to build a `MultipleAnalogSensorsClient` device.
  * @param handler pointer to a parameter handler interface.
- * @note the following parameters are required by the function
- * |       Parameter Name      |   Type   |                                          Description                                         | Mandatory |
- * |:-------------------------:|:--------:|:--------------------------------------------------------------------------------------------:|:---------:|
- * |       `description`       | `string` |      Description of the multiple analog sensor client. It is the device name                 |    Yes    |
- * |     `remote_port_name`    | `string` |                           Name of the port associate to the remote                           |    Yes    |
- * |       `local_prefix`      | `string` |                     Prefix of the local port (e.g. the application name)                     |    Yes    |
- * | `local_port_name_postfix` | `string` | Postfix of the local port. The local port name is `/<local_prefix><local_port_name_postfix>` |    Yes    |
- * |           `timeout`       | `double` |         Timeout in seconds after which the device reports an error if no measurement was received. (Default value 0.01)      |     No    |
- * |   `external_connection`   |  `bool`  | If set to true, the connection to the rpc port of the MAS server is skipped and it is possible to connect to the data source externally after being opened. (Default value `false`)      |     No    |
- * |   `carrier`    | `string` |  The carrier used for the connection with the server. (Default value `tcp`)      |     No    |
+ * @note The following parameters are taken into consideration
+ * |       Parameter Name      |   Type   |                                                                                              Description                                                                             | Mandatory |
+ * |:-------------------------:|:--------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:---------:|
+ * |       `description`       | `string` |                                                               Description of the multiple analog sensor client. It is the device name                                                |    Yes    |
+ * |     `remote_port_name`    | `string` |                                                                          Name of the port associate to the remote                                                                    |    Yes    |
+ * |       `local_prefix`      | `string` |                                                                  Prefix of the local port (e.g. the application name)                                                                |    Yes    |
+ * | `local_port_name_postfix` | `string` |                                               Postfix of the local port. The local port name is `/<local_prefix><local_port_name_postfix>`                                           |    Yes    |
+ * |           `timeout`       | `double` |                                      Timeout in seconds after which the device reports an error if no measurement was received. (Default value 0.01)                                 |     No    |
+ * |   `external_connection`   |  `bool`  | If set to true, the connection to the rpc port of the MAS server is skipped and it is possible to connect to the data source externally after being opened. (Default value `false`)  |     No    |
+ * |          `carrier`        | `string` |                                                   The carrier used for the connection with the server. (Default value `tcp`)                                                         |     No    |
  * @note The `MultipleAnalogSensorsClient` device is implement in [yarp](https://www.yarp.it/git-master/classMultipleAnalogSensorsClient.html).
  * @return A `PolyDriverDescriptor`. In case of error an invalid `PolyDriverDescriptor` is returned.
  */
@@ -102,7 +102,7 @@ PolyDriverDescriptor constructMultipleAnalogSensorsClient(
 /**
  * Helper function that can be used to build a `MultipleAnalogSensorsRemapper` device.
  * @param handler pointer to a parameter handler interface.
- * @note the following parameters are required by the function
+ * @note The following parameters are taken into consideration
  * |                Parameter Name           |       Type       |                                          Description                                    | Mandatory |
  * |:---------------------------------------:|:----------------:|:---------------------------------------------------------------------------------------:|:---------:|
  * |       `three_axis_gyroscopes_names`     | `vector<string>` |     Vector containing the names of the gyroscopes (Default empty vector)                |     No    |

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -80,6 +80,25 @@ PolyDriverDescriptor constructRemoteControlBoardRemapper(
 PolyDriverDescriptor constructGenericSensorClient(
     std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
 
+/**
+ * Helper function that can be used to build a `MultipleAnalogSensorsClient` device.
+ * @param handler pointer to a parameter handler interface.
+ * @note the following parameters are required by the function
+ * |       Parameter Name      |   Type   |                                          Description                                         | Mandatory |
+ * |:-------------------------:|:--------:|:--------------------------------------------------------------------------------------------:|:---------:|
+ * |       `description`       | `string` |      Description of the multiple analog sensor client. It is the device name                 |    Yes    |
+ * |     `remote_port_name`    | `string` |                           Name of the port associate to the remote                           |    Yes    |
+ * |       `local_prefix`      | `string` |                     Prefix of the local port (e.g. the application name)                     |    Yes    |
+ * | `local_port_name_suffix`  | `string` |  Suffix of the local port. The local port name is `/<local_prefix><local_port_name_suffix>`  |    Yes    |
+ * |           `timeout`       | `double` |         Timeout in seconds after which the device reports an error if no measurement was received. (Default value 0.01)      |     No    |
+ * |   `external_connection`   |  `bool`  | If set to true, the connection to the rpc port of the MAS server is skipped and it is possible to connect to the data source externally after being opened. (Default value `false`)      |     No    |
+ * |   `carrier`    | `string` |  The carrier used for the connection with the server. (Default value `tcp`)      |     No    |
+ * @note The `MultipleAnalogSensorsClient` device is implement in [yarp](https://www.yarp.it/git-master/classMultipleAnalogSensorsClient.html).
+ * @return A `PolyDriverDescriptor`. In case of error an invalid `PolyDriverDescriptor` is returned.
+ */
+PolyDriverDescriptor constructMultipleAnalogSensorsClient(
+    std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
 } // namespace RobotInterface
 } // namespace BipedalLocomotion
 

--- a/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
@@ -27,14 +27,13 @@ bool PolyDriverDescriptor::isValid() const
 PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructRemoteControlBoardRemapper(
     std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
 {
-    constexpr std::string_view errorPrefix = "[constructRemoteControlBoardRemapper] ";
+    constexpr auto errorPrefix = "[RobotInterface::constructRemoteControlBoardRemapper]";
 
     auto ptr = handler.lock();
 
-
     if (ptr == nullptr)
     {
-        std::cerr << errorPrefix << "IParametershandler is empty." << std::endl;
+        log()->error("{} Invalid parameter handler.", errorPrefix);
         return PolyDriverDescriptor();
     }
 
@@ -54,8 +53,7 @@ PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructRemoteControlBo
 
     if (!ok)
     {
-        std::cerr << errorPrefix << "Unable to get all the parameters from configuration file."
-                  << std::endl;
+        log()->error("{} Unable to get all the parameters from configuration file.", errorPrefix);
         return PolyDriverDescriptor();
     }
 
@@ -66,13 +64,17 @@ PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructRemoteControlBo
     options.addGroup("axesNames");
     yarp::os::Bottle& bottle = options.findGroup("axesNames").addList();
     for (const auto& joint : jointsList)
+    {
         bottle.addString(joint);
+    }
 
     yarp::os::Bottle remoteControlBoards;
 
     yarp::os::Bottle& remoteControlBoardsList = remoteControlBoards.addList();
     for (const auto& controlBoard : controlBoards)
+    {
         remoteControlBoardsList.addString("/" + robotName + "/" + controlBoard);
+    }
 
     options.put("remoteControlBoards", remoteControlBoards.get(0));
     options.put("localPortPrefix", "/" + localPrefix + "/remoteControlBoard");
@@ -83,7 +85,7 @@ PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructRemoteControlBo
 
     if (!device.poly->open(options) && !device.poly->isValid())
     {
-        std::cerr << errorPrefix << "Could not open polydriver object." << std::endl;
+        log()->error("{} Could not open polydriver object.", errorPrefix);
         return PolyDriverDescriptor();
     }
 
@@ -93,13 +95,13 @@ PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructRemoteControlBo
 PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructGenericSensorClient(
     std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
 {
-    constexpr std::string_view errorPrefix = "[constructGenericSensorClient] ";
+    constexpr auto errorPrefix = "[RobotInterface::constructGenericSensorClient]";
 
     auto ptr = handler.lock();
 
     if (ptr == nullptr)
     {
-        std::cerr << errorPrefix << "IParametershandler is empty." << std::endl;
+        log()->error("{} Invalid parameter handler.", errorPrefix);
         return PolyDriverDescriptor();
     }
 
@@ -119,8 +121,7 @@ PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructGenericSensorCl
 
     if (!ok)
     {
-        std::cerr << errorPrefix << "Unable to get all the parameters from configuration file."
-                  << std::endl;
+        log()->error("{} Unable to get all the parameters from configuration file.", errorPrefix);
         return PolyDriverDescriptor();
     }
 


### PR DESCRIPTION
This PR implements `RobotInterface::constructMultipleAnalogSensorsClient()` and `RobotInterface::constructMultipleAnalogsensorsRemapper()` function (and the associated bindings). These two methods allows the user to easily construct a multipleanalogsensorclient and `multipleanalogsensorremapper` from a set of configuration

The following example can be used as starting point to build the two polydrivers. 
```cpp
#include <BipedalLocomotion/RobotInterface/YarpHelper.h>
#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>

#include <yarp/os/ResourceFinder.h>

#include <memory>

int main(int argc, char *argv[])
{
    yarp::os::ResourceFinder &rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
    rf.setDefaultConfigFile("config.ini");
    rf.configure(argc - 1, argv);

    auto handler = std::make_shared<BipedalLocomotion::ParametersHandler::YarpImplementation>();
    handler->set(rf);

    auto polyMultiple = BipedalLocomotion::RobotInterface::constructMultipleAnalogSensorsClient(handler->getGroup("LEFT_FOOT"));

    auto polyRemapper = BipedalLocomotion::RobotInterface::constructMultipleAnalogSensorsRemapper(handler->getGroup("MULTIPLE_ANALOG_SENSORS_REMAPPER"));

    return 0;
}
```

```ini
[LEFT_FOOT]
description     left_foot
remote_port_name    /icub/left_foot/imu
local_prefix        example
local_port_name_postfix  /left_foot/imu


[MULTIPLE_ANALOG_SENSORS_REMAPPER]
three_axis_gyroscopes_names (l_foot_front_ft_gyro, l_foot_rear_ft_gyro)
three_axis_linear_accelerometers_names (l_foot_front_ft_acc, l_foot_rear_ft_acc)
three_axis_magnetometers_names (l_foot_front_ft_mag, l_foot_rear_ft_mag)
orientation_sensors_names (l_foot_front_ft_eul, l_foot_rear_ft_eul)
```