### PR TITLE
Improvements on the `MultipleAnalogSensorsRemapper` handling in the framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@ All notable changes to this project are documented in this file.
 
 ## [unreleased]
 ### Added
+- Add the possibility to attach all the multiple analog sensor clients  (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
 
 ### Changed
+- Add informative prints `YarpSensorBridge::Impl` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
 
 ### Fix
+- Return an invalid `PolyDriverDescriptor` if `description` is not found in `constructMultipleAnalogSensorsRemapper()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
 
 ## [0.10.0] - 2022-09-23
 ### Added

--- a/src/IK/src/SE3Task.cpp
+++ b/src/IK/src/SE3Task.cpp
@@ -204,7 +204,10 @@ bool SE3Task::initialize(std::weak_ptr<const ParametersHandler::IParametersHandl
                     m_usePositionExogenousFeedback);
     }
 
-    m_description = descriptionPrefix + frameName + " Mask:" + maskDescription + ".";
+    m_description = descriptionPrefix + frameName + " Mask:" + maskDescription
+      + ". Use exogenous feedback position:" + boolToString(m_usePositionExogenousFeedback)
+      + ". Use exogenous feedback orientation:" + boolToString(m_useOrientationExogenousFeedback)
+      + ".";
 
     // initialize the feedback of the controller
     m_R3Controller.setState(manif::SE3d::Translation::Zero());

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -16,6 +16,7 @@
 #include <yarp/dev/PolyDriver.h>
 
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <yarp/dev/PolyDriverList.h>
 
 namespace BipedalLocomotion
 {
@@ -116,6 +117,46 @@ PolyDriverDescriptor constructMultipleAnalogSensorsClient(
  */
 PolyDriverDescriptor constructMultipleAnalogSensorsRemapper(
     std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
+/**
+ * Helper function that can be used to build a `MultipleAnalogSensorsRemapper` device.
+ * @param handler pointer to a parameter handler interface.
+ * @param polydriverList a list of the polydriver that will be attached to the multiple analog sensor remapper
+ * @note The following parameters are taken into consideration
+ * |                Parameter Name           |       Type       |                                          Description                                    | Mandatory |
+ * |:---------------------------------------:|:----------------:|:---------------------------------------------------------------------------------------:|:---------:|
+ * |       `three_axis_gyroscopes_names`     | `vector<string>` |     Vector containing the names of the gyroscopes (Default empty vector)                |     No    |
+ * | `three_axis_linear_accelerometers_names`| `vector<string>` |  Vector containing the names of the accelerometers (Default empty vector)               |     No    |
+ * |    `three_axis_magnetometers_names`     | `vector<string>` |    Vector containing the names of the magnetometers (Default empty vector)              |     No    |
+ * |       `orientation_sensors_names`       | `vector<string>` |    Vector containing the names of the orientation sensors (Default empty vector)        |     No    |
+ * | `six_axis_force_torque_sensors_names`   | `vector<string>` |    Vector containing the names of the FT sensors (Default empty vector)                 |     No    |
+ * |      `temperature_sensors_names`        | `vector<string>` |    Vector containing the names of the temperature sensors (Default empty vector)        |     No    |
+ * @note The `MultipleAnalogSensorsRemapper` device is implement in [yarp](https://www.yarp.it/git-master/classMultipleAnalogSensorsRemapper.html).
+ * @return A PolyDriverDescriptor. In case of error an invalid `PolyDriverDescriptor` is returned.
+ */
+PolyDriverDescriptor constructMultipleAnalogSensorsRemapper(
+    std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
+    const std::vector<PolyDriverDescriptor>& polydriverList);
+
+/**
+ * Helper function that can be used to build a `MultipleAnalogSensorsRemapper` device.
+ * @param handler pointer to a parameter handler interface.
+ * @param polydriverList a list of the polydriver that will be attached to the multiple analog sensor remapper.
+ * @note The following parameters are taken into consideration
+ * |                Parameter Name           |       Type       |                                          Description                                    | Mandatory |
+ * |:---------------------------------------:|:----------------:|:---------------------------------------------------------------------------------------:|:---------:|
+ * |       `three_axis_gyroscopes_names`     | `vector<string>` |     Vector containing the names of the gyroscopes (Default empty vector)                |     No    |
+ * | `three_axis_linear_accelerometers_names`| `vector<string>` |  Vector containing the names of the accelerometers (Default empty vector)               |     No    |
+ * |    `three_axis_magnetometers_names`     | `vector<string>` |    Vector containing the names of the magnetometers (Default empty vector)              |     No    |
+ * |       `orientation_sensors_names`       | `vector<string>` |    Vector containing the names of the orientation sensors (Default empty vector)        |     No    |
+ * | `six_axis_force_torque_sensors_names`   | `vector<string>` |    Vector containing the names of the FT sensors (Default empty vector)                 |     No    |
+ * |      `temperature_sensors_names`        | `vector<string>` |    Vector containing the names of the temperature sensors (Default empty vector)        |     No    |
+ * @note The `MultipleAnalogSensorsRemapper` device is implement in [yarp](https://www.yarp.it/git-master/classMultipleAnalogSensorsRemapper.html).
+ * @return A PolyDriverDescriptor. In case of error an invalid `PolyDriverDescriptor` is returned.
+ */
+PolyDriverDescriptor constructMultipleAnalogSensorsRemapper(
+    std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
+    const yarp::dev::PolyDriverList& polydriverList);
 
 } // namespace RobotInterface
 } // namespace BipedalLocomotion

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
@@ -587,8 +587,11 @@ struct YarpSensorBridge::Impl
         if (nrSensors != sensorList.size())
         {
             log()->error("{} Expecting the same number of MAS sensors attached to the Bridge as "
-                         "many mentioned in the initialization step.",
-                         logPrefix);
+                         "many mentioned in the initialization step. Number of MAS sensor in the interface: {}. "
+                         "Number of sensor in itialization: {}.",
+                         logPrefix,
+                         nrSensors,
+                         sensorList.size());
             return false;
         }
 
@@ -893,6 +896,7 @@ struct YarpSensorBridge::Impl
                                                  metaData.sensorsList.IMUsList,
                                                  interfaceType))
             {
+                log()->error("{} Unable to attach the imus as generic or analog sensors.", logPrefix);
                 return false;
             }
         }
@@ -905,6 +909,7 @@ struct YarpSensorBridge::Impl
                                           metaData.sensorsList.linearAccelerometersList,
                                           interfaceType))
             {
+                log()->error("{} Unable to attach the accelerometer as MAS.", logPrefix);
                 return false;
             }
         }
@@ -917,6 +922,7 @@ struct YarpSensorBridge::Impl
                                           metaData.sensorsList.gyroscopesList,
                                           interfaceType))
             {
+                log()->error("{} Unable to attach the gyros as MAS.", logPrefix);
                 return false;
             }
         }
@@ -929,6 +935,7 @@ struct YarpSensorBridge::Impl
                                           metaData.sensorsList.orientationSensorsList,
                                           interfaceType))
             {
+                log()->error("{} Unable to attach the orientation as MAS.", logPrefix);
                 return false;
             }
         }
@@ -941,6 +948,7 @@ struct YarpSensorBridge::Impl
                                           metaData.sensorsList.magnetometersList,
                                           interfaceType))
             {
+                log()->error("{} Unable to attach the magnetoemeters as MAS.", logPrefix);
                 return false;
             }
         }

--- a/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
@@ -224,7 +224,7 @@ PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructMultipleAnalogS
     }
 
     std::string description;
-    if(ptr->getParameter("description", description))
+    if(!ptr->getParameter("description", description))
     {
         log()->error("{} Unable to find the parameter 'description'.", errorPrefix);
         return PolyDriverDescriptor();


### PR DESCRIPTION
This PR:
- fixes a bug `MultipleAnalogSensorsRemapper` 97f204ed9080ba80fc9aaa749ecfd0cb76fb1e2f
- Add the possibility to attach all the multiple analog sensor clients
- Add informative prints `YarpSensorBridge::Impl`