### PR TITLE
Log the status of the system with tiny-process-library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project are documented in this file.
 
 ## [unreleased]
 ### Added
+- Log the status of the system in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/571)
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,19 @@ if(MSVC)
     set(CMAKE_DEBUG_POSTFIX "d")
 endif()
 
+# Further details on PIC can be found here:
+# https://eli.thegreenplace.net/2011/11/03/position-independent-code-pic-in-shared-libraries/
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Disable C and C++ compiler extensions.
+# C/CXX_EXTENSIONS are ON by default to allow the compilers to use extended
+# variants of the C/CXX language.
+# However, this could expose cross-platform bugs in user code or in the headers
+# of third-party dependencies and thus it is strongly suggested to turn
+# extensions off.
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 option(ENABLE_RPATH "Enable RPATH for this library" ON)
 mark_as_advanced(ENABLE_RPATH)
 include(AddInstallRPATHSupport)

--- a/cmake/AddBipedalLocomotionYARPDevice.cmake
+++ b/cmake/AddBipedalLocomotionYARPDevice.cmake
@@ -33,6 +33,7 @@ function(add_bipedal_yarp_device)
   set(sources ${${prefix}_SOURCES})
   set(public_headers ${${prefix}_PUBLIC_HEADERS})
   set(public_link_libraries ${${prefix}_PUBLIC_LINK_LIBRARIES})
+  set(private_link_libraries ${${prefix}_PRIVATE_LINK_LIBRARIES})
 
   set(YARP_FORCE_DYNAMIC_PLUGINS ON)
   # Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
@@ -47,6 +48,7 @@ function(add_bipedal_yarp_device)
     yarp_add_plugin(${name} ${sources} ${public_headers})
 
     target_link_libraries(${name} PUBLIC ${public_link_libraries})
+    target_link_libraries(${name} PRIVATE ${private_link_libraries})
     target_compile_features(${name} PUBLIC cxx_std_17)
 
     # Specify include directories for both compilation and installation process.

--- a/devices/YarpRobotLoggerDevice/CMakeLists.txt
+++ b/devices/YarpRobotLoggerDevice/CMakeLists.txt
@@ -5,12 +5,39 @@
 if(FRAMEWORK_COMPILE_YarpRobotLoggerDevice)
   # Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
 
+
+  include(FetchContent)
+  FetchContent_Declare(tiny_process_library
+    GIT_REPOSITORY https://gitlab.com/eidheim/tiny-process-library.git
+    GIT_TAG v2.0.4)
+
+  if(NOT tiny_process_library_POPULATED)
+    FetchContent_Populate(tiny_process_library)
+
+    set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build libraries as shared as opposed to static")
+
+    set(BUILD_TESTING_OLD ${BUILD_TESTING})
+    set(BUILD_TESTING OFF CACHE INTERNAL "Create tests using CMake")
+
+    # Bring the populated content into the build
+    add_subdirectory(${tiny_process_library_SOURCE_DIR} ${tiny_process_library_BINARY_DIR})
+
+    # Restore the old value of the parameter
+    set(BUILD_TESTING ${BUILD_TESTING_OLD} CACHE BOOL
+      "Create tests using CMake" FORCE)
+
+    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD} CACHE BOOL
+      "Build libraries as shared as opposed to static" FORCE)
+  endif()
+
+
   add_bipedal_yarp_device(
     NAME YarpRobotLoggerDevice
     TYPE BipedalLocomotion::YarpRobotLoggerDevice
     SOURCES src/YarpRobotLoggerDevice.cpp src/YarpTextLoggingUtilities.cpp
     PUBLIC_HEADERS include/BipedalLocomotion/YarpRobotLoggerDevice.h include/BipedalLocomotion/YarpTextLoggingUtilities.h
-    PUBLIC_LINK_LIBRARIES
+    PRIVATE_LINK_LIBRARIES
       Eigen3::Eigen
       YARP::YARP_os
       YARP::YARP_dev
@@ -25,6 +52,7 @@ if(FRAMEWORK_COMPILE_YarpRobotLoggerDevice)
       BipedalLocomotion::PerceptionInterfaceYarpImplementation
       BipedalLocomotion::TextLoggingYarpImplementation
       BipedalLocomotion::SystemYarpImplementation
+      tiny-process-library::tiny-process-library
     CONFIGURE_PACKAGE_NAME yarp_robot_logger_device)
 endif()
 

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -9,6 +9,7 @@ BSD-3-Clause license. -->
   <param name="rgb_cameras_fps">(20, 10, 10)</param>
   <param name="port_prefix">/yarp-robot-logger</param>
   <param name="text_logging_subnames">("icub-head")</param>
+  <param name="code_status_cmd_prefixes">("ssh icub@10.0.0.2" "ssh icub@10.0.0.150")</param>
 
   <group name="Telemetry">
     <param name="save_period">600.0</param>

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -119,8 +119,8 @@ private:
                         const double& devicePeriod);
     bool setupExogenousInputs(std::weak_ptr<const ParametersHandler::IParametersHandler> params);
 
-    bool saveVideo(const std::string& fileName,
-                   const robometry::SaveCallbackSaveMethod& method);
+    bool saveCallback(const std::string& fileName,
+                      const robometry::SaveCallbackSaveMethod& method);
 };
 
 } // namespace BipedalLocomotion

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -103,6 +103,7 @@ private:
     bool m_streamFTSensors{false};
     bool m_streamTemperatureSensors{false};
     std::vector<std::string> m_textLoggingSubnames;
+    std::vector<std::string> m_codeStatusCmdPrefixes;
 
     robometry::BufferManager m_bufferManager;
 


### PR DESCRIPTION
Thanks to this PR every time a matfile is saved by the `YarpRobotLoggerDevice`, the device will also save a `md` file containing the status of the system. For the time being the output of 
```console
bash ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/scripts/robotologyGitStatus.sh
```
and
```console
apt list --installed
```
I also added a parameter called `code_status_cmd_prefixes` that can be sued to add a prefix to the previous two commands, for instance 
```xml
<param name="code_status_cmd_prefixes">("ssh icub@10.0.0.2")</param>
```
will call the commands on `icub-head`

Thanks to this it will be possible to reconstruct the experiment from a given dataset