### PR TITLE
AddBipedalLocomotionYARPDevice: Enable YARP devices by deafult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Log the status of the system in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/571)
 
 ### Changed
+- YARP devices are now enabled by default if YARP is found (https://github.com/ami-iit/bipedal-locomotion-framework/pull/576).
 
 ### Fix
 

--- a/cmake/AddBipedalLocomotionYARPDevice.cmake
+++ b/cmake/AddBipedalLocomotionYARPDevice.cmake
@@ -41,7 +41,9 @@ function(add_bipedal_yarp_device)
 
   yarp_prepare_plugin(${name} CATEGORY device
                               TYPE ${type}
-                              INCLUDE ${public_headers})
+                              INCLUDE ${public_headers}
+                              OPTION ENABLE_${name}
+                              DEFAULT ON)
 
   if(NOT SKIP_${name})
 


### PR DESCRIPTION
It is quite counterintuitive that beside enabling the YARP-specific option, some more options need to be enabled to actually compile YARP devices.

See also https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/issues/5 .