### PR TITLE
Remove use of deprecated include yarp/dev/Wrapper.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - YARP devices are now enabled by default if YARP is found (https://github.com/ami-iit/bipedal-locomotion-framework/pull/576).
 
 ### Fix
+- Fix compatibility with YARP 3.8 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/577).
 
 ## [0.10.0] - 2022-09-23
 ### Added

--- a/devices/FloatingBaseEstimatorDevice/include/BipedalLocomotion/FloatingBaseEstimatorDevice.h
+++ b/devices/FloatingBaseEstimatorDevice/include/BipedalLocomotion/FloatingBaseEstimatorDevice.h
@@ -17,7 +17,7 @@
 
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/dev/IFrameTransform.h>
 

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -18,7 +18,7 @@
 #include <opencv2/videoio.hpp>
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/PeriodicThread.h>


### PR DESCRIPTION
The header was deprecated since YARP 3.3.0 (see https://github.com/robotology/yarp/blob/v3.3.0/doc/release/v3_3_0.md?plain=1#L80) and wille be removed in YARP 3.8 .

Fix part of https://github.com/robotology/robotology-superbuild/issues/1307 .