### PR TITLE
[TextLogging] Allow custom logger name

### DIFF
--- a/src/TextLogging/YarpImplementation/include/BipedalLocomotion/TextLogging/YarpLogger.h
+++ b/src/TextLogging/YarpImplementation/include/BipedalLocomotion/TextLogging/YarpLogger.h
@@ -92,7 +92,7 @@ public:
      * Construct a new YarpLoggerFactory object
      * @param name the name of the logger which will be used inside the formatted messages
      */
-    YarpLoggerFactory(const std::string_view& name = "blf") : m_name{name} {}
+    YarpLoggerFactory(const std::string_view& name = "blf");
 
     /**
      * Create the YARPLogger as a singleton

--- a/src/TextLogging/YarpImplementation/include/BipedalLocomotion/TextLogging/YarpLogger.h
+++ b/src/TextLogging/YarpImplementation/include/BipedalLocomotion/TextLogging/YarpLogger.h
@@ -89,10 +89,19 @@ class YarpLoggerFactory final : public LoggerFactory
 {
 public:
     /**
+     * Construct a new YarpLoggerFactory object
+     * @param name the name of the logger which will be used inside the formatted messages
+     */
+    YarpLoggerFactory(const std::string_view& name = "blf") : m_name{name} {}
+
+    /**
      * Create the YARPLogger as a singleton
      * @return the pointer to TextLogging::Logger that streams the output using YARP
      */
     TextLogging::Logger* const createLogger() final;
+
+private:
+    const std::string m_name; /** The name of the logger */
 };
 
 } // namespace TextLogging

--- a/src/TextLogging/YarpImplementation/src/YarpLogger.cpp
+++ b/src/TextLogging/YarpImplementation/src/YarpLogger.cpp
@@ -18,18 +18,18 @@ inline std::shared_ptr<TextLogging::Logger> YarpSink_mt(const std::string& logge
     return Factory::template create<TextLogging::sinks::YarpSink_mt>(loggerName);
 }
 
-std::shared_ptr<TextLogging::Logger> _createLogger()
+std::shared_ptr<TextLogging::Logger> _createLogger(const std::string& name)
 {
-    auto logger = spdlog::get("blf");
+    auto logger = spdlog::get(name);
 
     // if the logger called blf already exist. If it does not exist it is created.
     if (logger == nullptr)
     {
         // spdlog already handle the logger as singleton create the logger called blf
-        auto console = YarpSink_mt("blf");
+        auto console = YarpSink_mt(name);
 
         // get the logger
-        logger = spdlog::get("blf");
+        logger = spdlog::get(name);
 
         // if the project is compiled in debug the level of spdlog is set in debug
 #ifdef NDEBUG
@@ -47,7 +47,7 @@ std::shared_ptr<TextLogging::Logger> _createLogger()
 TextLogging::Logger* const TextLogging::YarpLoggerFactory::createLogger()
 {
     // Since the oobject is static the memory is not deallocated
-    static std::shared_ptr<TextLogging::Logger> logger(_createLogger());
+    static std::shared_ptr<TextLogging::Logger> logger(_createLogger(m_name));
 
     // the logger exist because loggerCreation is called.
     return logger.get();

--- a/src/TextLogging/YarpImplementation/src/YarpLogger.cpp
+++ b/src/TextLogging/YarpImplementation/src/YarpLogger.cpp
@@ -44,6 +44,8 @@ std::shared_ptr<TextLogging::Logger> _createLogger(const std::string& name)
     return logger;
 }
 
+TextLogging::YarpLoggerFactory::YarpLoggerFactory(const std::string_view& name) : m_name{name} {}
+
 TextLogging::Logger* const TextLogging::YarpLoggerFactory::createLogger()
 {
     // Since the oobject is static the memory is not deallocated

--- a/src/TextLogging/YarpImplementation/src/YarpLogger.cpp
+++ b/src/TextLogging/YarpImplementation/src/YarpLogger.cpp
@@ -44,7 +44,10 @@ std::shared_ptr<TextLogging::Logger> _createLogger(const std::string& name)
     return logger;
 }
 
-TextLogging::YarpLoggerFactory::YarpLoggerFactory(const std::string_view& name) : m_name{name} {}
+TextLogging::YarpLoggerFactory::YarpLoggerFactory(const std::string_view& name)
+    : m_name{name}
+{
+}
 
 TextLogging::Logger* const TextLogging::YarpLoggerFactory::createLogger()
 {

--- a/src/TextLogging/include/BipedalLocomotion/TextLogging/DefaultLogger.h
+++ b/src/TextLogging/include/BipedalLocomotion/TextLogging/DefaultLogger.h
@@ -9,6 +9,7 @@
 #define BIPEDAL_LOCOMOTION_TEXT_LOGGING_DEFAULT_LOGGER_FACTORY_H
 
 #include <BipedalLocomotion/TextLogging/Logger.h>
+#include <string_view>
 
 namespace BipedalLocomotion
 {
@@ -19,10 +20,19 @@ class DefaultLoggerFactory final : public LoggerFactory
 {
 public:
     /**
+     * Construct a new DefaultLoggerFactory object
+     * @param name the name of the logger which will be used inside the formatted messages
+     */
+    DefaultLoggerFactory(const std::string_view& name = "blf") : m_name{name}{}
+
+    /**
      * Create the std clock as a singleton
      * @return the reference to a System::StdClock
      */
     Logger* const createLogger() final;
+
+private:
+    const std::string m_name; /** The name of the logger */
 };
 
 } // namespace TextLogging

--- a/src/TextLogging/include/BipedalLocomotion/TextLogging/DefaultLogger.h
+++ b/src/TextLogging/include/BipedalLocomotion/TextLogging/DefaultLogger.h
@@ -23,7 +23,7 @@ public:
      * Construct a new DefaultLoggerFactory object
      * @param name the name of the logger which will be used inside the formatted messages
      */
-    DefaultLoggerFactory(const std::string_view& name = "blf") : m_name{name}{}
+    DefaultLoggerFactory(const std::string_view& name = "blf");
 
     /**
      * Create the std clock as a singleton

--- a/src/TextLogging/src/DefaultLogger.cpp
+++ b/src/TextLogging/src/DefaultLogger.cpp
@@ -39,7 +39,10 @@ std::shared_ptr<TextLogging::Logger> _createLogger(const std::string& name)
     return logger;
 }
 
-TextLogging::DefaultLoggerFactory::DefaultLoggerFactory(const std::string_view& name) : m_name(name) {}
+TextLogging::DefaultLoggerFactory::DefaultLoggerFactory(const std::string_view& name)
+    : m_name(name)
+{
+}
 
 TextLogging::Logger* const TextLogging::DefaultLoggerFactory::createLogger()
 {

--- a/src/TextLogging/src/DefaultLogger.cpp
+++ b/src/TextLogging/src/DefaultLogger.cpp
@@ -39,6 +39,8 @@ std::shared_ptr<TextLogging::Logger> _createLogger(const std::string& name)
     return logger;
 }
 
+TextLogging::DefaultLoggerFactory::DefaultLoggerFactory(const std::string_view& name) : m_name(name) {}
+
 TextLogging::Logger* const TextLogging::DefaultLoggerFactory::createLogger()
 {
     // Since the oobject is static the memory is not deallocated

--- a/src/TextLogging/src/DefaultLogger.cpp
+++ b/src/TextLogging/src/DefaultLogger.cpp
@@ -13,18 +13,18 @@
 namespace BipedalLocomotion
 {
 
-std::shared_ptr<TextLogging::Logger> _createLogger()
+std::shared_ptr<TextLogging::Logger> _createLogger(const std::string& name)
 {
-    auto logger = spdlog::get("blf");
+    auto logger = spdlog::get(name);
 
     // if the logger called blf already exist. If it does not exist it is created.
     if (logger == nullptr)
     {
         // spdlog already handle the logger as singleton create the logger called blf
-        auto console = spdlog::stdout_color_mt("blf");
+        auto console = spdlog::stdout_color_mt(name);
 
         // get the logger
-        logger = spdlog::get("blf");
+        logger = spdlog::get(name);
 
         // if the project is compiled in debug the level of spdlog is set in debug
 #ifdef NDEBUG
@@ -42,7 +42,7 @@ std::shared_ptr<TextLogging::Logger> _createLogger()
 TextLogging::Logger* const TextLogging::DefaultLoggerFactory::createLogger()
 {
     // Since the oobject is static the memory is not deallocated
-    static std::shared_ptr<TextLogging::Logger> logger(_createLogger());
+    static std::shared_ptr<TextLogging::Logger> logger(_createLogger(m_name));
 
     // the logger exist because loggerCreation is called.
     return logger.get();


### PR DESCRIPTION
When using the implemented Logger Factories, the logger's name (currently `blf`) is displayed in the formatted message -  see [here](https://github.com/ami-iit/bipedal-locomotion-framework/blob/6747c2dfb0f3fc3f1feeb94ad911095ccb356780/src/TextLogging/YarpImplementation/src/YarpLogger.cpp#L42) for a reference (where `%n` is the name of the logger).

Users may not want to use `blf`, so this PR to allow the usage of a custom name for the implemented loggers of the TextLogging component.

The changes do not break the current API since the default name `blf` is provided as default value.