### PR TITLE
Fix iDynTree 4.3.0 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 - The YarpRobotLogger will now automatically connect to the exogenous signal port if available (https://github.com/ami-iit/bipedal-locomotion-framework/pull/570/)
 - 🤖 [iCubGenova09] Add the left and right hands skin (raw and filtered) data acquisition (https://github.com/ami-iit/bipedal-locomotion-framework/pull/570/)
 - Add informative prints `YarpSensorBridge::Impl` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
+- The minimum version of iDynTree now supported is iDynTree 4.3.0 ().
 
 ### Fix
 - Return an invalid `PolyDriverDescriptor` if `description` is not found in `constructMultipleAnalogSensorsRemapper()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented in this file.
 - The YarpRobotLogger will now automatically connect to the exogenous signal port if available (https://github.com/ami-iit/bipedal-locomotion-framework/pull/570/)
 - 🤖 [iCubGenova09] Add the left and right hands skin (raw and filtered) data acquisition (https://github.com/ami-iit/bipedal-locomotion-framework/pull/570/)
 - Add informative prints `YarpSensorBridge::Impl` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
-- The minimum version of iDynTree now supported is iDynTree 4.3.0 ().
+- The minimum version of iDynTree now supported is iDynTree 4.3.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/588).
 
 ### Fix
 - Return an invalid `PolyDriverDescriptor` if `description` is not found in `constructMultipleAnalogSensorsRemapper()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -19,6 +19,6 @@ if(FRAMEWORK_COMPILE_FloatingBaseEstimators)
     SOURCES                src/FloatingBaseEstimator.cpp src/InvariantEKFBaseEstimator.cpp src/LeggedOdometry.cpp
     SUBDIRECTORIES         tests/FloatingBaseEstimators
     PUBLIC_HEADERS         ${H_PREFIX}/FloatingBaseEstimatorParams.h ${H_PREFIX}/FloatingBaseEstimatorIO.h ${H_PREFIX}/FloatingBaseEstimator.h ${H_PREFIX}/InvariantEKFBaseEstimator.h ${H_PREFIX}/LeggedOdometry.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen BipedalLocomotion::Contacts iDynTree::idyntree-modelio-urdf BipedalLocomotion::TextLogging
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen BipedalLocomotion::Contacts iDynTree::idyntree-modelio BipedalLocomotion::TextLogging
     PRIVATE_LINK_LIBRARIES MANIF::manif)
 endif()

--- a/src/Estimators/tests/FloatingBaseEstimators/CMakeLists.txt
+++ b/src/Estimators/tests/FloatingBaseEstimators/CMakeLists.txt
@@ -8,7 +8,7 @@ if(FRAMEWORK_USE_icub-models)
   add_bipedal_test(
     NAME BareBonesBaseEstimator
     SOURCES FloatingBaseEstimatorTest.cpp
-    LINKS BipedalLocomotion::FloatingBaseEstimators BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions Eigen3::Eigen iDynTree::idyntree-modelio-urdf icub-models::icub-models)
+    LINKS BipedalLocomotion::FloatingBaseEstimators BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions Eigen3::Eigen iDynTree::idyntree-modelio icub-models::icub-models)
 
 
   add_bipedal_test(


### PR DESCRIPTION
There were this warnings:
~~~
CMake Warning (dev) at cmake/AddBipedalLocomotionLibrary.cmake:73 (target_link_libraries):
  The library that is being linked to, iDynTree::idyntree-modelio-urdf, is
  marked as being deprecated by the owner.  The message provided by the
  developer is:

  Do not use deprecated target iDynTree::idyntree-modelio-urdf, use
  iDynTree::idyntree-modelio instead.

Call Stack (most recent call first):
  src/Estimators/CMakeLists.txt:17 (add_bipedal_locomotion_library)
This warning is for project developers.  Use -Wno-dev to suppress it.
~~~

These were introduced in iDynTree 4.3.0, I think it is safe to use the new target.