### PR TITLE
Use _WIN32 to check windows OS

### DIFF
--- a/src/System/src/QuitHandler.cpp
+++ b/src/System/src/QuitHandler.cpp
@@ -43,7 +43,7 @@ void my_handler(int sig)
     customHandlerLambda();
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #include <windows.h>
 
@@ -67,7 +67,7 @@ BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
 
 void handleQuitSignals(std::function<void()> customHandler)
 {
-#ifdef WIN32
+#ifdef _WIN32
     SetConsoleCtrlHandler(CtrlHandler, TRUE);
 #else
     struct sigaction action;


### PR DESCRIPTION
As per title, this PR is to check if the OS is Windows using the preprocessing flag `_WIN32`.

Currently, the only file checking for windows is the one addressed by this PR, and it checks the OS using `WIN32`.
According to many discussions (e.g. [here](https://stackoverflow.com/questions/142508/how-do-i-check-os-with-a-preprocessor-directive) or [here](https://stackoverflow.com/questions/2989810/which-cross-platform-preprocessor-defines-win32-or-win32-or-win32)) or even on [Microsoft's documentation](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170), `_WIN32` is the flag that should be used.