### PR TITLE
Implement QPFixedBaseInverseKinematics class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Add the possibility to attach all the multiple analog sensor clients  (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
 - Add a tutorial for the inverse kinematics  (https://github.com/ami-iit/bipedal-locomotion-framework/pull/596)
 - Implement the ROS2 sink for the `TextLogging` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/587)
+- Implement the `QPFixedBaseInverseKinematics` in the `IK` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/599)
 
 ### Changed
 - Ask for `toml++ v3.0.1` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/581)
@@ -13,6 +14,7 @@ All notable changes to this project are documented in this file.
 - 🤖 [iCubGenova09] Add the left and right hands skin (raw and filtered) data acquisition (https://github.com/ami-iit/bipedal-locomotion-framework/pull/570/)
 - Add informative prints `YarpSensorBridge::Impl` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
 - The minimum version of iDynTree now supported is iDynTree 4.3.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/588).
+- Allow using the `iDynTree swig` bindings in `QPFixedBaseTSID` for the kindyncomputation object (https://github.com/ami-iit/bipedal-locomotion-framework/pull/599)
 
 ### Fix
 - Return an invalid `PolyDriverDescriptor` if `description` is not found in `constructMultipleAnalogSensorsRemapper()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)

--- a/bindings/python/IK/src/QPInverseKinematics.cpp
+++ b/bindings/python/IK/src/QPInverseKinematics.cpp
@@ -9,9 +9,12 @@
 #include <pybind11/stl.h>
 
 #include <BipedalLocomotion/IK/IntegrationBasedIK.h>
+#include <BipedalLocomotion/IK/QPFixedBaseInverseKinematics.h>
 #include <BipedalLocomotion/IK/QPInverseKinematics.h>
 #include <BipedalLocomotion/System/Source.h>
+
 #include <BipedalLocomotion/bindings/IK/QPInverseKinematics.h>
+#include <BipedalLocomotion/bindings/type_caster/swig.h>
 
 namespace BipedalLocomotion
 {
@@ -27,6 +30,26 @@ void CreateQPInverseKinematics(pybind11::module& module)
 
     py::class_<QPInverseKinematics, IntegrationBasedIK>(module, "QPInverseKinematics")
         .def(py::init());
+
+    py::class_<QPFixedBaseInverseKinematics, QPInverseKinematics>(module,
+                                                                  "QPFixedBaseInverseKinematics")
+        .def(py::init())
+        .def(
+            "set_kin_dyn",
+            [](QPFixedBaseInverseKinematics& impl, ::pybind11::object& obj) -> bool {
+                std::shared_ptr<iDynTree::KinDynComputations>* cls
+                    = pybind11::detail::swig_wrapped_pointer_to_pybind<
+                        std::shared_ptr<iDynTree::KinDynComputations>>(obj);
+
+                if (cls == nullptr)
+                {
+                    throw ::pybind11::value_error("Invalid input for the function. Please provide "
+                                                  "an iDynTree::KinDynComputations object.");
+                }
+
+                return impl.setKinDyn(*cls);
+            },
+            py::arg("kin_dyn"));
 }
 
 } // namespace IK

--- a/bindings/python/TSID/src/QPTSID.cpp
+++ b/bindings/python/TSID/src/QPTSID.cpp
@@ -1,5 +1,5 @@
 /**
- * @file QPInverseKinematics.cpp
+ * @file QPTSID.cpp
  * @authors Giulio Romualdi
  * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the BSD-3-Clause license.
@@ -13,6 +13,7 @@
 #include <BipedalLocomotion/TSID/QPTSID.h>
 
 #include <BipedalLocomotion/bindings/TSID/QPTSID.h>
+#include <BipedalLocomotion/bindings/type_caster/swig.h>
 
 namespace BipedalLocomotion
 {
@@ -37,7 +38,22 @@ void CreateQPFixedBaseTSID(pybind11::module& module)
 
     py::class_<QPFixedBaseTSID, QPTSID>(module, "QPFixedBaseTSID")
         .def(py::init())
-        .def("set_kin_dyn", &QPFixedBaseTSID::setKinDyn, py::arg("kin_dyn"));
+        .def(
+            "set_kin_dyn",
+            [](QPFixedBaseTSID& impl, ::pybind11::object& obj) -> bool {
+                std::shared_ptr<iDynTree::KinDynComputations>* cls
+                    = pybind11::detail::swig_wrapped_pointer_to_pybind<
+                        std::shared_ptr<iDynTree::KinDynComputations>>(obj);
+
+                if (cls == nullptr)
+                {
+                    throw ::pybind11::value_error("Invalid input for the function. Please provide "
+                                                  "an iDynTree::KinDynComputations object.");
+                }
+
+                return impl.setKinDyn(*cls);
+            },
+            py::arg("kin_dyn"));
 }
 
 } // namespace TSID

--- a/src/IK/CMakeLists.txt
+++ b/src/IK/CMakeLists.txt
@@ -8,8 +8,11 @@ if(FRAMEWORK_COMPILE_IK)
 
   add_bipedal_locomotion_library(
     NAME                   IK
-    PUBLIC_HEADERS         ${H_PREFIX}/R3Task.h ${H_PREFIX}/SE3Task.h ${H_PREFIX}/SO3Task.h ${H_PREFIX}/JointTrackingTask.h ${H_PREFIX}/CoMTask.h ${H_PREFIX}/IntegrationBasedIK.h ${H_PREFIX}/QPInverseKinematics.h ${H_PREFIX}/IKLinearTask.h ${H_PREFIX}/AngularMomentumTask.h
-    SOURCES                src/R3Task.cpp src/SE3Task.cpp src/SO3Task.cpp src/JointTrackingTask.cpp src/CoMTask.cpp src/QPInverseKinematics.cpp src/AngularMomentumTask.cpp
+    PUBLIC_HEADERS         ${H_PREFIX}/R3Task.h ${H_PREFIX}/SE3Task.h ${H_PREFIX}/SO3Task.h ${H_PREFIX}/JointTrackingTask.h ${H_PREFIX}/CoMTask.h ${H_PREFIX}/IntegrationBasedIK.h
+                           ${H_PREFIX}/AngularMomentumTask.h ${H_PREFIX}/QPFixedBaseInverseKinematics.h
+                           ${H_PREFIX}/QPInverseKinematics.h ${H_PREFIX}/IKLinearTask.h
+    SOURCES                src/R3Task.cpp src/SE3Task.cpp src/SO3Task.cpp src/JointTrackingTask.cpp src/CoMTask.cpp src/AngularMomentumTask.cpp
+                           src/QPInverseKinematics.cpp src/QPFixedBaseInverseKinematics.cpp
     PUBLIC_LINK_LIBRARIES  Eigen3::Eigen
                            BipedalLocomotion::ParametersHandler BipedalLocomotion::System
                            LieGroupControllers::LieGroupControllers

--- a/src/IK/include/BipedalLocomotion/IK/QPFixedBaseInverseKinematics.h
+++ b/src/IK/include/BipedalLocomotion/IK/QPFixedBaseInverseKinematics.h
@@ -1,0 +1,103 @@
+/**
+ * @file QPFixedBaseTSID.h
+ * @authors Ines Sorrentino, Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_QP_FIXED_BASE_TSID_H
+#define BIPEDAL_LOCOMOTION_QP_FIXED_BASE_TSID_H
+
+#include "BipedalLocomotion/IK/QPInverseKinematics.h"
+#include <memory>
+#include <optional>
+#include <functional>
+
+#include <BipedalLocomotion/IK/IntegrationBasedIK.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+
+#include <iDynTree/KinDynComputations.h>
+
+namespace BipedalLocomotion
+{
+
+namespace IK
+{
+
+/**
+ * QPFixedBaseInverseKinematics is specialization of QPInverseKinematics class in the case of fixed
+ * base system. The IK is here implemented as Quadratic Programming (QP) problem. The user should
+ * set the desired task with the method QPFixedBaseInverseKinematics::addTask. Each task has a given
+ * priority. Currently we support only priority equal to 0 or 1. If the task priority is set to 0
+ * the task will be considered as a hard task, thus treated as a constraint. If the priority
+ * is equal to 1 the task will be embedded in the cost function. The class is also able to treat
+ * inequality constraints. Note that this class considers just one contact wrench as we assume the
+ * external wrench acting on only the base link.
+ * Here you can find an example of the QPFixedBaseInverseKinematics class used as velocity
+ * controller or IK
+ * @subsection vc Velocity Control
+ * Here you can find an example of the QPFixedBaseInverseKinematics interface used as
+ * a velocity controller.
+ * <br/>
+ * <img
+ * src="https://user-images.githubusercontent.com/16744101/142453785-9e6f2b5e-dc82-417a-a5e3-bc8c61865d0b.png"
+ * alt="VelocityControl" width="1500">
+ * @subsection ik Inverse Kinematics
+ * If you want to use IntegrationBasedInverseKinematics as IK you need to integrate the output
+ * velocity. System::FloatingBaseSystemKinematics and System::Integrator classes can be used
+ * to integrate the output of the IK taking into account the geometrical structure of the
+ * configuration space (\f$ \mathbb{R}^3 \times SO(3) \times \mathbb{R}^n\f$)
+ * <br/>
+ * <img
+ * src="https://user-images.githubusercontent.com/16744101/142453860-6bba2a7a-26af-48da-b04e-114314c6f67c.png"
+ * alt="InverseKinematics" width="1500">
+ * @note If you want to solve the Inverse Dynamics for a floating base system please use
+ * QPInverseKinematics.
+ */
+class QPFixedBaseInverseKinematics : public QPInverseKinematics
+{
+    /**
+     * Private implementation
+     */
+    struct Impl;
+    std::unique_ptr<Impl> m_pimpl;
+
+public:
+
+    /**
+     * Constructor.
+     */
+    QPFixedBaseInverseKinematics();
+
+    /**
+     * Destructor.
+     */
+    ~QPFixedBaseInverseKinematics();
+
+    /**
+     * Initialize the TSID algorithm.
+     * @param handler pointer to the IParametersHandler interface.h
+     * @note the following parameters are required by the class
+     * |            Parameter Name            |   Type   |                                             Description                                        | Mandatory |
+     * |:------------------------------------:|:--------:|:----------------------------------------------------------------------------------------------:|:---------:|
+     * |     `robot_velocity_variable_name`   | `string` | Name of the variable contained in `VariablesHandler` describing the generalized robot velocity |    Yes    |
+     * |             `verbosity`              |  `bool`  |                        Verbosity of the solver. Default value `false`                          |     No    |
+     * Where the generalized robot velocity is a vector containing the base spatialvelocity
+     * (expressed in mixed representation) and the joint velocities.
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
+
+    /**
+     * Set the kinDynComputations object.
+     * @param kinDyn pointer to a kinDynComputations object.
+     * @return True in case of success, false otherwise.
+     */
+    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+};
+
+} // namespace TSID
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_FIXED_BASE_TSID_H

--- a/src/IK/include/BipedalLocomotion/IK/QPInverseKinematics.h
+++ b/src/IK/include/BipedalLocomotion/IK/QPInverseKinematics.h
@@ -36,6 +36,23 @@ namespace IK
  * A possible usage of the IK can be found in "Romualdi et al. A Benchmarking of DCM Based
  * Architectures for Position and Velocity Controlled Walking of Humanoid Robots"
  * https://doi.org/10.1109/HUMANOIDS.2018.8625025
+ * Here you can find an example of the QPInverseKinematics class used as velocity controller or IK
+ * @subsection vc Velocity Control
+ * Here you can find an example of the QPFixedBaseInverseKinematics interface used as
+ * a velocity controller.
+ * <br/>
+ * <img
+ * src="https://user-images.githubusercontent.com/16744101/142453785-9e6f2b5e-dc82-417a-a5e3-bc8c61865d0b.png"
+ * alt="VelocityControl" width="1500">
+ * @subsection ik Inverse Kinematics
+ * If you want to use IntegrationBasedInverseKinematics as IK you need to integrate the output
+ * velocity. System::FloatingBaseSystemKinematics and System::Integrator classes can be used
+ * to integrate the output of the IK taking into account the geometrical structure of the
+ * configuration space (\f$ \mathbb{R}^3 \times SO(3) \times \mathbb{R}^n\f$)
+ * <br/>
+ * <img
+ * src="https://user-images.githubusercontent.com/16744101/142453860-6bba2a7a-26af-48da-b04e-114314c6f67c.png"
+ * alt="InverseKinematics" width="1500">
  */
 class QPInverseKinematics : public IntegrationBasedIK
 {
@@ -140,7 +157,7 @@ public:
      * | `robot_velocity_variable_name` | `string` | Name of the variable contained in `VariablesHandler` describing the generalized robot velocity |    Yes    |
      * |           `verbosity`          |  `bool`  |                         Verbosity of the solver. Default value `false`                         |     No    |
      * Where the generalized robot velocity is a vector containing the base spatialvelocity
-     (expressed in mixed representation) and the joint velocities.
+     * (expressed in mixed representation) and the joint velocities.
      * @return True in case of success, false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;

--- a/src/IK/src/QPFixedBaseInverseKinematics.cpp
+++ b/src/IK/src/QPFixedBaseInverseKinematics.cpp
@@ -1,0 +1,123 @@
+/**
+ * @file QPFixedBaseInverseKinematics.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/IK/QPFixedBaseInverseKinematics.h>
+#include <BipedalLocomotion/IK/SE3Task.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+using namespace BipedalLocomotion;
+using namespace BipedalLocomotion::IK;
+using namespace BipedalLocomotion::ParametersHandler;
+
+struct QPFixedBaseInverseKinematics::Impl
+{
+    std::string baseLink;
+    std::shared_ptr<SE3Task> baseSE3Task;
+    // const std::string baseContactWrenchVariableName{"base_contact_wrench"};
+    bool isKinDynSet{false};
+
+    bool createBaseSE3Task(std::shared_ptr<const IParametersHandler> handler)
+    {
+        constexpr auto logPrefix = "[QPFixedBaseInverseKinematics::createBaseSE3Task]";
+
+        auto baseSE3ParameterHandler = std::make_shared<StdImplementation>();
+        std::string robotVelocityVariableName;
+        if (!handler->getParameter("robot_velocity_variable_name", robotVelocityVariableName))
+        {
+            log()->error("{} Unable to get the parameter 'robot_velocity_variable_name'",
+                         logPrefix);
+            return false;
+        }
+        baseSE3ParameterHandler->setParameter("robot_velocity_variable_name",
+                                              robotVelocityVariableName);
+
+        // This task is to consider the robot fixed base, so the controller gains are set to 0.
+        // Read it a zero acceleration task
+        baseSE3ParameterHandler->setParameter("kp_linear", 0.0);
+        baseSE3ParameterHandler->setParameter("kp_angular", 0.0);
+        baseSE3ParameterHandler->setParameter("frame_name", this->baseLink);
+
+        if (!baseSE3Task->initialize(baseSE3ParameterHandler))
+        {
+            log()->error("{} Error initializing se3task on the base", logPrefix);
+            return false;
+        }
+
+        baseSE3Task->setTaskControllerMode(SE3Task::Mode::Disable);
+        baseSE3Task->setSetPoint(manif::SE3d::Identity(),
+                                 manif::SE3d::Tangent::Zero());
+
+        return true;
+    }
+};
+
+QPFixedBaseInverseKinematics::QPFixedBaseInverseKinematics()
+{
+    m_pimpl = std::make_unique<QPFixedBaseInverseKinematics::Impl>();
+    m_pimpl->baseSE3Task = std::make_shared<SE3Task>();
+}
+
+QPFixedBaseInverseKinematics::~QPFixedBaseInverseKinematics() = default;
+
+bool QPFixedBaseInverseKinematics::setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    constexpr auto logPrefix = "[QPFixedBaseInverseKinematics::setKinDyn]";
+
+    if (kinDyn == nullptr)
+    {
+        log()->error("{} The kinDyn object is not valid.", logPrefix);
+        return false;
+    }
+
+    if (!m_pimpl->baseSE3Task->setKinDyn(kinDyn))
+    {
+        log()->error("{} Unable to set the kinDyn object for SE3Task on the base.", logPrefix);
+        return false;
+    }
+
+    // get the robot base link
+    m_pimpl->baseLink = kinDyn->getFloatingBase();
+
+    m_pimpl->isKinDynSet = true;
+
+    return true;
+}
+
+bool QPFixedBaseInverseKinematics::initialize(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> handler)
+{
+    constexpr auto logPrefix = "[QPFixedBaseInverseKinematics::initialize]";
+
+    if (!m_pimpl->isKinDynSet)
+    {
+        log()->error("{} The object kinDyn is not valid.", logPrefix);
+        return false;
+    }
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", logPrefix);
+        return false;
+    }
+
+    if (!m_pimpl->createBaseSE3Task(ptr))
+    {
+        log()->error("{} Error creating SE3task for the base.", logPrefix);
+        return false;
+    }
+
+    if (!this->QPInverseKinematics::initialize(ptr))
+    {
+        log()->error("{} Unable to initialize QPInverseKinematics class.", logPrefix);
+        return false;
+    }
+
+    constexpr std::size_t highPriority = 0;
+    return this->addTask(m_pimpl->baseSE3Task, "base_se3_task", highPriority);
+}

--- a/src/IK/tests/CMakeLists.txt
+++ b/src/IK/tests/CMakeLists.txt
@@ -37,3 +37,9 @@ add_bipedal_test(
   SOURCES QPInverseKinematicsTest.cpp
   LINKS BipedalLocomotion::IK BipedalLocomotion::ManifConversions
         BipedalLocomotion::ContinuousDynamicalSystem)
+
+add_bipedal_test(
+  NAME QPFixedBaseInverseKinematics
+  SOURCES QPFixedBaseInverseKinematicsTest.cpp
+  LINKS BipedalLocomotion::IK BipedalLocomotion::ManifConversions
+        BipedalLocomotion::ContinuousDynamicalSystem)

--- a/src/IK/tests/QPFixedBaseInverseKinematicsTest.cpp
+++ b/src/IK/tests/QPFixedBaseInverseKinematicsTest.cpp
@@ -1,0 +1,295 @@
+/**
+ * @file QPFixedBaseInverseKinematicsTest.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+// Catch2
+#include <catch2/catch.hpp>
+
+// std
+#include <iDynTree/Core/Transform.h>
+#include <memory>
+#include <random>
+
+// BipedalLocomotion
+#include <BipedalLocomotion/Conversions/ManifConversions.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+#include <BipedalLocomotion/System/ConstantWeightProvider.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+
+#include <BipedalLocomotion/IK/IntegrationBasedIK.h>
+#include <BipedalLocomotion/IK/JointTrackingTask.h>
+#include <BipedalLocomotion/IK/QPFixedBaseInverseKinematics.h>
+#include <BipedalLocomotion/IK/SE3Task.h>
+
+#include <BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseSystemKinematics.h>
+#include <BipedalLocomotion/ContinuousDynamicalSystem/ForwardEuler.h>
+
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/Model/ModelTestUtils.h>
+
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+using namespace BipedalLocomotion::ContinuousDynamicalSystem;
+using namespace BipedalLocomotion::IK;
+using namespace BipedalLocomotion::Conversions;
+
+constexpr auto robotVelocity = "robotVelocity";
+constexpr double dT = 0.005;
+
+struct InverseKinematicsAndTasks
+{
+    std::shared_ptr<QPFixedBaseInverseKinematics> ik;
+    std::shared_ptr<SE3Task> se3Task;
+    std::shared_ptr<JointTrackingTask> regularizationTask;
+};
+
+struct DesiredSetPoints
+{
+    manif::SE3d endEffectorPose;
+    Eigen::VectorXd joints;
+};
+
+struct System
+{
+    std::shared_ptr<ForwardEuler<FloatingBaseSystemKinematics>> integrator;
+    std::shared_ptr<FloatingBaseSystemKinematics> dynamics;
+};
+
+std::shared_ptr<IParametersHandler> createParameterHandler()
+{
+    constexpr double gain = 0.5;
+
+    auto parameterHandler = std::make_shared<StdImplementation>();
+    parameterHandler->setParameter("robot_velocity_variable_name", robotVelocity);
+
+    parameterHandler->setParameter("verbosity", false);
+
+    /////// SE3 Task
+    auto SE3ParameterHandler = std::make_shared<StdImplementation>();
+    SE3ParameterHandler->setParameter("robot_velocity_variable_name", robotVelocity);
+
+    SE3ParameterHandler->setParameter("kp_linear", gain);
+    SE3ParameterHandler->setParameter("kp_angular", gain);
+    parameterHandler->setGroup("SE3_TASK", SE3ParameterHandler);
+
+    /////// Joint regularization task
+    auto jointRegularizationHandler = std::make_shared<StdImplementation>();
+    jointRegularizationHandler->setParameter("robot_velocity_variable_name", robotVelocity);
+    parameterHandler->setGroup("REGULARIZATION_TASK", jointRegularizationHandler);
+
+    return parameterHandler;
+}
+
+InverseKinematicsAndTasks createIK(std::shared_ptr<IParametersHandler> handler,
+                                   std::shared_ptr<iDynTree::KinDynComputations> kinDyn,
+                                   const VariablesHandler& variables)
+{
+    // prepare the parameters related to the size of the system
+    const Eigen::VectorXd kpRegularization = Eigen::VectorXd::Ones(kinDyn->model().getNrOfDOFs());
+    const Eigen::VectorXd weightRegularization = kpRegularization;
+    handler->getGroup("REGULARIZATION_TASK").lock()->setParameter("kp", kpRegularization);
+
+    InverseKinematicsAndTasks out;
+
+    constexpr std::size_t highPriority = 0;
+    constexpr std::size_t lowPriority = 1;
+
+    out.ik = std::make_shared<QPFixedBaseInverseKinematics>();
+    REQUIRE(out.ik->setKinDyn(kinDyn));
+    REQUIRE(out.ik->initialize(handler));
+
+    out.se3Task = std::make_shared<SE3Task>();
+    REQUIRE(out.se3Task->setKinDyn(kinDyn));
+    REQUIRE(out.se3Task->initialize(handler->getGroup("SE3_TASK")));
+    REQUIRE(out.ik->addTask(out.se3Task, "se3_task", highPriority));
+
+    out.regularizationTask = std::make_shared<JointTrackingTask>();
+
+
+    REQUIRE(out.regularizationTask->setKinDyn(kinDyn));
+    REQUIRE(out.regularizationTask->initialize(handler->getGroup("REGULARIZATION_TASK")));
+    REQUIRE(out.ik->addTask(out.regularizationTask,
+                            "regularization_task",
+                            lowPriority,
+                            weightRegularization));
+
+
+
+    Eigen::VectorXd newWeight = 10 * weightRegularization;
+    auto newWeightProvider = std::make_shared<BipedalLocomotion::System::ConstantWeightProvider>(newWeight);
+    REQUIRE(out.ik->setTaskWeight("regularization_task", newWeightProvider));
+
+    auto outWeightProvider = out.ik->getTaskWeightProvider("regularization_task").lock();
+    REQUIRE(outWeightProvider);
+    REQUIRE(outWeightProvider->getOutput().isApprox(newWeight));
+
+    REQUIRE(out.ik->setTaskWeight("regularization_task", weightRegularization));
+
+    REQUIRE(out.ik->finalize(variables));
+
+    return out;
+}
+
+DesiredSetPoints getDesiredReference(std::shared_ptr<iDynTree::KinDynComputations> kinDyn,
+                                     std::size_t numberOfJoints)
+{
+    DesiredSetPoints out;
+
+    const auto worldBasePos = iDynTree::Transform::Identity();
+    const auto baseVel = iDynTree::Twist::Zero();
+
+    iDynTree::VectorDynSize jointsPos(kinDyn->model().getNrOfDOFs());
+    iDynTree::VectorDynSize jointsVel(kinDyn->model().getNrOfDOFs());
+    iDynTree::Vector3 gravity;
+
+    for (auto& joint : jointsPos)
+    {
+        joint = iDynTree::getRandomDouble();
+    }
+
+    for (auto& joint : jointsVel)
+    {
+        joint = 0;
+    }
+
+    for (auto& element : gravity)
+    {
+        element = iDynTree::getRandomDouble();
+    }
+
+    REQUIRE(kinDyn->setRobotState(worldBasePos, jointsPos, baseVel, jointsVel, gravity));
+
+    const std::string controlledFrame = kinDyn->model().getFrameName(numberOfJoints);
+    out.endEffectorPose = toManifPose(kinDyn->getWorldTransform(controlledFrame));
+
+    out.joints.resize(jointsPos.size());
+    out.joints = iDynTree::toEigen(jointsPos);
+
+    return out;
+}
+
+System getSystem(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    System out;
+
+    // random noise in the joints position
+    std::default_random_engine generator;
+    generator.seed(42);
+    std::normal_distribution<double> distribution(0.0, 0.01);
+
+    // create the System
+    Eigen::Matrix<double, 6, 1> baseVelocity;
+    Eigen::VectorXd jointVelocities(kinDyn->getNrOfDegreesOfFreedom());
+    Eigen::Matrix4d basePose;
+    Eigen::VectorXd jointPositions(kinDyn->getNrOfDegreesOfFreedom());
+    Eigen::Vector3d gravity;
+
+    REQUIRE(kinDyn->getRobotState(basePose, jointPositions, baseVelocity, jointVelocities, gravity));
+
+    // perturb the joint position
+    for (int i = 0; i < kinDyn->getNrOfDegreesOfFreedom(); i++)
+    {
+        jointPositions[i] += distribution(generator);
+    }
+
+
+    out.dynamics = std::make_shared<FloatingBaseSystemKinematics>();
+    out.dynamics->setState({basePose.topRightCorner<3, 1>(),
+                            toManifRot(basePose.topLeftCorner<3, 3>()),
+                            jointPositions});
+
+    out.integrator = std::make_shared<ForwardEuler<FloatingBaseSystemKinematics>>();
+    REQUIRE(out.integrator->setIntegrationStep(dT));
+    out.integrator->setDynamicalSystem(out.dynamics);
+
+    return out;
+}
+
+TEST_CASE("QP-IK")
+{
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    auto parameterHandler = createParameterHandler();
+
+    constexpr double tolerance = 1e-1;
+
+    // set the velocity representation
+    REQUIRE(kinDyn->setFrameVelocityRepresentation(
+        iDynTree::FrameVelocityRepresentation::MIXED_REPRESENTATION));
+
+    for (std::size_t numberOfJoints = 20; numberOfJoints < 40; numberOfJoints += 15)
+    {
+        DYNAMIC_SECTION("Model with " << numberOfJoints << " joints")
+        {
+            // create the model
+            const iDynTree::Model model = iDynTree::getRandomModel(numberOfJoints);
+            REQUIRE(kinDyn->loadRobotModel(model));
+
+            const auto desiredSetPoints = getDesiredReference(kinDyn, numberOfJoints);
+
+            // Instantiate the handler
+            VariablesHandler variablesHandler;
+            variablesHandler.addVariable(robotVelocity, model.getNrOfDOFs() + 6);
+
+            auto system = getSystem(kinDyn);
+
+            // Set the frame name
+            const std::string controlledFrame = model.getFrameName(numberOfJoints);
+            parameterHandler->getGroup("SE3_TASK")
+                .lock()
+                ->setParameter("frame_name", controlledFrame);
+
+            // create the IK
+            auto ikAndTasks = createIK(parameterHandler, kinDyn, variablesHandler);
+
+            REQUIRE(ikAndTasks.se3Task->setSetPoint(desiredSetPoints.endEffectorPose,
+                                                    manif::SE3d::Tangent::Zero()));
+            REQUIRE(ikAndTasks.regularizationTask->setSetPoint(desiredSetPoints.joints));
+
+            // propagate the inverse kinematics for
+            constexpr std::size_t iterations = 10;
+            Eigen::Vector3d gravity;
+            gravity << 0, 0, -9.81;
+            Eigen::Matrix4d baseTransform = Eigen::Matrix4d::Identity();
+            Eigen::Matrix<double, 6, 1> baseVelocity = Eigen::Matrix<double, 6, 1>::Zero();
+            Eigen::VectorXd jointVelocity = Eigen::VectorXd::Zero(model.getNrOfDOFs());
+
+            for (std::size_t iteration = 0; iteration < iterations; iteration++)
+            {
+                // get the solution of the integrator
+                const auto& [basePosition, baseRotation, jointPosition]
+                    = system.integrator->getSolution();
+
+                // update the KinDynComputations object
+                baseTransform.topLeftCorner<3, 3>() = baseRotation.rotation();
+                baseTransform.topRightCorner<3, 1>() = basePosition;
+                REQUIRE(kinDyn->setRobotState(baseTransform,
+                                              jointPosition,
+                                              baseVelocity,
+                                              jointVelocity,
+                                              gravity));
+
+                // solve the IK
+                REQUIRE(ikAndTasks.ik->advance());
+
+                // get the output of the IK
+                baseVelocity = ikAndTasks.ik->getOutput().baseVelocity.coeffs();
+                jointVelocity = ikAndTasks.ik->getOutput().jointVelocity;
+
+                // propagate the dynamical system
+                system.dynamics->setControlInput({baseVelocity, jointVelocity});
+                system.integrator->integrate(0, dT);
+            }
+
+            // Check the end-effector pose error
+            const manif::SE3d endEffectorPose  = toManifPose(kinDyn->getWorldTransform(controlledFrame));
+
+            // please read it as (log(desiredSetPoints.endEffectorPose^-1 * endEffectorPose))^v
+            const manif::SE3d::Tangent error = endEffectorPose - desiredSetPoints.endEffectorPose;
+            REQUIRE(error.coeffs().isZero(tolerance));
+        }
+    }
+}


### PR DESCRIPTION
This PR implements:
- `QPFixedBaseInverseKinematics` and the associated python bindings
- Improve the documentation of the `QPInverseKinematics`
- Allow using the iDynTree swig bindings in `QPFixedBaseTSID` for the kindyncomputation object https://github.com/ami-iit/bipedal-locomotion-framework/commit/85dc4fe9b95908035d44a9c91e3879ddbfb403f8

This PR closes #598
