### PR TITLE
Add SubModelKinDynWrapper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 - Implement the python bindings for the iDynTree to manif conversions (https://github.com/ami-iit/bipedal-locomotion-framework/pull/610)
 - Implement `blf-balancing-position-control` application (https://github.com/ami-iit/bipedal-locomotion-framework/pull/611)
 - Implement the python bindings for `YarpTextLogging` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/611)
+- Add SubModelKinDynWrapper class to handle the `KinDynComputation` object of a sub-model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/605)
 
 ### Changed
 - Ask for `toml++ v3.0.1` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/581)

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -170,7 +170,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_FloatingBaseEstimators
 
 framework_dependent_option(FRAMEWORK_COMPILE_RobotDynamicsEstimator
   "Compile RobotDynamicsEstimator libraries?" ON
-  "" OFF)
+  "FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_System;FRAMEWORK_COMPILE_ManifConversions;FRAMEWORK_USE_manif" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_ManifConversions
   "Compile manif Conversions libraries?" ON

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -26,10 +26,20 @@ endif()
 if(FRAMEWORK_COMPILE_RobotDynamicsEstimator)
   set(H_PREFIX include/BipedalLocomotion/RobotDynamicsEstimator)
   add_bipedal_locomotion_library(
-    NAME                   RobotDynamicsEstimator
-    SOURCES                src/SubModel.cpp
-    SUBDIRECTORIES         tests/RobotDynamicsEstimator
-    PUBLIC_HEADERS         ${H_PREFIX}/SubModel.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::TextLogging iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model Eigen3::Eigen iDynTree::idyntree-modelio
+    NAME                    RobotDynamicsEstimator
+    SOURCES                 src/SubModel.cpp
+                            src/SubModelKinDynWrapper.cpp
+    SUBDIRECTORIES          tests/RobotDynamicsEstimator
+    PUBLIC_HEADERS          ${H_PREFIX}/SubModel.h
+                            ${H_PREFIX}/SubModelKinDynWrapper.h
+    PUBLIC_LINK_LIBRARIES   BipedalLocomotion::ParametersHandler
+                            BipedalLocomotion::TextLogging
+                            BipedalLocomotion::ManifConversions
+                            iDynTree::idyntree-high-level
+                            iDynTree::idyntree-core
+                            iDynTree::idyntree-model
+                            iDynTree::idyntree-modelio
+                            Eigen3::Eigen
+                            MANIF::manif
 )
 endif()

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h
@@ -1,0 +1,208 @@
+/**
+ * @file SubModelKinDynWrapper.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_SUB_MODEL_KINDYN_WRAPPER_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_SUB_MODEL_KINDYN_WRAPPER_H
+
+#include <map>
+
+// iDynTree
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/Model/FreeFloatingState.h>
+#include <iDynTree/Model/Model.h>
+
+// Eigen
+#include <Eigen/Dense>
+
+// RDE
+#include <BipedalLocomotion/Conversions/ManifConversions.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * SubModelKinDynWrapper is a concrete class and implements a wrapper of the KinDynComputation class
+ * from iDynTree. The class is used to take updated the sub-model kinematics and dynamics
+ */
+
+class SubModelKinDynWrapper
+{
+    SubModel m_subModel; /**< SubModel struct containing all the information about the sub-model */
+    iDynTree::KinDynComputations m_kinDyn; /**< kindyncomputation object used to get the sub-model
+                                            kinematic and dynamic information */
+    Eigen::MatrixXd m_massMatrix; /**< Mass matrix of the sub-model */
+    Eigen::VectorXd m_genForces; /**< Generalized force vector */
+    std::map<const std::string, Eigen::MatrixXd> m_jacFTList; /**< Jacobians of the FT sensors */
+    std::map<const std::string, Eigen::MatrixXd> m_jacAccList; /**< Jacobians of the accelerometer
+                                                                  sensors */
+    std::map<const std::string, Eigen::MatrixXd> m_jacGyroList; /**< Jacobians of the gyroscope
+                                                                   sensors */
+    std::map<const std::string, Eigen::MatrixXd> m_jacContactList; /**< Jacobians of the external
+                                                                      contacts */
+    std::map<const std::string, Eigen::VectorXd> m_dJnuList; /**< Accelerometer bias accelerations
+                                                              */
+    std::map<const std::string, manif::SO3d> m_accRworldList; /**< Rotation matrix of the
+                                                                 accelerometer frame wrt world */
+    manif::SE3d::Tangent m_baseVelocity; /**< Velocity of the base of the sub-model */
+    std::string m_baseFrame; /**< Name of the base frame of the sub-model */
+
+protected:
+    int m_numOfJoints; /**< Number of joints in the sub-model */
+    Eigen::MatrixXd m_FTranspose; /**< It is the bottom-left block of the mass matrix, that is,
+                                     massmatrix[6:end, 0:6] */
+    Eigen::MatrixXd m_H; /**< It is the bottom-right block of the mass matrix, that is,
+                            massmatrix[6:end, 6:end] */
+    Eigen::VectorXd m_genBiasJointTorques; /**< Generalized bias joint torques */
+    Eigen::MatrixXd m_pseudoInverseH; /**< m_H pseudoinverse */
+    Eigen::VectorXd m_FTBaseAcc; /**< FTranspose times base acceleration */
+    Eigen::VectorXd m_totalTorques; /**< total torques acting on the joints, before being converted
+                                       into joint acceleration through the mass matrix */
+    Eigen::VectorXd m_jointPositionModel; /**< Vector of joint positions from full model */
+    Eigen::VectorXd m_jointVelocityModel; /**< Vector of joint velocities from full model */
+    Eigen::Vector3d m_worldGravity; /**< world gravity acceleration */
+    manif::SE3d m_worldTBase; /**< Pose of base of the sub-model wrt the world frame */
+    Eigen::VectorXd m_qj; /**< Vector of joint positions of the sub-model */
+    Eigen::VectorXd m_dqj; /**< Vector of joint velocities of the sub-model */
+
+protected:
+    /**
+     * updateDynamicsVariableState updates the value of all the member variables containing
+     * information about the robot kinematics and dynamics
+     */
+    bool updateDynamicsVariableState();
+
+public:
+    /**
+     * @brief initialize initializes the kindyncomputation object and resizes
+     * all the variable not allocated yet.
+     * @param subModel a struct of type SubModif el describing the subModel structure and model.
+     * @param kinDynFullModel is the KinDynComputation object associated to a model.
+     * @return a boolean value saying if all the variables are initialized correctly.
+     */
+    bool
+    initialize(SubModel& subModel, std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel);
+
+    /**
+     * @brief updateKinDynState updates the state of the KinDynWrapper object.
+     * @param kinDynFullModel is the KinDynComputation object associated to a model.
+     * @return a boolean value saying if the subModelList has been created correctly.
+     */
+    bool updateKinDynState(std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel);
+
+    /**
+     * @brief inverseDynamics computes the free floaing inverse dynamics
+     * @param motorTorqueAfterGearbox a vector of size number of joints containing the motor torques
+     * times the gearbox ratio.
+     * @param frictionTorques a vector of size number of joints containing the friction torques.
+     * @param tauExt a vector of size number of joints containing the joint torques generated by the
+     * external contacts.
+     * @param baseAcceleration the sub-model base acceleration.
+     * @return a boolean value
+     */
+    bool inverseDynamics(Eigen::Ref<Eigen::VectorXd> motorTorqueAfterGearbox,
+                         Eigen::Ref<Eigen::VectorXd> frictionTorques,
+                         Eigen::Ref<Eigen::VectorXd> tauExt,
+                         Eigen::Ref<Eigen::VectorXd> baseAcceleration,
+                         Eigen::Ref<Eigen::VectorXd> jointAcceleration);
+
+    /**
+     * @brief getBaseAcceleration gets the acceleration of the sub-model base
+     * @param kinDynFullModel is the KinDynComputation object associated to a model.
+     * @param robotBaseAcceleration the acceleration of the robot base.
+     * @param robotJointAcceleration the acceleration of the robot joints.
+     * @param subModelBaseAcceleration the base acceleration of the sub-model.
+     * @return a boolean value.
+     */
+    bool getBaseAcceleration(std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                             manif::SE3d::Tangent& robotBaseAcceleration,
+                             Eigen::Ref<const Eigen::VectorXd> robotJointAcceleration,
+                             manif::SE3d::Tangent& subModelBaseAcceleration);
+
+    /**
+     * @brief getBaseVelocity gets the acceleration of the sub-model base
+     * @param kinDynFullModel is the KinDynComputation object associated to a model.
+     * @return baseVelocity the the base velocity of the sub-model.
+     */
+    const manif::SE3d::Tangent&
+    getBaseVelocity(std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel);
+
+    /**
+     * Getters
+     */
+
+    /** Access the name of the sub-model base frame.
+     * @return The name of the base frame.
+     */
+    const std::string& getBaseFrameName() const;
+
+    /** Access massMatrix
+     * @return The current value of massMatrix.
+     */
+    const Eigen::Ref<const Eigen::MatrixXd> getMassMatrix() const;
+
+    /** Access genForces
+     * @return The current value of genForces.
+     */
+    const Eigen::Ref<const Eigen::VectorXd> getGeneralizedForces() const;
+
+    /** Access the jacobian of the force/torque sensor specified by ftName.
+     * @throws an out_of_range exception if ftName is not in the list of force/torque sensors of the
+     * sub-model.
+     * @return a boolean value saying if the desired jacobian is found.
+     */
+    const Eigen::Ref<const Eigen::MatrixXd> getFTJacobian(const std::string& ftName) const;
+
+    /** Access the jacobian of the accelerometer sensor specified by accName.
+     * @throws an out_of_range exception if accName is not in the list of accelerometer sensors of
+     * the sub-model.
+     * @return a boolean value saying if the desired jacobian is found.
+     */
+    const Eigen::Ref<const Eigen::MatrixXd>
+    getAccelerometerJacobian(const std::string& accName) const;
+
+    /** Access the jacobian of the gyroscope sensor specified by gyroName.
+     * @throws an out_of_range exception if gyroName is not in the list of gyroscope sensors of the
+     * sub-model.
+     * @return a boolean value saying if the desired jacobian is found.
+     */
+    const Eigen::Ref<const Eigen::MatrixXd> getGyroscopeJacobian(const std::string& gyroName) const;
+
+    /** Access the jacobian of the contact frame specified by extContactName.
+     * @throws an out_of_range exception if extContactName is not in the list of external contacts
+     * of the sub-model.
+     * @return a boolean value saying if the desired jacobian is found.
+     */
+    const Eigen::Ref<const Eigen::MatrixXd>
+    getExtContactJacobian(const std::string& extContactName) const;
+
+    /** Access the bias acceleration referred to the accelerometer specified by accName.
+     * @throws an out_of_range exception if accName is not in the list of accelerometer sensors of
+     * the sub-model.
+     * @return a boolean value saying if the bias acceleration is found.
+     */
+    const Eigen::Ref<const Eigen::VectorXd>
+    getAccelerometerBiasAcceleration(const std::string& accName) const;
+
+    /** Access the rotation matrix between the senosr accName and the world.
+     * @throws an out_of_range exception if accName is not in the list of accelerometer sensors of
+     * the sub-model.
+     * @return a boolean value saying if the rotation matrix is found.
+     */
+    const manif::SO3d& getAccelerometerRotation(const std::string& accName) const;
+};
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_SUB_MODEL_KINDYN_WRAPPER_H

--- a/src/Estimators/src/SubModelKinDynWrapper.cpp
+++ b/src/Estimators/src/SubModelKinDynWrapper.cpp
@@ -1,0 +1,334 @@
+/**
+ * @file SubModelKinDynWrapper.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <Eigen/QR>
+
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/Core/MatrixView.h>
+#include <iDynTree/Core/Span.h>
+
+// BLF
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+namespace blf = BipedalLocomotion;
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+bool RDE::SubModelKinDynWrapper::initialize(
+    RDE::SubModel& subModel, std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel)
+{
+    constexpr auto logPrefix = "[BipedalLocomotion::Estimators::SubModelKinDynWrapper::initialize]";
+
+    this->m_subModel = subModel;
+
+    // Load robot model to the kindyncomputation object
+    if (!m_kinDyn.loadRobotModel(m_subModel.getModel()))
+    {
+        blf::log()->error("{} Unable to load the robot model.", logPrefix);
+        return false;
+    }
+
+    m_numOfJoints = m_subModel.getModel().getNrOfDOFs();
+
+    m_baseFrame = m_kinDyn.getFloatingBase();
+
+    m_baseVelocity.setZero();
+
+    m_jointPositionModel.resize(kinDynFullModel->getNrOfDegreesOfFreedom());
+    m_jointVelocityModel.resize(kinDynFullModel->getNrOfDegreesOfFreedom());
+
+    m_qj.resize(m_numOfJoints);
+    m_dqj.resize(m_numOfJoints);
+
+    m_FTranspose.resize(m_numOfJoints, 6);
+    m_H.resize(m_numOfJoints, m_numOfJoints);
+    m_genBiasJointTorques.resize(m_numOfJoints);
+    m_pseudoInverseH.resize(m_numOfJoints, m_numOfJoints);
+    m_FTBaseAcc.resize(m_numOfJoints);
+    m_totalTorques.resize(m_numOfJoints);
+
+    // Initialize attributes with correct sizes
+    m_massMatrix.resize(6 + m_subModel.getModel().getNrOfDOFs(),
+                        6 + m_subModel.getModel().getNrOfDOFs());
+    m_massMatrix.setZero();
+
+    m_genForces.resize(6 + m_subModel.getModel().getNrOfDOFs());
+    m_genForces.setZero();
+
+    for (int idx = 0; idx < m_subModel.getFTList().size(); idx++)
+    {
+        Eigen::MatrixXd tempJacobian(6, 6 + m_numOfJoints);
+        tempJacobian.setZero();
+        m_jacFTList[m_subModel.getFTList()[idx].name] = std::move(tempJacobian);
+    }
+
+    for (int idx = 0; idx < m_subModel.getAccelerometerList().size(); idx++)
+    {
+        Eigen::MatrixXd tempJacobian(6, 6 + m_numOfJoints);
+        tempJacobian.setZero();
+        m_jacAccList[m_subModel.getAccelerometerList()[idx].name] = std::move(tempJacobian);
+
+        Eigen::VectorXd tempAcceleration(6);
+        tempAcceleration.setZero();
+        m_dJnuList[m_subModel.getAccelerometerList()[idx].name] = std::move(tempAcceleration);
+
+        manif::SO3d rotMatrix;
+        rotMatrix.coeffs().setZero();
+        m_accRworldList[m_subModel.getAccelerometerList()[idx].name] = std::move(rotMatrix);
+    }
+
+    for (int idx = 0; idx < m_subModel.getGyroscopeList().size(); idx++)
+    {
+        Eigen::MatrixXd tempJacobian(6, 6 + m_numOfJoints);
+        tempJacobian.setZero();
+        m_jacGyroList[m_subModel.getGyroscopeList()[idx].name] = std::move(tempJacobian);
+    }
+
+    for (int idx = 0; idx < m_subModel.getExternalContactList().size(); idx++)
+    {
+        Eigen::MatrixXd tempJacobian(6, 6 + m_numOfJoints);
+        tempJacobian.setZero();
+        m_jacContactList[m_subModel.getExternalContactList()[idx]] = std::move(tempJacobian);
+    }
+
+    return true;
+}
+
+bool RDE::SubModelKinDynWrapper::updateKinDynState(
+    std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel)
+{
+    constexpr auto logPrefix = "[BipedalLocomotion::Estimators::SubModelKinDynWrapper::"
+                               "updateKinDynState]";
+
+    // Get world transform for the base frame
+    m_worldTBase = blf::Conversions::toManifPose(kinDynFullModel->getWorldTransform(m_baseFrame));
+
+    // Get base velocity
+    m_baseVelocity = blf::Conversions::toManifTwist(kinDynFullModel->getFrameVel(m_baseFrame));
+
+    // Get position and velocity of the joints in the full model
+    kinDynFullModel->getRobotState(m_jointPositionModel, m_jointVelocityModel, m_worldGravity);
+
+    // Get positions and velocities of joints of the sub model
+    for (int idx = 0; idx < m_subModel.getJointMapping().size(); idx++)
+    {
+        m_qj(idx) = m_jointPositionModel[m_subModel.getJointMapping()[idx]];
+        m_dqj(idx) = m_jointVelocityModel[m_subModel.getJointMapping()[idx]];
+    }
+
+    if (!m_kinDyn.setRobotState(m_worldTBase.transform(),
+                                m_qj,
+                                iDynTree::make_span(m_baseVelocity.data(),
+                                                    manif::SE3d::Tangent::DoF),
+                                iDynTree::Span<double>(m_dqj.data(), m_dqj.size()),
+                                m_worldGravity))
+    {
+        blf::log()->error("{} Unable to set the robot state.", logPrefix);
+        return false;
+    }
+
+    return updateDynamicsVariableState();
+}
+
+bool RDE::SubModelKinDynWrapper::updateDynamicsVariableState()
+{
+    constexpr auto logPrefix = "[BipedalLocomotion::Estimators::SubModelKinDynWrapper::"
+                               "updateDynamicsVariableState]";
+
+    if (!m_kinDyn.getFreeFloatingMassMatrix(m_massMatrix))
+    {
+        blf::log()->error("{} Unable to get the mass matrix of the sub-model.", logPrefix);
+        return false;
+    }
+
+    if (!m_kinDyn.generalizedBiasForces(
+            iDynTree::make_span(m_genForces.data(), m_genForces.size())))
+    {
+        blf::log()->error("{} Unable to get the generalized bias forces of the sub-model.",
+                          logPrefix);
+        return false;
+    }
+
+    // The jacobians are computed wrt the base of the submodel
+    // (floating base with known pos and vel thanks to the kinematics)
+    for (int idx = 0; idx < m_subModel.getFTList().size(); idx++)
+    {
+        if (!m_kinDyn.getFrameFreeFloatingJacobian(m_subModel.getFTList()[idx].frame,
+                                                   m_jacFTList[m_subModel.getFTList()[idx].name]))
+        {
+            blf::log()->error("{} Unable to get the compute the free floating jacobian of the "
+                              "frame {}.",
+                              logPrefix,
+                              m_subModel.getFTList()[idx].frame);
+            return false;
+        }
+    }
+
+    // Update accelerometer jacobians, dJnu, rotMatrix
+    for (int idx = 0; idx < m_subModel.getAccelerometerList().size(); idx++)
+    {
+        // Update jacobian
+        if (!m_kinDyn
+                 .getFrameFreeFloatingJacobian(m_subModel.getAccelerometerList()[idx].frame,
+                                               m_jacAccList[m_subModel.getAccelerometerList()[idx]
+                                                                .name]))
+        {
+            blf::log()->error("{} Unable to get the compute the free floating jacobian of the "
+                              "frame {}.",
+                              logPrefix,
+                              m_subModel.getAccelerometerList()[idx].frame);
+            return false;
+        }
+
+        // Update dJnu
+        m_dJnuList[m_subModel.getAccelerometerList()[idx].name] = iDynTree::toEigen(
+            m_kinDyn.getFrameBiasAcc(m_subModel.getAccelerometerList()[idx].frame));
+
+        // Update rotMatrix
+        m_accRworldList[m_subModel.getAccelerometerList()[idx].name] = blf::Conversions::toManifRot(
+            m_kinDyn.getWorldTransform(m_subModel.getAccelerometerList()[idx].frame)
+                .getRotation()
+                .inverse());
+    }
+
+    // Update gyroscope jacobians
+    for (int idx = 0; idx < m_subModel.getGyroscopeList().size(); idx++)
+    {
+        if (!m_kinDyn.getFrameFreeFloatingJacobian(m_subModel.getGyroscopeList()[idx].frame,
+                                                   m_jacGyroList[m_subModel.getGyroscopeList()[idx]
+                                                                     .name]))
+        {
+            blf::log()->error("{} Unable to get the compute the free floating jacobian of the "
+                              "frame {}.",
+                              logPrefix,
+                              m_subModel.getGyroscopeList()[idx].frame);
+            return false;
+        }
+    }
+
+    // Update external contact jacobians
+    for (int idx = 0; idx < m_subModel.getExternalContactList().size(); idx++)
+    {
+        if (!m_kinDyn.getFrameFreeFloatingJacobian(m_subModel.getExternalContactList()[idx],
+                                                   m_jacContactList
+                                                       [m_subModel.getExternalContactList()[idx]]))
+        {
+            blf::log()->error("{} Unable to get the compute the free floating jacobian of the "
+                              "frame {}.",
+                              logPrefix,
+                              m_subModel.getExternalContactList()[idx]);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool RDE::SubModelKinDynWrapper::inverseDynamics(Eigen::Ref<Eigen::VectorXd> motorTorqueAfterGearbox,
+                                                 Eigen::Ref<Eigen::VectorXd> frictionTorques,
+                                                 Eigen::Ref<Eigen::VectorXd> tauExt,
+                                                 Eigen::Ref<Eigen::VectorXd> baseAcceleration,
+                                                 Eigen::Ref<Eigen::VectorXd> jointAcceleration)
+{
+    m_FTranspose = m_massMatrix.block(6, 0, m_numOfJoints, 6);
+    m_H = m_massMatrix.block(6, 6, m_numOfJoints, m_numOfJoints);
+
+    m_genBiasJointTorques = m_genForces.tail(m_numOfJoints);
+
+    m_pseudoInverseH = m_H.completeOrthogonalDecomposition().pseudoInverse();
+
+    m_FTBaseAcc = m_FTranspose * baseAcceleration;
+    m_totalTorques
+        = motorTorqueAfterGearbox - frictionTorques - m_genBiasJointTorques + tauExt + m_FTBaseAcc;
+
+    jointAcceleration = m_pseudoInverseH * m_totalTorques;
+
+    return true;
+}
+
+bool RDE::SubModelKinDynWrapper::getBaseAcceleration(
+    std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+    manif::SE3d::Tangent& robotBaseAcceleration,
+    Eigen::Ref<const Eigen::VectorXd> robotJointAcceleration,
+    manif::SE3d::Tangent& subModelBaseAcceleration)
+{
+    constexpr auto logPrefix = "[BipedalLocomotion::Estimators::SubModelKinDynWrapper::"
+                               "getBaseAcceleration]";
+
+    if (!kinDynFullModel->getFrameAcc(m_baseFrame,
+                                      iDynTree::make_span(robotBaseAcceleration.data(),
+                                                          manif::SE3d::Tangent::DoF),
+                                      robotJointAcceleration,
+                                      iDynTree::make_span(subModelBaseAcceleration.data(),
+                                                          manif::SE3d::Tangent::DoF)))
+    {
+        blf::log()->error("{} Unable to get the acceleration of the frame {}.",
+                          logPrefix,
+                          m_baseFrame);
+        return false;
+    }
+
+    return true;
+}
+
+const manif::SE3d::Tangent& RDE::SubModelKinDynWrapper::getBaseVelocity(
+    std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel)
+{
+    m_baseVelocity = blf::Conversions::toManifTwist(kinDynFullModel->getFrameVel(m_baseFrame));
+    return m_baseVelocity;
+}
+
+const std::string& RDE::SubModelKinDynWrapper::getBaseFrameName() const
+{
+    return m_baseFrame;
+}
+
+const Eigen::Ref<const Eigen::MatrixXd> RDE::SubModelKinDynWrapper::getMassMatrix() const
+{
+    return m_massMatrix;
+}
+
+const Eigen::Ref<const Eigen::VectorXd> RDE::SubModelKinDynWrapper::getGeneralizedForces() const
+{
+    return m_genForces;
+}
+
+const Eigen::Ref<const Eigen::MatrixXd>
+RDE::SubModelKinDynWrapper::getFTJacobian(const std::string& ftName) const
+{
+    return m_jacFTList.at(ftName);
+}
+
+const Eigen::Ref<const Eigen::MatrixXd>
+RDE::SubModelKinDynWrapper::getAccelerometerJacobian(const std::string& accName) const
+{
+    return m_jacAccList.at(accName);
+}
+
+const Eigen::Ref<const Eigen::MatrixXd>
+RDE::SubModelKinDynWrapper::getGyroscopeJacobian(const std::string& gyroName) const
+{
+    return m_jacGyroList.at(gyroName);
+}
+
+const Eigen::Ref<const Eigen::MatrixXd>
+RDE::SubModelKinDynWrapper::getExtContactJacobian(const std::string& extContactName) const
+{
+    return m_jacContactList.at(extContactName);
+}
+
+const Eigen::Ref<const Eigen::VectorXd>
+RDE::SubModelKinDynWrapper::getAccelerometerBiasAcceleration(const std::string& accName) const
+{
+    return m_dJnuList.at(accName);
+}
+
+const manif::SO3d&
+RDE::SubModelKinDynWrapper::getAccelerometerRotation(const std::string& accName) const
+{
+    return m_accRworldList.at(accName);
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
+++ b/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
@@ -11,6 +11,17 @@ if(FRAMEWORK_USE_icub-models AND FRAMEWORK_COMPILE_YarpImplementation)
                            BipedalLocomotion::ParametersHandlerYarpImplementation
                            icub-models::icub-models)
 
+    add_bipedal_test(NAME SubModelKinDynWrapper
+                     SOURCES SubModelKinDynWrapperTest.cpp
+                     LINKS BipedalLocomotion::RobotDynamicsEstimator
+                           BipedalLocomotion::ParametersHandler
+                           BipedalLocomotion::ParametersHandlerYarpImplementation
+                           BipedalLocomotion::ManifConversions
+                           icub-models::icub-models
+                           Eigen3::Eigen
+                           MANIF::manif
+                           )
+
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/ConfigFolderPath.h.in" "${CMAKE_CURRENT_BINARY_DIR}/ConfigFolderPath.h" @ONLY)
 

--- a/src/Estimators/tests/RobotDynamicsEstimator/SubModelKinDynWrapperTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/SubModelKinDynWrapperTest.cpp
@@ -1,0 +1,215 @@
+/**
+ * @file KinDynWrapperTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <ConfigFolderPath.h>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+
+// BLF
+#include <BipedalLocomotion/Conversions/ManifConversions.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+
+// iDynTree
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+
+using namespace BipedalLocomotion::ParametersHandler;
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+double random_double()
+{
+    return 1.0 * ((double)rand() - RAND_MAX / 2) / ((double)RAND_MAX);
+}
+
+double real_random_double()
+{
+    return 1.0 * ((double)rand() - RAND_MAX / 2) / ((double)RAND_MAX);
+}
+
+int real_random_int(int initialValue, int finalValue)
+{
+    int length = finalValue - initialValue;
+    return initialValue + rand() % length;
+}
+
+bool setStaticState(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    size_t dofs = kinDyn->getNrOfDegreesOfFreedom();
+    iDynTree::Transform worldTbase;
+    Eigen::VectorXd baseVel(6);
+    Eigen::Vector3d gravity;
+
+    Eigen::VectorXd qj(dofs), dqj(dofs), ddqj(dofs);
+
+    worldTbase = iDynTree::Transform(iDynTree::Rotation::Identity(), iDynTree::Position::Zero());
+
+    Eigen::Matrix4d transform = toEigen(worldTbase.asHomogeneousTransform());
+
+    gravity.setZero();
+    gravity(2) = -9.80665;
+
+    baseVel.setZero();
+
+    for (size_t dof = 0; dof < dofs; dof++)
+
+    {
+        qj(dof) = 0.0;
+        dqj(dof) = 0.0;
+        ddqj(dof) = 0.0;
+    }
+
+    return kinDyn->setRobotState(transform,
+                                 iDynTree::make_span(qj.data(), qj.size()),
+                                 iDynTree::make_span(baseVel.data(), baseVel.size()),
+                                 iDynTree::make_span(dqj.data(), dqj.size()),
+                                 iDynTree::make_span(gravity.data(), gravity.size()));
+}
+
+TEST_CASE("SubModelKinDynWrapper")
+{
+    std::shared_ptr<YarpImplementation> originalHandler = std::make_shared<YarpImplementation>();
+    IParametersHandler::shared_ptr parameterHandler = originalHandler;
+
+    yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
+    rf.setDefaultConfigFile("model.ini");
+
+    std::vector<std::string> arguments = {" ", "--from ", getConfigPath()};
+
+    std::vector<char*> argv;
+    for (const auto& arg : arguments)
+        argv.push_back((char*)arg.data());
+    argv.push_back(nullptr);
+
+    rf.configure(argv.size() - 1, argv.data());
+
+    REQUIRE_FALSE(rf.isNull());
+    parameterHandler->clear();
+    REQUIRE(parameterHandler->isEmpty());
+    originalHandler->set(rf);
+
+    const std::string modelPath = iCubModels::getModelFile("iCubGenova09");
+
+    std::vector<std::string> jointList;
+    REQUIRE(parameterHandler->getParameter("joint_list", jointList));
+
+    std::vector<std::string> ftFramesList;
+    auto ftGroup = parameterHandler->getGroup("FT").lock();
+    REQUIRE(ftGroup->getParameter("frames", ftFramesList));
+
+    std::vector<std::string> jointsAndFTs;
+    jointsAndFTs.insert(jointsAndFTs.begin(), jointList.begin(), jointList.end());
+    jointsAndFTs.insert(jointsAndFTs.end(), ftFramesList.begin(), ftFramesList.end());
+
+    iDynTree::ModelLoader mdlLdr;
+    REQUIRE(mdlLdr.loadReducedModelFromFile(modelPath, jointsAndFTs));
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    REQUIRE(kinDyn->loadRobotModel(mdlLdr.model()));
+
+    // List of joints and fts to load the model
+    RDE::SubModelCreator subModelCreator;
+    subModelCreator.setModel(mdlLdr.model());
+    REQUIRE(subModelCreator.setKinDyn(kinDyn));
+    subModelCreator.setSensorList(mdlLdr.sensors());
+
+    REQUIRE(subModelCreator.createSubModels(originalHandler));
+
+    auto subModelList = subModelCreator.getSubModelList();
+
+    // Full model base acceleration
+    manif::SE3d::Tangent robotBaseAcceleration;
+    robotBaseAcceleration.setZero();
+
+    // Full model joint acceleration
+    Eigen::VectorXd robotJointAcceleration(kinDyn->model().getNrOfDOFs());
+    robotJointAcceleration.setZero();
+
+    REQUIRE(setStaticState(kinDyn));
+
+    for (int idx = 0; idx < subModelList.size(); idx++)
+    {
+        RDE::SubModelKinDynWrapper kinDynSubModel;
+        REQUIRE(kinDynSubModel.initialize(subModelList[idx], kinDyn));
+
+        REQUIRE(kinDynSubModel.updateKinDynState(kinDyn));
+
+        int numberOfJoints = subModelList[idx].getModel().getNrOfDOFs();
+
+        if (numberOfJoints > 0)
+        {
+            Eigen::VectorXd motorTorques(numberOfJoints);
+            Eigen::VectorXd frictionTorques(numberOfJoints);
+            Eigen::VectorXd contactTorques(numberOfJoints);
+
+            const std::string baseFrame = kinDynSubModel.getBaseFrameName();
+
+            manif::SE3d::Tangent baseAcceleration;
+            REQUIRE(kinDynSubModel.getBaseAcceleration(kinDyn,
+                                                       robotBaseAcceleration,
+                                                       robotJointAcceleration,
+                                                       baseAcceleration));
+            manif::SE3d::Tangent subModelBaseAcceleration;
+            REQUIRE(kinDyn->getFrameAcc(baseFrame,
+                                        iDynTree::make_span(robotBaseAcceleration.data(),
+                                                            manif::SE3d::Tangent::DoF),
+                                        robotJointAcceleration,
+                                        iDynTree::make_span(subModelBaseAcceleration.data(),
+                                                            manif::SE3d::Tangent::DoF)));
+            REQUIRE(subModelBaseAcceleration == baseAcceleration);
+
+            manif::SE3d::Tangent baseVelocity;
+            baseVelocity = kinDynSubModel.getBaseVelocity(kinDyn);
+
+            manif::SE3d::Tangent baseVelFromFullModel
+                = BipedalLocomotion::Conversions::toManifTwist(kinDyn->getFrameVel(baseFrame));
+            REQUIRE(baseVelocity == baseVelFromFullModel);
+
+            Eigen::VectorXd jointAcceleration(numberOfJoints);
+
+            for (int i = 0; i < numberOfJoints; i++)
+            {
+                motorTorques(i) = random_double();
+                frictionTorques(i) = random_double();
+                contactTorques(i) = random_double();
+            }
+
+            REQUIRE(kinDynSubModel.inverseDynamics(motorTorques,
+                                                   frictionTorques,
+                                                   contactTorques,
+                                                   baseAcceleration.coeffs(),
+                                                   jointAcceleration));
+
+            auto massMatrix = kinDynSubModel.getMassMatrix();
+            REQUIRE(massMatrix.rows() == (6 + numberOfJoints));
+
+            auto genForces = kinDynSubModel.getGeneralizedForces();
+            REQUIRE(genForces.size() == (6 + numberOfJoints));
+        }
+
+        if (subModelList[idx].getFTList().size() > 0)
+        {
+            const std::string ftname = subModelList[idx].getFTList()[0].name;
+            auto jacobianFT = kinDynSubModel.getFTJacobian(ftname);
+            REQUIRE(jacobianFT.rows() == 6);
+            REQUIRE(jacobianFT.cols() == 6 + numberOfJoints);
+        }
+
+        if (subModelList[idx].getAccelerometerList().size())
+        {
+            const std::string accName = subModelList[idx].getAccelerometerList()[0].name;
+            auto jacobianAcc = kinDynSubModel.getAccelerometerJacobian(accName);
+            REQUIRE(jacobianAcc.rows() == 6);
+            REQUIRE(jacobianAcc.cols() == 6 + numberOfJoints);
+        }
+    }
+}


### PR DESCRIPTION
Adding the `SubModelKinDynWrapper` class. It handles the `KinDynComputation` object of a sub-model and keeps updated the dynamics and kinematics information.

This PR is blocked by #604.