### PR TITLE
Fix attachRemappedRemoteControlBoard in YarpSensorBridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented in this file.
 ### Fix
 - Return an invalid `PolyDriverDescriptor` if `description` is not found in `constructMultipleAnalogSensorsRemapper()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
 - Fix compatibility with OpenCV 4.7.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/589)
+- Fix `attachRemappedRemoteControlBoard` in `YarpSensorBridge` when the `RemoteControlBoard` is not the first polydriver in the polydriverlist (https://github.com/ami-iit/bipedal-locomotion-framework/pull/608)
 
 ## [0.11.1] - 2022-12-19
 ### Fix


### PR DESCRIPTION
This fix is required when the the YarpSensorBridge is attached to a list of polydriver and the remote control board remapper is not the first one.