### PR TITLE
Add the possibility to programmatically build an IK problem from a configuration file 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - Implement the python bindings for `YarpTextLogging` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/611)
 - Add SubModelKinDynWrapper class to handle the `KinDynComputation` object of a sub-model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/605)
 - Implement the `JointLimitsTask` for the IK (https://github.com/ami-iit/bipedal-locomotion-framework/pull/603)
+- Add the possibility to programmatically build an IK problem from a configuration file (https://github.com/ami-iit/bipedal-locomotion-framework/pull/614)
 
 ### Changed
 - Ask for `toml++ v3.0.1` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/581)

--- a/bindings/python/IK/src/CoMTask.cpp
+++ b/bindings/python/IK/src/CoMTask.cpp
@@ -29,9 +29,6 @@ void CreateCoMTask(pybind11::module& module)
 
     py::class_<CoMTask, std::shared_ptr<CoMTask>, IKLinearTask>(module, "CoMTask")
         .def(py::init())
-        .def("set_kin_dyn",
-             BipedalLocomotion::bindings::System::setKinDyn<CoMTask>,
-             py::arg("kin_dyn"))
         .def("set_set_point", &CoMTask::setSetPoint, py::arg("position"), py::arg("velocity"));
 }
 

--- a/bindings/python/IK/src/IKLinearTask.cpp
+++ b/bindings/python/IK/src/IKLinearTask.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <iDynTree/KinDynComputations.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -31,7 +32,10 @@ void CreateIKLinearTask(pybind11::module& module)
                ::BipedalLocomotion::System::LinearTask,
                ::BipedalLocomotion::bindings::System::LinearTaskTrampoline<IKLinearTask>,
                std::shared_ptr<IKLinearTask>>(module, "IKLinearTask")
-        .def(py::init<>());
+        .def(py::init<>())
+        .def("set_kin_dyn",
+             BipedalLocomotion::bindings::System::setKinDyn<IKLinearTask>,
+             py::arg("kin_dyn"));
 }
 
 } // namespace IK

--- a/bindings/python/IK/src/JointLimitsTask.cpp
+++ b/bindings/python/IK/src/JointLimitsTask.cpp
@@ -30,10 +30,7 @@ void CreateJointLimitsTask(pybind11::module& module)
     py::class_<JointLimitsTask, std::shared_ptr<JointLimitsTask>, IKLinearTask>( //
         module,
         "JointLimitsTask")
-        .def(py::init())
-        .def("set_kin_dyn",
-             BipedalLocomotion::bindings::System::setKinDyn<JointLimitsTask>,
-             py::arg("kin_dyn"));
+        .def(py::init());
 }
 
 } // namespace IK

--- a/bindings/python/IK/src/JointTrackingTask.cpp
+++ b/bindings/python/IK/src/JointTrackingTask.cpp
@@ -31,9 +31,6 @@ void CreateJointTrackingTask(pybind11::module& module)
         module,
         "JointTrackingTask")
         .def(py::init())
-        .def("set_kin_dyn",
-             BipedalLocomotion::bindings::System::setKinDyn<JointTrackingTask>,
-             py::arg("kin_dyn"))
         .def("set_set_point",
              py::overload_cast<Eigen::Ref<const Eigen::VectorXd>>(&JointTrackingTask::setSetPoint),
              py::arg("joint_position"))

--- a/bindings/python/IK/src/R3Task.cpp
+++ b/bindings/python/IK/src/R3Task.cpp
@@ -35,9 +35,6 @@ void CreateR3Task(pybind11::module& module)
                IKLinearTask,
                BipedalLocomotion::System::ITaskControllerManager>(module, "R3Task")
         .def(py::init())
-        .def("set_kin_dyn",
-             BipedalLocomotion::bindings::System::setKinDyn<R3Task>,
-             py::arg("kin_dyn"))
         .def("set_set_point",
              &R3Task::setSetPoint,
              py::arg("I_p_F"),

--- a/bindings/python/IK/src/SE3Task.cpp
+++ b/bindings/python/IK/src/SE3Task.cpp
@@ -37,9 +37,6 @@ void CreateSE3Task(pybind11::module& module)
                IKLinearTask,
                BipedalLocomotion::System::ITaskControllerManager>(module, "SE3Task")
         .def(py::init())
-        .def("set_kin_dyn",
-             BipedalLocomotion::bindings::System::setKinDyn<SE3Task>,
-             py::arg("kin_dyn"))
         .def("set_set_point",
              &SE3Task::setSetPoint,
              py::arg("I_H_F"),

--- a/bindings/python/IK/src/SO3Task.cpp
+++ b/bindings/python/IK/src/SO3Task.cpp
@@ -31,9 +31,6 @@ void CreateSO3Task(pybind11::module& module)
 
     py::class_<SO3Task, std::shared_ptr<SO3Task>, IKLinearTask>(module, "SO3Task")
         .def(py::init())
-        .def("set_kin_dyn",
-             BipedalLocomotion::bindings::System::setKinDyn<SO3Task>,
-             py::arg("kin_dyn"))
         .def("set_set_point",
              &SO3Task::setSetPoint,
              py::arg("I_R_F"),

--- a/bindings/python/System/include/BipedalLocomotion/bindings/System/ILinearTaskSolver.h
+++ b/bindings/python/System/include/BipedalLocomotion/bindings/System/ILinearTaskSolver.h
@@ -85,6 +85,19 @@ void CreateILinearTaskSolver(pybind11::module& module, const std::string& python
             py::arg("task_name"))
         .def("get_task_names",
              &::BipedalLocomotion::System::ILinearTaskSolver<_Task, _State>::getTaskNames)
+        .def(
+            "get_task",
+            [](const ::BipedalLocomotion::System::ILinearTaskSolver<_Task, _State>& impl,
+               const std::string& name) -> std::shared_ptr<_Task> {
+                auto task = impl.getTask(name).lock();
+                if (task == nullptr)
+                {
+                    const std::string msg = "Failed to get the task named '" + name + "'.";
+                    throw py::value_error(msg);
+                }
+                return task;
+            },
+            py::arg("name"))
         .def("finalize",
              &::BipedalLocomotion::System::ILinearTaskSolver<_Task, _State>::finalize,
              py::arg("handler"))

--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -157,6 +157,11 @@ def create_ik(kindyn: idyn.KinDynComputations,
         a tuple containing the solver, a dictionary of the tasks and the variables handler
     """
 
+    import warnings
+    warnings.warn("The function is deprecated. It will be removed in the next release. "
+                  "Please use bipedalLocomotion.ik.QPInverseKinematics.build() instead.",
+                  DeprecationWarning)
+
     solver = blf.ik.QPInverseKinematics()
     tasks = dict()
     variables_handler = blf.system.VariablesHandler()

--- a/src/IK/CMakeLists.txt
+++ b/src/IK/CMakeLists.txt
@@ -12,7 +12,7 @@ if(FRAMEWORK_COMPILE_IK)
                            ${H_PREFIX}/AngularMomentumTask.h ${H_PREFIX}/JointLimitsTask.h ${H_PREFIX}/QPFixedBaseInverseKinematics.h
                            ${H_PREFIX}/QPInverseKinematics.h ${H_PREFIX}/IKLinearTask.h
     SOURCES                src/R3Task.cpp src/SE3Task.cpp src/SO3Task.cpp src/JointTrackingTask.cpp src/CoMTask.cpp src/AngularMomentumTask.cpp src/JointLimitsTask.cpp
-                           src/QPInverseKinematics.cpp src/QPFixedBaseInverseKinematics.cpp
+                           src/QPInverseKinematics.cpp src/QPFixedBaseInverseKinematics.cpp src/IKLinearTask.cpp
     PUBLIC_LINK_LIBRARIES  Eigen3::Eigen
                            BipedalLocomotion::ParametersHandler BipedalLocomotion::System
                            LieGroupControllers::LieGroupControllers

--- a/src/IK/include/BipedalLocomotion/IK/AngularMomentumTask.h
+++ b/src/IK/include/BipedalLocomotion/IK/AngularMomentumTask.h
@@ -75,7 +75,7 @@ public:
      * @param kinDyn pointer to a kinDynComputations object.
      * @return True in case of success, false otherwise.
      */
-    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn) override;
 
     /**
      * Set the set of variables required by the task. The variables are stored in the
@@ -121,6 +121,8 @@ public:
      */
     bool isValid() const override;
 };
+
+BLF_REGISTER_IK_TASK(AngularMomentumTask);
 
 } // namespace IK
 } // namespace BipedalLocomotion

--- a/src/IK/include/BipedalLocomotion/IK/CoMTask.h
+++ b/src/IK/include/BipedalLocomotion/IK/CoMTask.h
@@ -91,7 +91,7 @@ public:
      * @param kinDyn pointer to a kinDynComputations object.
      * @return True in case of success, false otherwise.
      */
-    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn) override;
 
     /**
      * Set the set of variables required by the task. The variables are stored in the
@@ -138,6 +138,8 @@ public:
      */
     bool isValid() const override;
 };
+
+BLF_REGISTER_IK_TASK(CoMTask);
 
 } // namespace IK
 } // namespace BipedalLocomotion

--- a/src/IK/include/BipedalLocomotion/IK/IKLinearTask.h
+++ b/src/IK/include/BipedalLocomotion/IK/IKLinearTask.h
@@ -9,6 +9,16 @@
 #define BIPEDAL_LOCOMOTION_SYSTEM_IK_LINEAR_TASK_H
 
 #include <BipedalLocomotion/System/LinearTask.h>
+#include <BipedalLocomotion/System/ILinearTaskFactory.h>
+
+#include <iDynTree/KinDynComputations.h>
+
+/**
+ * BLF_REGISTER_IK_TASK is a macro that can be used to register an IKLinearTask. The key of the
+ * task will be the stringified version of the Task C++ Type
+ * @param _type the type of the task
+ */
+#define BLF_REGISTER_IK_TASK(_type) BLF_REGISTER_TASK(_type, ::BipedalLocomotion::IK::IKLinearTask)
 
 namespace BipedalLocomotion
 {
@@ -21,7 +31,16 @@ namespace IK
 struct IKLinearTask : public BipedalLocomotion::System::LinearTask
 {
     virtual ~IKLinearTask() = default;
+
+    /**
+     * Set the kinDynComputations object.
+     * @param kinDyn pointer to a kinDynComputations object.
+     * @return True in case of success, false otherwise.
+     */
+    virtual bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
 };
+
+using IKLinearTaskFactory = ::BipedalLocomotion::System::ILinearTaskFactory<IKLinearTask>;
 
 } // namespace IK
 } // namespace BipedalLocomotion

--- a/src/IK/include/BipedalLocomotion/IK/JointLimitsTask.h
+++ b/src/IK/include/BipedalLocomotion/IK/JointLimitsTask.h
@@ -83,7 +83,7 @@ public:
      * @param kinDyn pointer to a kinDynComputations object.
      * @return True in case of success, false otherwise.
      */
-    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn) override;
 
     /**
      * Set the set of variables required by the task. The variables are stored in the
@@ -122,6 +122,8 @@ public:
      */
     bool isValid() const override;
 };
+
+BLF_REGISTER_IK_TASK(JointLimitsTask);
 
 } // namespace IK
 } // namespace BipedalLocomotion

--- a/src/IK/include/BipedalLocomotion/IK/JointTrackingTask.h
+++ b/src/IK/include/BipedalLocomotion/IK/JointTrackingTask.h
@@ -69,7 +69,7 @@ public:
      * @param kinDyn pointer to a kinDynComputations object.
      * @return True in case of success, false otherwise.
      */
-    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn) override;
 
     /**
      * Set the set of variables required by the task. The variables are stored in the
@@ -125,6 +125,8 @@ public:
      */
     bool isValid() const override;
 };
+
+BLF_REGISTER_IK_TASK(JointTrackingTask);
 
 } // namespace IK
 } // namespace BipedalLocomotion

--- a/src/IK/include/BipedalLocomotion/IK/R3Task.h
+++ b/src/IK/include/BipedalLocomotion/IK/R3Task.h
@@ -97,7 +97,7 @@ public:
      * @param kinDyn pointer to a kinDynComputations object.
      * @return True in case of success, false otherwise.
      */
-    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn) override;
 
     /**
      * Set the set of variables required by the task. The variables are stored in the
@@ -158,6 +158,8 @@ public:
      */
     Mode getTaskControllerMode() const override;
 };
+
+BLF_REGISTER_IK_TASK(R3Task);
 
 } // namespace IK
 } // namespace BipedalLocomotion

--- a/src/IK/include/BipedalLocomotion/IK/SE3Task.h
+++ b/src/IK/include/BipedalLocomotion/IK/SE3Task.h
@@ -114,7 +114,7 @@ public:
      * @param kinDyn pointer to a kinDynComputations object.
      * @return True in case of success, false otherwise.
      */
-    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn) override;
 
     /**
      * Set the set of variables required by the task. The variables are stored in the
@@ -202,6 +202,8 @@ public:
      */
     Mode getTaskControllerMode() const override;
 };
+
+BLF_REGISTER_IK_TASK(SE3Task);
 
 } // namespace IK
 } // namespace BipedalLocomotion

--- a/src/IK/include/BipedalLocomotion/IK/SO3Task.h
+++ b/src/IK/include/BipedalLocomotion/IK/SO3Task.h
@@ -83,7 +83,7 @@ public:
      * @param kinDyn pointer to a kinDynComputations object.
      * @return True in case of success, false otherwise.
      */
-    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn) override;
 
     /**
      * Set the set of variables required by the task. The variables are stored in the
@@ -132,6 +132,8 @@ public:
      */
     bool isValid() const override;
 };
+
+BLF_REGISTER_IK_TASK(SO3Task);
 
 } // namespace IK
 } // namespace BipedalLocomotion

--- a/src/IK/src/IKLinearTask.cpp
+++ b/src/IK/src/IKLinearTask.cpp
@@ -1,0 +1,14 @@
+/**
+ * @file IKLinearTask.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+#include <BipedalLocomotion/IK/IKLinearTask.h>
+
+using namespace BipedalLocomotion::IK;
+
+bool IKLinearTask::setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    return true;
+}

--- a/src/IK/src/JointLimitsTask.cpp
+++ b/src/IK/src/JointLimitsTask.cpp
@@ -78,7 +78,6 @@ bool JointLimitsTask::setVariablesHandler(const System::VariablesHandler& variab
         return false;
     }
 
-
     if (!variablesHandler.getVariable(m_robotVelocityVariableName, robotVelocityVariable))
     {
         log()->error("{} Error while retrieving the robot velocity variable.", errorPrefix);

--- a/src/IK/tests/QPInverseKinematicsTest.cpp
+++ b/src/IK/tests/QPInverseKinematicsTest.cpp
@@ -10,6 +10,7 @@
 
 // std
 #include <memory>
+#include <ostream>
 #include <random>
 
 // BipedalLocomotion
@@ -65,12 +66,18 @@ struct System
 
 std::shared_ptr<IParametersHandler> createParameterHandler()
 {
+
     constexpr double gain = 5.0;
 
     auto parameterHandler = std::make_shared<StdImplementation>();
     parameterHandler->setParameter("robot_velocity_variable_name", robotVelocity);
-
     parameterHandler->setParameter("verbosity", false);
+
+    parameterHandler->setParameter("tasks",
+                                   std::vector<std::string>{"SE3_TASK",
+                                                            "COM_TASK",
+                                                            "REGULARIZATION_TASK",
+                                                            "JOINT_LIMITS_TASK"});
 
     /////// SE3 Task
     auto SE3ParameterHandler = std::make_shared<StdImplementation>();
@@ -78,53 +85,71 @@ std::shared_ptr<IParametersHandler> createParameterHandler()
 
     SE3ParameterHandler->setParameter("kp_linear", gain);
     SE3ParameterHandler->setParameter("kp_angular", gain);
+    SE3ParameterHandler->setParameter("type", "SE3Task");
+    SE3ParameterHandler->setParameter("priority", 0);
     parameterHandler->setGroup("SE3_TASK", SE3ParameterHandler);
 
     /////// CoM task
     auto CoMParameterHandler = std::make_shared<StdImplementation>();
     CoMParameterHandler->setParameter("robot_velocity_variable_name", robotVelocity);
     CoMParameterHandler->setParameter("kp_linear", gain);
+    CoMParameterHandler->setParameter("type", "CoMTask");
+    CoMParameterHandler->setParameter("priority", 0);
     parameterHandler->setGroup("COM_TASK", CoMParameterHandler);
 
     /////// Joint regularization task
     auto jointRegularizationHandler = std::make_shared<StdImplementation>();
     jointRegularizationHandler->setParameter("robot_velocity_variable_name", robotVelocity);
+    jointRegularizationHandler->setParameter("type", "JointTrackingTask");
+    jointRegularizationHandler->setParameter("priority", 1);
     parameterHandler->setGroup("REGULARIZATION_TASK", jointRegularizationHandler);
+
 
     auto jointLimitsHandler = std::make_shared<StdImplementation>();
     jointLimitsHandler->setParameter("robot_velocity_variable_name", robotVelocity);
     jointLimitsHandler->setParameter("sampling_time", dT);
     jointLimitsHandler->setParameter("use_model_limits", false);
+    jointLimitsHandler->setParameter("type", "JointLimitsTask");
+    jointLimitsHandler->setParameter("priority", 0);
     parameterHandler->setGroup("JOINT_LIMITS_TASK", jointLimitsHandler);
 
     return parameterHandler;
 }
 
-InverseKinematicsAndTasks createIK(std::shared_ptr<IParametersHandler> handler,
-                                   std::shared_ptr<iDynTree::KinDynComputations> kinDyn,
-                                   const VariablesHandler& variables,
-                                   const System& system,
-                                   const Eigen::Ref<const Eigen::VectorXd>& jointsLimits)
+void finalizeParameterHandler(std::shared_ptr<IParametersHandler> handler,
+                              std::shared_ptr<iDynTree::KinDynComputations> kinDyn,
+                              const System& system,
+                              const Eigen::Ref<const Eigen::VectorXd>& jointsLimits)
 {
     // prepare the parameters related to the size of the system
     const Eigen::VectorXd kpRegularization = Eigen::VectorXd::Ones(kinDyn->model().getNrOfDOFs());
     const Eigen::VectorXd weightRegularization = kpRegularization;
     handler->getGroup("REGULARIZATION_TASK").lock()->setParameter("kp", kpRegularization);
+    handler->getGroup("REGULARIZATION_TASK").lock()->setParameter("weight", weightRegularization);
 
-    const Eigen::VectorXd kLimRegularization = 0.5 * Eigen::VectorXd::Ones(kinDyn->model().getNrOfDOFs());
+    const Eigen::VectorXd kLimRegularization
+        = 0.5 * Eigen::VectorXd::Ones(kinDyn->model().getNrOfDOFs());
     handler->getGroup("JOINT_LIMITS_TASK").lock()->setParameter("klim", kLimRegularization);
 
     const Eigen::VectorXd jointPositions = std::get<2>(system.dynamics->getState());
-    const Eigen::VectorXd upperLimits =  jointPositions + jointsLimits;
-    const Eigen::VectorXd lowerLimits =  jointPositions - jointsLimits;
+    const Eigen::VectorXd upperLimits = jointPositions + jointsLimits;
+    const Eigen::VectorXd lowerLimits = jointPositions - jointsLimits;
 
     handler->getGroup("JOINT_LIMITS_TASK").lock()->setParameter("upper_limits", upperLimits);
     handler->getGroup("JOINT_LIMITS_TASK").lock()->setParameter("lower_limits", lowerLimits);
+}
+
+InverseKinematicsAndTasks createIK(std::shared_ptr<IParametersHandler> handler,
+                                   std::shared_ptr<iDynTree::KinDynComputations> kinDyn,
+                                   const VariablesHandler& variables)
+{
 
     InverseKinematicsAndTasks out;
 
     constexpr std::size_t highPriority = 0;
     constexpr std::size_t lowPriority = 1;
+    Eigen::VectorXd kpRegularization;
+    Eigen::VectorXd weightRegularization;
 
     out.ik = std::make_shared<QPInverseKinematics>();
     REQUIRE(out.ik->initialize(handler));
@@ -139,6 +164,8 @@ InverseKinematicsAndTasks createIK(std::shared_ptr<IParametersHandler> handler,
     REQUIRE(out.comTask->initialize(handler->getGroup("COM_TASK")));
     REQUIRE(out.ik->addTask(out.comTask, "com_task", highPriority));
 
+    REQUIRE(handler->getGroup("REGULARIZATION_TASK").lock()->getParameter("kp", kpRegularization));
+    REQUIRE(handler->getGroup("REGULARIZATION_TASK").lock()->getParameter("weight", weightRegularization));
     out.regularizationTask = std::make_shared<JointTrackingTask>();
     REQUIRE(out.regularizationTask->setKinDyn(kinDyn));
     REQUIRE(out.regularizationTask->initialize(handler->getGroup("REGULARIZATION_TASK")));
@@ -277,12 +304,12 @@ TEST_CASE("QP-IK")
 
             // create the IK
             constexpr double jointLimitDelta = 0.5;
-            auto ikAndTasks = createIK(parameterHandler,
-                                       kinDyn,
-                                       variablesHandler,
-                                       system,
-                                       Eigen::VectorXd::Constant(kinDyn->model().getNrOfDOFs(),
-                                                                 jointLimitDelta));
+            finalizeParameterHandler(parameterHandler,
+                                     kinDyn,
+                                     system,
+                                     Eigen::VectorXd::Constant(kinDyn->model().getNrOfDOFs(),
+                                                               jointLimitDelta));
+            auto ikAndTasks = createIK(parameterHandler, kinDyn, variablesHandler);
 
             REQUIRE(ikAndTasks.se3Task->setSetPoint(desiredSetPoints.endEffectorPose,
                                                     manif::SE3d::Tangent::Zero()));
@@ -377,7 +404,8 @@ TEST_CASE("QP-IK [With strict limits]")
     limitsDelta(0) = 0;
     limitsDelta(3) = 0;
 
-    auto ikAndTasks = createIK(parameterHandler, kinDyn, variablesHandler, system, limitsDelta);
+    finalizeParameterHandler(parameterHandler, kinDyn, system, limitsDelta);
+    auto ikAndTasks = createIK(parameterHandler, kinDyn, variablesHandler);
 
     REQUIRE(ikAndTasks.se3Task->setSetPoint(desiredSetPoints.endEffectorPose,
                                             manif::SE3d::Tangent::Zero()));
@@ -428,4 +456,115 @@ TEST_CASE("QP-IK [With strict limits]")
         system.dynamics->setControlInput({baseVelocity, jointVelocity});
         system.integrator->integrate(0, dT);
     }
+}
+
+
+TEST_CASE("QP-IK [With builder]")
+{
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    auto parameterHandler = createParameterHandler();
+
+    constexpr double tolerance = 1e-1;
+
+    // set the velocity representation
+    REQUIRE(kinDyn->setFrameVelocityRepresentation(
+        iDynTree::FrameVelocityRepresentation::MIXED_REPRESENTATION));
+
+    constexpr std::size_t numberOfJoints = 30;
+
+    // create the model
+    const iDynTree::Model model = iDynTree::getRandomModel(numberOfJoints);
+    REQUIRE(kinDyn->loadRobotModel(model));
+
+    /////// VariableHandler and IK params
+    auto variablesParameterHandler = std::make_shared<StdImplementation>();
+    variablesParameterHandler->setParameter("variables_name",
+                                            std::vector<std::string>{robotVelocity});
+
+    const int generalizedRobotVelocitySize = kinDyn->model().getNrOfDOFs() + 6;
+    variablesParameterHandler->setParameter("variables_size",
+                                            std::vector<int>{generalizedRobotVelocitySize});
+    parameterHandler->setGroup("VARIABLES", variablesParameterHandler);
+
+    auto ikParameterHandler = std::make_shared<StdImplementation>();
+    ikParameterHandler->setParameter("robot_velocity_variable_name", robotVelocity);
+    parameterHandler->setGroup("IK", ikParameterHandler);
+
+    const auto desiredSetPoints = getDesiredReference(kinDyn, numberOfJoints);
+
+    auto system = getSystem(kinDyn);
+
+    // Set the frame name
+    const std::string controlledFrame = model.getFrameName(numberOfJoints);
+    parameterHandler->getGroup("SE3_TASK").lock()->setParameter("frame_name", controlledFrame);
+
+    // finalize the parameter handler
+    constexpr double jointLimitDelta = 0.5;
+    finalizeParameterHandler(parameterHandler,
+                             kinDyn,
+                             system,
+                             Eigen::VectorXd::Constant(kinDyn->model().getNrOfDOFs(),
+                                                       jointLimitDelta));
+
+    // automatic build the IK from parameter handler
+    auto [variablesHandler, ik] = QPInverseKinematics::build(parameterHandler, kinDyn);
+    REQUIRE_FALSE(ik == nullptr);
+
+
+    auto se3Task = std::dynamic_pointer_cast<SE3Task>(ik->getTask("SE3_TASK").lock());
+    REQUIRE_FALSE(se3Task == nullptr);
+    REQUIRE(se3Task->setSetPoint(desiredSetPoints.endEffectorPose, manif::SE3d::Tangent::Zero()));
+
+    auto comTask = std::dynamic_pointer_cast<CoMTask>(ik->getTask("COM_TASK").lock());
+    REQUIRE_FALSE(comTask == nullptr);
+    REQUIRE(comTask->setSetPoint(desiredSetPoints.CoMPosition, Eigen::Vector3d::Zero()));
+
+    auto regularizationTask
+        = std::dynamic_pointer_cast<JointTrackingTask>(ik->getTask("REGULARIZATION_TASK").lock());
+    REQUIRE_FALSE(regularizationTask == nullptr);
+    REQUIRE(regularizationTask->setSetPoint(desiredSetPoints.joints));
+
+    // propagate the inverse kinematics for
+    constexpr std::size_t iterations = 30;
+    Eigen::Vector3d gravity;
+    gravity << 0, 0, -9.81;
+    Eigen::Matrix4d baseTransform = Eigen::Matrix4d::Identity();
+    Eigen::Matrix<double, 6, 1> baseVelocity = Eigen::Matrix<double, 6, 1>::Zero();
+    Eigen::VectorXd jointVelocity = Eigen::VectorXd::Zero(model.getNrOfDOFs());
+    for (std::size_t iteration = 0; iteration < iterations; iteration++)
+    {
+        // get the solution of the integrator
+        const auto& [basePosition, baseRotation, jointPosition] = system.integrator->getSolution();
+
+        // update the KinDynComputations object
+        baseTransform.topLeftCorner<3, 3>() = baseRotation.rotation();
+        baseTransform.topRightCorner<3, 1>() = basePosition;
+        REQUIRE(kinDyn->setRobotState(baseTransform,
+                                      jointPosition,
+                                      baseVelocity,
+                                      jointVelocity,
+                                      gravity));
+
+        // solve the IK
+        REQUIRE(ik->advance());
+
+        // get the output of the IK
+        baseVelocity = ik->getOutput().baseVelocity.coeffs();
+        jointVelocity =ik->getOutput().jointVelocity;
+
+        // propagate the dynamical system
+        system.dynamics->setControlInput({baseVelocity, jointVelocity});
+        system.integrator->integrate(0, dT);
+    }
+
+    // check the CoM position
+    REQUIRE(desiredSetPoints.CoMPosition.isApprox(toEigen(kinDyn->getCenterOfMassPosition()),
+                                                  tolerance));
+
+    // Check the end-effector pose error
+    const manif::SE3d endEffectorPose = toManifPose(kinDyn->getWorldTransform(controlledFrame));
+
+    // please read it as (log(desiredSetPoints.endEffectorPose^-1 * endEffectorPose))^v
+    const manif::SE3d::Tangent error = endEffectorPose - desiredSetPoints.endEffectorPose;
+    REQUIRE(error.coeffs().isZero(tolerance));
 }

--- a/src/System/CMakeLists.txt
+++ b/src/System/CMakeLists.txt
@@ -12,7 +12,7 @@ if(FRAMEWORK_COMPILE_System)
     NAME                   System
     PUBLIC_HEADERS         ${H_PREFIX}/InputPort.h ${H_PREFIX}/OutputPort.h
                            ${H_PREFIX}/Advanceable.h ${H_PREFIX}/Source.h ${H_PREFIX}/Sink.h
-                           ${H_PREFIX}/VariablesHandler.h ${H_PREFIX}/LinearTask.h ${H_PREFIX}/ILinearTaskSolver.h ${H_PREFIX}/ITaskControllerManager.h
+                           ${H_PREFIX}/VariablesHandler.h ${H_PREFIX}/LinearTask.h ${H_PREFIX}/ILinearTaskSolver.h ${H_PREFIX}/ILinearTaskFactory.h ${H_PREFIX}/ITaskControllerManager.h
                            ${H_PREFIX}/IClock.h ${H_PREFIX}/StdClock.h ${H_PREFIX}/Clock.h
                            ${H_PREFIX}/SharedResource.h ${H_PREFIX}/AdvanceableRunner.h
                            ${H_PREFIX}/QuitHandler.h

--- a/src/System/include/BipedalLocomotion/System/ILinearTaskFactory.h
+++ b/src/System/include/BipedalLocomotion/System/ILinearTaskFactory.h
@@ -1,0 +1,107 @@
+/**
+ * @file ILinearTaskFactory.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SYSTEM_ILINEAR_TASK_FACTORY
+#define BIPEDAL_LOCOMOTION_SYSTEM_ILINEAR_TASK_FACTORY
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <BipedalLocomotion/System/LinearTask.h>
+
+/**
+ * BLF_REGISTER_TASK is a macro that can be used to register a task given a baseType. The key of the
+ * task will be the stringified version of the Task C++ Type
+ * @param _type the type of the task
+ * @param _baseType the base type from which the _task inherits.
+ */
+#define BLF_REGISTER_TASK(_type, _baseType)                   \
+    static std::shared_ptr<_baseType> _type##FactoryCreator() \
+    {                                                         \
+        return std::make_shared<_type>();                     \
+    };                                                        \
+                                                              \
+    static std::string _type##CreatorAutoRegHook              \
+        = ::BipedalLocomotion::System::ILinearTaskFactory<    \
+            _baseType>::registerCreator(#_type, _type##FactoryCreator);
+
+namespace BipedalLocomotion
+{
+namespace System
+{
+
+/**
+ * ILinearTaskFactory implements the factory design patter for constructing a linear task given its
+ * type.
+ */
+template <typename _Task> class ILinearTaskFactory
+{
+    static_assert(std::is_base_of_v<LinearTask, _Task>,
+                  "The _Task template argument of ILinearTaskFactory must inherits from "
+                  "LinearTask");
+
+public:
+    using Task = _Task;
+    using TaskCreator = typename std::add_pointer<std::shared_ptr<Task>()>::type; /**< Pointer to
+                                                                                     the task
+                                                                                     builder */
+
+private:
+    /**
+     * Get the map containing a map of idKey and the associated TaskCreator function.
+     * @return an unordered_map of idKey and pointer to create the task
+     */
+    static std::unordered_map<std::string, TaskCreator>& getMapFactory()
+    {
+        static std::unordered_map<std::string, TaskCreator> m_mapFactory;
+        return m_mapFactory;
+    }
+
+public:
+    /**
+     * Add a creator for a given task.
+     * @param idKey the string representing the type of the task. i.e., the stringify version of the
+     * class type
+     * @param classCreator pointer to the function that creates a given task.
+     * @return the idKey
+     */
+    static std::string registerCreator(std::string idKey, TaskCreator classCreator)
+    {
+        getMapFactory().insert(std::pair<std::string, TaskCreator>(idKey, classCreator));
+        return idKey;
+    }
+
+    /**
+     * Create an instance of a Task given its id.
+     * @param idKey the string representing the type of the task. i.e., the stringify version of the
+     * class type
+     * @return a pointer to the Task. In case of issues, the pointer will be a nullptr.
+     */
+    static std::shared_ptr<Task> createInstance(const std::string& idKey)
+    {
+        auto it = getMapFactory().find(idKey);
+        if (it == getMapFactory().end())
+        {
+            return std::shared_ptr<Task>();
+        }
+
+        if (it->second == nullptr)
+        {
+            return std::shared_ptr<Task>();
+        }
+
+        return it->second();
+    }
+
+    virtual ~ILinearTaskFactory() = default;
+};
+} // namespace System
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SYSTEM_ILINEAR_TASK_FACTORY


### PR DESCRIPTION
This PR adds the possibility to build an IK problem directly from a configuration file.

This means that the if the user provides a suitable config file (an example is added in the documentation), all the tasks are automatically built and the `QPInverseKinematics` is finalized.
The only thing the user has to do is to provide the setpoints for the tasks.

This is achieved by following
```cpp
auto [variableHandler, solver] = BipedalLocomotion::IK::QPInverseKinematics::build(paramHandler, kinDyn)
```

where `paramHandler` is a `std::weak_ptr<IParameterHandler>` and `kinDyn` is a `std::shared_ptr<iDynTree::KinDynComputations>`.

This feature is implemented by using the factory design pattern. After declaring a new task, the user must call the following macro
```cpp
BLF_REGISTER_IK_TASK(TaskType);
```
This macro will register a new entry that maps a stringified version of the `TaskType` and a function that creates the Task.

---

@isorrentino 