### PR TITLE
Add WeightProvider factory and implement IntegrationBasedIKProblem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project are documented in this file.
 - Implement the python bindings for `YarpTextLogging` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/611)
 - Add SubModelKinDynWrapper class to handle the `KinDynComputation` object of a sub-model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/605)
 - Implement the `JointLimitsTask` for the IK (https://github.com/ami-iit/bipedal-locomotion-framework/pull/603)
-- Add the possibility to programmatically build an IK problem from a configuration file (https://github.com/ami-iit/bipedal-locomotion-framework/pull/614)
+- Add the possibility to programmatically build an IK problem from a configuration file (https://github.com/ami-iit/bipedal-locomotion-framework/pull/614, https://github.com/ami-iit/bipedal-locomotion-framework/pull/619)
 
 ### Changed
 - Ask for `toml++ v3.0.1` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/581)

--- a/bindings/python/IK/src/IntegrationBasedIK.cpp
+++ b/bindings/python/IK/src/IntegrationBasedIK.cpp
@@ -7,6 +7,7 @@
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
 
 #include <BipedalLocomotion/IK/IntegrationBasedIK.h>
@@ -44,6 +45,37 @@ void CreateIntegrationBasedIK(pybind11::module& module)
     py::class_<IntegrationBasedIK, //
                ILinearTaskSolver<IKLinearTask, IntegrationBasedIKState>>(module,
                                                                          "IntegrationBasedIK");
+
+    py::class_<IntegrationBasedIKProblem>(module, "IntegrationBasedIKProblem")
+        .def_readwrite("variables_handler", &IntegrationBasedIKProblem::variablesHandler)
+        .def_readwrite("weights", &IntegrationBasedIKProblem::weights)
+        .def_property_readonly(
+            "ik",
+            [](const IntegrationBasedIKProblem& impl) { return impl.ik.get(); },
+            py::return_value_policy::reference_internal)
+        .def("__getitem__",
+             [](IntegrationBasedIKProblem& impl, int index) -> py::object {
+                 if (index == 0)
+                 {
+                     return py::cast(impl.variablesHandler);
+                 }
+                 if (index == 1)
+                 {
+                     return py::cast(impl.weights);
+                 }
+                 if (index == 2)
+                 {
+                     // in this case the onwership of the object is taken py python.
+                     // Python will call the destructor and delete operator when the object’s
+                     // reference count reaches zero. Undefined behavior ensues when the C++ side
+                     // does the same, or when the data was not dynamically allocated. (This will
+                     // not happen since the reasle is called)
+                     return py::cast(impl.ik.release(), py::return_value_policy::take_ownership);
+                 }
+
+                 throw pybind11::index_error();
+             })
+        .def("is_valid", &IntegrationBasedIKProblem::isValid);
 }
 
 } // namespace IK

--- a/bindings/python/IK/src/QPInverseKinematics.cpp
+++ b/bindings/python/IK/src/QPInverseKinematics.cpp
@@ -37,7 +37,7 @@ void CreateQPInverseKinematics(pybind11::module& module)
         .def_static(
             "build",
             [](std::shared_ptr<const IParametersHandler> handler, py::object& obj)
-                -> std::pair<VariablesHandler, std::unique_ptr<QPInverseKinematics>> {
+                -> IntegrationBasedIKProblem {
 
                 // get the kindyn computation object from the swig binsings
                 std::shared_ptr<iDynTree::KinDynComputations>* cls

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/MultiStateWeightProvider.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/MultiStateWeightProvider.h
@@ -91,6 +91,9 @@ private:
                                                                    the provider */
     FirstOrderSmoother m_smoother; /**< Smoother required to perform the weight scheduling */
 };
+
+BLF_REGISTER_WEIGHT_PROVIDER(MultiStateWeightProvider);
+
 } // namespace ContinuousDynamicalSystem
 } // namespace BipedalLocomotion
 

--- a/src/IK/CMakeLists.txt
+++ b/src/IK/CMakeLists.txt
@@ -12,7 +12,7 @@ if(FRAMEWORK_COMPILE_IK)
                            ${H_PREFIX}/AngularMomentumTask.h ${H_PREFIX}/JointLimitsTask.h ${H_PREFIX}/QPFixedBaseInverseKinematics.h
                            ${H_PREFIX}/QPInverseKinematics.h ${H_PREFIX}/IKLinearTask.h
     SOURCES                src/R3Task.cpp src/SE3Task.cpp src/SO3Task.cpp src/JointTrackingTask.cpp src/CoMTask.cpp src/AngularMomentumTask.cpp src/JointLimitsTask.cpp
-                           src/QPInverseKinematics.cpp src/QPFixedBaseInverseKinematics.cpp src/IKLinearTask.cpp
+                           src/QPInverseKinematics.cpp src/QPFixedBaseInverseKinematics.cpp src/IKLinearTask.cpp src/IntegrationBasedIK.cpp
     PUBLIC_LINK_LIBRARIES  Eigen3::Eigen
                            BipedalLocomotion::ParametersHandler BipedalLocomotion::System
                            LieGroupControllers::LieGroupControllers

--- a/src/IK/include/BipedalLocomotion/IK/IntegrationBasedIK.h
+++ b/src/IK/include/BipedalLocomotion/IK/IntegrationBasedIK.h
@@ -8,11 +8,16 @@
 #ifndef BIPEDAL_LOCOMOTION_IK_INTEGRATION_BASE_IK_H
 #define BIPEDAL_LOCOMOTION_IK_INTEGRATION_BASE_IK_H
 
+#include <unordered_map>
+#include <type_traits>
+
 #include <Eigen/Dense>
 #include <manif/SE3.h>
 
 #include <BipedalLocomotion/IK/IKLinearTask.h>
 #include <BipedalLocomotion/System/ILinearTaskSolver.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/System/WeightProvider.h>
 
 namespace BipedalLocomotion
 {
@@ -63,7 +68,78 @@ public:
      */
     virtual ~IntegrationBasedIK() = default;
 };
+
+/**
+ * IntegrationBasedIKProblem store all the ingredients to run an modfy at runtime an
+ * Integration based inverse kinematics problem.
+ */
+struct IntegrationBasedIKProblem
+{
+    System::VariablesHandler variablesHandler; /**< Container of the variables considered by the IK
+                                                * problem
+                                                */
+    /** Map containing the weight associated to each task stored considering the task name */
+    std::unordered_map<std::string, std::shared_ptr<System::WeightProvider>> weights;
+    std::unique_ptr<IntegrationBasedIK> ik; /**< Pointer to the IK solver */
+
+    /**
+     * Check if the problem is valid.
+     * @return true if the problem is valid.
+     */
+    [[nodiscard]] bool isValid() const;
+
+    /**
+     * Get the element of the problem from a given index.
+     * @tparam index a positive number from 0 to 2.
+     * @note 0 is associated to the variablesHandler, 1 to the weights and 2 to the ik. Thanks to
+     * this method the IntegrationBasedIKProblem behaves as a tuple. I.e., the
+     * [`std::tie()`](https://en.cppreference.com/w/cpp/utility/tuple/tie) or
+     * [Structured binding declaration](https://en.cppreference.com/w/cpp/language/structured_binding)
+     * are supported by IntegrationBasedIKProblem.
+     * @note the implementation of this method was taken from
+     * https://devblogs.microsoft.com/oldnewthing/20201015-00/?p=104369
+     */
+    template <std::size_t index> std::tuple_element_t<index, IntegrationBasedIKProblem>& get()
+    {
+        if constexpr (index == 0)
+        {
+            return variablesHandler;
+        }
+        if constexpr (index == 1)
+        {
+            return weights;
+        }
+        if constexpr (index == 2)
+        {
+            return ik;
+        }
+    }
+};
+
 } // namespace IK
 } // namespace BipedalLocomotion
+
+namespace std
+{
+
+// The following methods are required to make ::BipedalLocomotion::IK::IntegrationBasedIKProblem
+// behaving as a tuple. Please check here:
+// https://devblogs.microsoft.com/oldnewthing/20201015-00/?p=104369
+template <>
+struct tuple_size<::BipedalLocomotion::IK::IntegrationBasedIKProblem> : integral_constant<size_t, 3>
+{
+};
+
+template <size_t Index>
+struct tuple_element<Index, ::BipedalLocomotion::IK::IntegrationBasedIKProblem>
+    : tuple_element<
+          Index,
+          tuple<::BipedalLocomotion::System::VariablesHandler,
+                unordered_map<string, shared_ptr<::BipedalLocomotion::System::WeightProvider>>,
+                unique_ptr<::BipedalLocomotion::IK::IntegrationBasedIK>>>
+{
+};
+
+} // namespace std
 
 #endif // BIPEDAL_LOCOMOTION_IK_INTEGRATION_BASE_INVERSE_KINEMATICS_H

--- a/src/IK/src/IntegrationBasedIK.cpp
+++ b/src/IK/src/IntegrationBasedIK.cpp
@@ -1,0 +1,15 @@
+/**
+ * @file IntegrationBasedIK.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/IK/IntegrationBasedIK.h>
+
+using namespace BipedalLocomotion::IK;
+
+bool IntegrationBasedIKProblem::isValid() const
+{
+    return this->ik != nullptr;
+}

--- a/src/IK/tests/QPInverseKinematicsTest.cpp
+++ b/src/IK/tests/QPInverseKinematicsTest.cpp
@@ -507,7 +507,7 @@ TEST_CASE("QP-IK [With builder]")
                                                        jointLimitDelta));
 
     // automatic build the IK from parameter handler
-    auto [variablesHandler, ik] = QPInverseKinematics::build(parameterHandler, kinDyn);
+    auto [variablesHandler, weights, ik] = QPInverseKinematics::build(parameterHandler, kinDyn);
     REQUIRE_FALSE(ik == nullptr);
 
 
@@ -556,6 +556,13 @@ TEST_CASE("QP-IK [With builder]")
         system.dynamics->setControlInput({baseVelocity, jointVelocity});
         system.integrator->integrate(0, dT);
     }
+
+    auto weightProvider
+        = std::dynamic_pointer_cast<const BipedalLocomotion::System::ConstantWeightProvider>(
+            ik->getTaskWeightProvider("REGULARIZATION_TASK").lock());
+
+
+    REQUIRE(weightProvider != nullptr);
 
     // check the CoM position
     REQUIRE(desiredSetPoints.CoMPosition.isApprox(toEigen(kinDyn->getCenterOfMassPosition()),

--- a/src/System/CMakeLists.txt
+++ b/src/System/CMakeLists.txt
@@ -12,6 +12,7 @@ if(FRAMEWORK_COMPILE_System)
     NAME                   System
     PUBLIC_HEADERS         ${H_PREFIX}/InputPort.h ${H_PREFIX}/OutputPort.h
                            ${H_PREFIX}/Advanceable.h ${H_PREFIX}/Source.h ${H_PREFIX}/Sink.h
+                           ${H_PREFIX}/Factory.h
                            ${H_PREFIX}/VariablesHandler.h ${H_PREFIX}/LinearTask.h ${H_PREFIX}/ILinearTaskSolver.h ${H_PREFIX}/ILinearTaskFactory.h ${H_PREFIX}/ITaskControllerManager.h
                            ${H_PREFIX}/IClock.h ${H_PREFIX}/StdClock.h ${H_PREFIX}/Clock.h
                            ${H_PREFIX}/SharedResource.h ${H_PREFIX}/AdvanceableRunner.h

--- a/src/System/include/BipedalLocomotion/System/ConstantWeightProvider.h
+++ b/src/System/include/BipedalLocomotion/System/ConstantWeightProvider.h
@@ -68,6 +68,9 @@ public:
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
 };
+
+BLF_REGISTER_WEIGHT_PROVIDER(ConstantWeightProvider);
+
 } // namespace System
 } // namespace BipedalLocomotion
 

--- a/src/System/include/BipedalLocomotion/System/Factory.h
+++ b/src/System/include/BipedalLocomotion/System/Factory.h
@@ -1,0 +1,85 @@
+/**
+ * @file Factory.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SYSTEM_FACTORY
+#define BIPEDAL_LOCOMOTION_SYSTEM_FACTORY
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+namespace BipedalLocomotion
+{
+namespace System
+{
+
+/**
+ * Factory implements the factory design patter for constructing a an object of a given Type given
+ * its id.
+ */
+template <typename _Type> class Factory
+{
+public:
+    using Type = _Type;
+    using Builder = typename std::add_pointer<std::shared_ptr<Type>()>::type; /**< Pointer to the
+                                                                                 Type builder */
+
+private:
+    /**
+     * Get the map containing a map of idKey and the associated Builder function.
+     * @return an unordered_map of idKey and pointer to create the Type
+     */
+    static std::unordered_map<std::string, Builder>& getMapFactory()
+    {
+        static std::unordered_map<std::string, Builder> m_mapFactory;
+        return m_mapFactory;
+    }
+
+public:
+    /**
+     * Add a Builder for a given Type.
+     * @param idKey the string representing the type of the Type. i.e., the stringify version of the
+     * class type
+     * @param classBuilder pointer to the function that creates a given Type.
+     * @return the idKey
+     */
+    static std::string registerBuilder(std::string idKey, Builder classBuilder)
+    {
+        getMapFactory().insert(std::pair<std::string, Builder>(idKey, classBuilder));
+        return idKey;
+    }
+
+    /**
+     * Create an instance of a Type given its id.
+     * @param idKey the string representing the type of the Type. i.e., the stringify version of the
+     * class type
+     * @return a pointer to the Type. In case of issues, the pointer will be a nullptr.
+     */
+    static std::shared_ptr<Type> createInstance(const std::string& idKey)
+    {
+        auto it = getMapFactory().find(idKey);
+        if (it == getMapFactory().end())
+        {
+            return std::shared_ptr<Type>();
+        }
+
+        if (it->second == nullptr)
+        {
+            return std::shared_ptr<Type>();
+        }
+
+        return it->second();
+    }
+
+    virtual ~Factory() = default;
+};
+} // namespace System
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SYSTEM_FACTORY

--- a/src/System/include/BipedalLocomotion/System/ILinearTaskFactory.h
+++ b/src/System/include/BipedalLocomotion/System/ILinearTaskFactory.h
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <utility>
 
+#include <BipedalLocomotion/System/Factory.h>
 #include <BipedalLocomotion/System/LinearTask.h>
 
 /**
@@ -22,14 +23,14 @@
  * @param _baseType the base type from which the _task inherits.
  */
 #define BLF_REGISTER_TASK(_type, _baseType)                   \
-    static std::shared_ptr<_baseType> _type##FactoryCreator() \
+    static std::shared_ptr<_baseType> _type##FactoryBuilder() \
     {                                                         \
         return std::make_shared<_type>();                     \
     };                                                        \
                                                               \
-    static std::string _type##CreatorAutoRegHook              \
+    static std::string _type##BuilderAutoRegHook              \
         = ::BipedalLocomotion::System::ILinearTaskFactory<    \
-            _baseType>::registerCreator(#_type, _type##FactoryCreator);
+            _baseType>::registerBuilder(#_type, _type##FactoryBuilder);
 
 namespace BipedalLocomotion
 {
@@ -40,64 +41,15 @@ namespace System
  * ILinearTaskFactory implements the factory design patter for constructing a linear task given its
  * type.
  */
-template <typename _Task> class ILinearTaskFactory
+template <typename _Task> class ILinearTaskFactory : public Factory<_Task>
 {
     static_assert(std::is_base_of_v<LinearTask, _Task>,
                   "The _Task template argument of ILinearTaskFactory must inherits from "
                   "LinearTask");
 
 public:
-    using Task = _Task;
-    using TaskCreator = typename std::add_pointer<std::shared_ptr<Task>()>::type; /**< Pointer to
-                                                                                     the task
-                                                                                     builder */
-
-private:
-    /**
-     * Get the map containing a map of idKey and the associated TaskCreator function.
-     * @return an unordered_map of idKey and pointer to create the task
-     */
-    static std::unordered_map<std::string, TaskCreator>& getMapFactory()
-    {
-        static std::unordered_map<std::string, TaskCreator> m_mapFactory;
-        return m_mapFactory;
-    }
-
-public:
-    /**
-     * Add a creator for a given task.
-     * @param idKey the string representing the type of the task. i.e., the stringify version of the
-     * class type
-     * @param classCreator pointer to the function that creates a given task.
-     * @return the idKey
-     */
-    static std::string registerCreator(std::string idKey, TaskCreator classCreator)
-    {
-        getMapFactory().insert(std::pair<std::string, TaskCreator>(idKey, classCreator));
-        return idKey;
-    }
-
-    /**
-     * Create an instance of a Task given its id.
-     * @param idKey the string representing the type of the task. i.e., the stringify version of the
-     * class type
-     * @return a pointer to the Task. In case of issues, the pointer will be a nullptr.
-     */
-    static std::shared_ptr<Task> createInstance(const std::string& idKey)
-    {
-        auto it = getMapFactory().find(idKey);
-        if (it == getMapFactory().end())
-        {
-            return std::shared_ptr<Task>();
-        }
-
-        if (it->second == nullptr)
-        {
-            return std::shared_ptr<Task>();
-        }
-
-        return it->second();
-    }
+    using Task = typename Factory<_Task>::Type;
+    using TaskBuilder = typename Factory<_Task>::Builder;
 
     virtual ~ILinearTaskFactory() = default;
 };

--- a/src/System/include/BipedalLocomotion/System/WeightProvider.h
+++ b/src/System/include/BipedalLocomotion/System/WeightProvider.h
@@ -8,7 +8,22 @@
 #ifndef BIPEDAL_LOCOMOTION_SYSTEM_WEIGHT_PROVIDER_H
 #define BIPEDAL_LOCOMOTION_SYSTEM_WEIGHT_PROVIDER_H
 
+#include <BipedalLocomotion/System/Factory.h>
 #include <BipedalLocomotion/System/Source.h>
+
+/**
+ * BLF_REGISTER_WEIGHT_PROVIDER is a macro that can be used to register a WeightProvider. The key of
+ * the task will be the stringified version of the Task C++ Type
+ * @param _type the type of the task
+ */
+#define BLF_REGISTER_WEIGHT_PROVIDER(_type)                                                     \
+    static std::shared_ptr<::BipedalLocomotion::System::WeightProvider> _type##FactoryBuilder() \
+    {                                                                                           \
+        return std::make_shared<_type>();                                                       \
+    };                                                                                          \
+                                                                                                \
+    static std::string _type##BuilderAutoRegHook = ::BipedalLocomotion::System::                \
+        WeightProviderFactory::registerBuilder(#_type, _type##FactoryBuilder);
 
 namespace BipedalLocomotion
 {
@@ -20,6 +35,17 @@ namespace System
  */
 struct WeightProvider : public Source<Eigen::VectorXd>
 {
+};
+
+/**
+ * WeightProviderFactory implements the factory design patter for constructing a WeightProvidergiven
+ * its type.
+ */
+class WeightProviderFactory : public Factory<WeightProvider>
+{
+
+public:
+    virtual ~WeightProviderFactory() = default;
 };
 
 } // namespace System


### PR DESCRIPTION
This PR complements #614, in detail, it will allow the user to pass different kinds of WeightProviders to the IK directly from the configuration file.
Moreover, I introduced the `IntegrationBasedIKProblem` that stores all the ingredients required to solve the IK problem. 