### PR TITLE
Return an error if an invalid KinDynComputations object is passed to `QPInverseKinematics::build()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Update the `IK tutorial` to use `QPInverseKinematics::build` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/621)
 
 ### Fixed
+- Return an error if an invalid `KinDynComputations` object is passed to `QPInverseKinematics::build()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/622)
 
 ## [0.12.0] - 2023-03-07
 ### Added

--- a/src/IK/src/QPInverseKinematics.cpp
+++ b/src/IK/src/QPInverseKinematics.cpp
@@ -625,6 +625,12 @@ QPInverseKinematics::build(std::weak_ptr<const ParametersHandler::IParametersHan
         return IntegrationBasedIKProblem();
     }
 
+    if (kinDyn == nullptr || !kinDyn->isValid())
+    {
+        log()->error("{} Invalid iDynTree::KinDynComputations object.", logPrefix);
+        return IntegrationBasedIKProblem();
+    }
+
     std::unique_ptr<QPInverseKinematics> solver = std::make_unique<QPInverseKinematics>();
     std::unordered_map<std::string, std::shared_ptr<System::WeightProvider>> weights;
 


### PR DESCRIPTION
cc @LoreMoretti 