### PR TITLE
Restructure ContactDetector machinery 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project are documented in this file.
 ## [unreleased]
 ### Added
 - Implement the `DiscreteGeometryContact` in Contacts component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/626)
+- Implement the `SchmittTrigger` in component `Math` and the associated python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/624)
 
 ### Changed
 - Update the `IK tutorial` to use `QPInverseKinematics::build` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/621)
 - Handle case where no FT sensors are specified to split the model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/625)
+- General restructure of the `ContactDetector`and the derived classes (`SchmittTriggerDetector` and `FixedFootDetector`) (https://github.com/ami-iit/bipedal-locomotion-framework/pull/624)
+  Thanks to this refactory the `FixedFootDetector` usage becomes similar to the others `advanceable`.
+  Indeed now `FixedFootDetector::advace()` considers the input set by the user and provides the corresponding output.
+  ⚠️  Even if this modification do not break the API the user may notice some strange behavior if `advance` was called after getting the output of the detector.
 
 ### Fixed
 - Return an error if an invalid `KinDynComputations` object is passed to `QPInverseKinematics::build()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/622)

--- a/bindings/python/Contacts/include/BipedalLocomotion/bindings/Contacts/ContactDetectors.h
+++ b/bindings/python/Contacts/include/BipedalLocomotion/bindings/Contacts/ContactDetectors.h
@@ -1,7 +1,7 @@
 /**
  * @file ContactDetectors.h
  * @authors Giulio Romualdi
- * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * @copyright 2021-2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the BSD-3-Clause license.
  */
 
@@ -18,7 +18,6 @@ namespace Contacts
 {
 
 void CreateContactDetector(pybind11::module& module);
-void CreateSchmittTriggerUnit(pybind11::module& module);
 void CreateSchmittTriggerDetector(pybind11::module& module);
 void CreateFixedFootDetector(pybind11::module& module);
 

--- a/bindings/python/Contacts/src/Module.cpp
+++ b/bindings/python/Contacts/src/Module.cpp
@@ -28,7 +28,6 @@ void CreateModule(pybind11::module& module)
     CreateContactListJsonParser(module);
 
     CreateContactDetector(module);
-    CreateSchmittTriggerUnit(module);
     CreateSchmittTriggerDetector(module);
     CreateFixedFootDetector(module);
 }

--- a/bindings/python/Contacts/tests/test_schmitt_trigger_detector.py
+++ b/bindings/python/Contacts/tests/test_schmitt_trigger_detector.py
@@ -22,11 +22,14 @@ def test_schmitt_trigger_detector():
     assert(detector.reset_contacts())
 
     # rise signal
-    assert(detector.set_timed_trigger_input("right", 0.1, 120.0))
+    assert(detector.set_timed_trigger_input("right",
+                                            blf.math.SchmittTriggerInput(time=0.1, raw_value=120.0)))
     assert(detector.advance())
-    assert(detector.set_timed_trigger_input("right", 0.2, 120.0))
+    assert(detector.set_timed_trigger_input("right",
+                                            blf.math.SchmittTriggerInput(time=0.2, raw_value=120.0)))
     assert(detector.advance())
-    assert(detector.set_timed_trigger_input("right", 0.3, 120.0))
+    assert(detector.set_timed_trigger_input("right",
+                                            blf.math.SchmittTriggerInput(time=0.3, raw_value=120.0)))
     assert(detector.advance())
 
     # contact state should turn true
@@ -35,11 +38,14 @@ def test_schmitt_trigger_detector():
     assert(right_contact.switch_time == 0.3)
 
     # fall signal
-    assert(detector.set_timed_trigger_input("right", 0.4, 7.0))
+    assert(detector.set_timed_trigger_input("right",
+                                            blf.math.SchmittTriggerInput(time=0.4, raw_value=7.0)))
     assert(detector.advance())
-    assert(detector.set_timed_trigger_input("right", 0.5, 7.0))
+    assert(detector.set_timed_trigger_input("right",
+                                            blf.math.SchmittTriggerInput(time=0.5, raw_value=7.0)))
     assert(detector.advance())
-    assert(detector.set_timed_trigger_input("right", 0.6, 7.0))
+    assert(detector.set_timed_trigger_input("right",
+                                            blf.math.SchmittTriggerInput(time=0.6, raw_value=7.0)))
     assert(detector.advance())
 
     # contact state should turn false
@@ -48,23 +54,22 @@ def test_schmitt_trigger_detector():
     assert(right_contact.switch_time == 0.6)
 
     # add a new contact
-    params = blf.contacts.SchmittTriggerParams()
-    params.off_threshold = 10
-    params.on_threshold = 100
-    params.switch_off_after = 0.2
-    params.switch_on_after = 0.2
-    detector.add_contact("left", False, params, 0.6)
+    params = blf.math.SchmittTrigger.Params(off_threshold=10, on_threshold=100,
+                                            switch_off_after=0.2, switch_on_after=0.2)
+    detector.add_contact("left",
+                         blf.math.SchmittTriggerState(state=False, switch_time=0.6, edge_time=0.6),
+                         params)
     contacts = detector.get_output()
     assert(len(contacts) == 2)
     assert(contacts["right"].is_active == False)
 
     # test multiple measurement updates
-    right_input = blf.contacts.SchmittTriggerInput()
+    right_input = blf.math.SchmittTriggerInput()
     right_input.time = 0.7
-    right_input.value = 120
-    left_input = blf.contacts.SchmittTriggerInput()
+    right_input.raw_value = 120
+    left_input = blf.math.SchmittTriggerInput()
     left_input.time = 0.7
-    left_input.value = 120
+    left_input.raw_value = 120
     timed_inputs = {"right":right_input, "left":left_input}
     assert(detector.set_timed_trigger_inputs(timed_inputs))
 

--- a/bindings/python/Math/CMakeLists.txt
+++ b/bindings/python/Math/CMakeLists.txt
@@ -6,7 +6,7 @@ set(H_PREFIX include/BipedalLocomotion/bindings/Math)
 
 add_bipedal_locomotion_python_module(
   NAME MathBindings
-  SOURCES src/Constants.cpp src/Module.cpp
-  HEADERS ${H_PREFIX}/Constants.h ${H_PREFIX}/Module.h
+  SOURCES src/Constants.cpp src/SchmittTrigger.cpp src/Module.cpp
+  HEADERS ${H_PREFIX}/Constants.h ${H_PREFIX}/SchmittTrigger.h ${H_PREFIX}/Module.h
   LINK_LIBRARIES BipedalLocomotion::Math
   )

--- a/bindings/python/Math/include/BipedalLocomotion/bindings/Math/SchmittTrigger.h
+++ b/bindings/python/Math/include/BipedalLocomotion/bindings/Math/SchmittTrigger.h
@@ -1,0 +1,26 @@
+/**
+ * @file SchmittTrigger.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_MATH_SCHMITT_TRIGGER_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_MATH_SCHMITT_TRIGGER_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace Math
+{
+
+void CreateSchmittTrigger(pybind11::module& module);
+
+} // namespace Math
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_MATH_SCHMITT_TRIGGER_H

--- a/bindings/python/Math/src/Module.cpp
+++ b/bindings/python/Math/src/Module.cpp
@@ -1,15 +1,15 @@
 /**
  * @file Module.cpp
  * @authors Giulio Romualdi
- * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * @copyright 2021-2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <pybind11/pybind11.h>
 
-#include <BipedalLocomotion/bindings/Math/Module.h>
-
 #include <BipedalLocomotion/bindings/Math/Constants.h>
+#include <BipedalLocomotion/bindings/Math/Module.h>
+#include <BipedalLocomotion/bindings/Math/SchmittTrigger.h>
 
 namespace BipedalLocomotion
 {
@@ -22,6 +22,7 @@ void CreateModule(pybind11::module& module)
     module.doc() = "Math module contains the bindings for BipedalLocomotion::Math";
 
     CreateConstants(module);
+    CreateSchmittTrigger(module);
 }
 } // namespace Math
 } // namespace bindings

--- a/bindings/python/Math/src/SchmittTrigger.cpp
+++ b/bindings/python/Math/src/SchmittTrigger.cpp
@@ -25,13 +25,25 @@ void CreateSchmittTrigger(pybind11::module& module)
     namespace py = ::pybind11;
 
     py::class_<SchmittTriggerState>(module, "SchmittTriggerState")
-        .def(py::init<>())
+        .def(py::init([](bool state, double switchTime, double edgeTime) -> SchmittTriggerState {
+                 return SchmittTriggerState{.state = std::move(state),
+                                            .switchTime = std::move(switchTime),
+                                            .edgeTime = std::move(edgeTime)};
+             }),
+             py::arg("state") = false,
+             py::arg("switch_time") = 0.0,
+             py::arg("edge_time") = 0.0)
         .def_readwrite("state", &SchmittTriggerState::state)
         .def_readwrite("switch_time", &SchmittTriggerState::switchTime)
         .def_readwrite("edge_time", &SchmittTriggerState::edgeTime);
 
     py::class_<SchmittTriggerInput>(module, "SchmittTriggerInput")
-        .def(py::init<>())
+        .def(py::init([](double time, double rawValue) -> SchmittTriggerInput {
+                 return SchmittTriggerInput{.time = std::move(time),
+                                            .rawValue = std::move(rawValue)};
+             }),
+             py::arg("time") = 0.0,
+             py::arg("raw_value") = 0.0)
         .def_readwrite("time", &SchmittTriggerInput::time)
         .def_readwrite("raw_value", &SchmittTriggerInput::rawValue);
 
@@ -40,17 +52,34 @@ void CreateSchmittTrigger(pybind11::module& module)
         BipedalLocomotion::Math::SchmittTriggerState>(module, "SchmittTrigger");
 
     py::class_<SchmittTrigger,
-               BipedalLocomotion::System::Advanceable<SchmittTriggerInput, //
-                                                      SchmittTriggerState>>
+               ::BipedalLocomotion::System::Advanceable<SchmittTriggerInput, //
+                                                        SchmittTriggerState>>
         schmittTrigger(module, "SchmittTrigger");
 
     py::class_<SchmittTrigger::Params>(schmittTrigger, "Params")
-        .def(py::init())
+        .def(py::init([](double onThreshold,
+                         double offThreshold,
+                         double switchOnAfter,
+                         double switchOffAfter,
+                         double timeComparisonThreshold) -> SchmittTrigger::Params {
+                 return SchmittTrigger::Params{.onThreshold = std::move(onThreshold),
+                                               .offThreshold = std::move(offThreshold),
+                                               .switchOnAfter = std::move(switchOnAfter),
+                                               .switchOffAfter = std::move(switchOffAfter),
+                                               .timeComparisonThreshold
+                                               = std::move(timeComparisonThreshold)};
+             }),
+             py::arg("on_threshold") = 0.0,
+             py::arg("off_threshold") = 0.0,
+             py::arg("switch_on_after") = 0.0,
+             py::arg("switch_off_after") = 0.0,
+             py::arg("time_comparison_threshold") = std::numeric_limits<double>::epsilon())
         .def_readwrite("on_threshold", &SchmittTrigger::Params::onThreshold)
         .def_readwrite("off_threshold", &SchmittTrigger::Params::offThreshold)
         .def_readwrite("switch_on_after", &SchmittTrigger::Params::switchOnAfter)
         .def_readwrite("switch_off_after", &SchmittTrigger::Params::switchOffAfter)
-        .def_readwrite("time_comparison_threshold", &SchmittTrigger::Params::timeComparisonThreshold);
+        .def_readwrite("time_comparison_threshold",
+                       &SchmittTrigger::Params::timeComparisonThreshold);
 
     schmittTrigger.def(py::init())
         .def("set_state", &SchmittTrigger::setState, py::arg("state"))

--- a/bindings/python/Math/src/SchmittTrigger.cpp
+++ b/bindings/python/Math/src/SchmittTrigger.cpp
@@ -26,9 +26,9 @@ void CreateSchmittTrigger(pybind11::module& module)
 
     py::class_<SchmittTriggerState>(module, "SchmittTriggerState")
         .def(py::init([](bool state, double switchTime, double edgeTime) -> SchmittTriggerState {
-                 return SchmittTriggerState{.state = std::move(state),
-                                            .switchTime = std::move(switchTime),
-                                            .edgeTime = std::move(edgeTime)};
+                 return SchmittTriggerState{std::move(state),
+                                            std::move(switchTime),
+                                            std::move(edgeTime)};
              }),
              py::arg("state") = false,
              py::arg("switch_time") = 0.0,
@@ -39,8 +39,7 @@ void CreateSchmittTrigger(pybind11::module& module)
 
     py::class_<SchmittTriggerInput>(module, "SchmittTriggerInput")
         .def(py::init([](double time, double rawValue) -> SchmittTriggerInput {
-                 return SchmittTriggerInput{.time = std::move(time),
-                                            .rawValue = std::move(rawValue)};
+                 return SchmittTriggerInput{std::move(time), std::move(rawValue)};
              }),
              py::arg("time") = 0.0,
              py::arg("raw_value") = 0.0)
@@ -62,12 +61,13 @@ void CreateSchmittTrigger(pybind11::module& module)
                          double switchOnAfter,
                          double switchOffAfter,
                          double timeComparisonThreshold) -> SchmittTrigger::Params {
-                 return SchmittTrigger::Params{.onThreshold = std::move(onThreshold),
-                                               .offThreshold = std::move(offThreshold),
-                                               .switchOnAfter = std::move(switchOnAfter),
-                                               .switchOffAfter = std::move(switchOffAfter),
-                                               .timeComparisonThreshold
-                                               = std::move(timeComparisonThreshold)};
+                 SchmittTrigger::Params params;
+                 params.onThreshold = std::move(onThreshold);
+                 params.offThreshold = std::move(offThreshold);
+                 params.switchOnAfter = std::move(switchOnAfter);
+                 params.switchOffAfter = std::move(switchOffAfter);
+                 params.timeComparisonThreshold = std::move(timeComparisonThreshold);
+                 return params;
              }),
              py::arg("on_threshold") = 0.0,
              py::arg("off_threshold") = 0.0,

--- a/bindings/python/Math/src/SchmittTrigger.cpp
+++ b/bindings/python/Math/src/SchmittTrigger.cpp
@@ -1,0 +1,63 @@
+/**
+ * @file SchmittTrigger.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include <BipedalLocomotion/Math/SchmittTrigger.h>
+#include <BipedalLocomotion/System/Advanceable.h>
+#include <BipedalLocomotion/bindings/Math/SchmittTrigger.h>
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace Math
+{
+
+void CreateSchmittTrigger(pybind11::module& module)
+{
+    using namespace BipedalLocomotion::Math;
+    namespace py = ::pybind11;
+
+    py::class_<SchmittTriggerState>(module, "SchmittTriggerState")
+        .def(py::init<>())
+        .def_readwrite("state", &SchmittTriggerState::state)
+        .def_readwrite("switch_time", &SchmittTriggerState::switchTime)
+        .def_readwrite("edge_time", &SchmittTriggerState::edgeTime);
+
+    py::class_<SchmittTriggerInput>(module, "SchmittTriggerInput")
+        .def(py::init<>())
+        .def_readwrite("time", &SchmittTriggerInput::time)
+        .def_readwrite("raw_value", &SchmittTriggerInput::rawValue);
+
+    BipedalLocomotion::bindings::System::CreateAdvanceable<
+        BipedalLocomotion::Math::SchmittTriggerInput,
+        BipedalLocomotion::Math::SchmittTriggerState>(module, "SchmittTrigger");
+
+    py::class_<SchmittTrigger,
+               BipedalLocomotion::System::Advanceable<SchmittTriggerInput, //
+                                                      SchmittTriggerState>>
+        schmittTrigger(module, "SchmittTrigger");
+
+    py::class_<SchmittTrigger::Params>(schmittTrigger, "Params")
+        .def(py::init())
+        .def_readwrite("on_threshold", &SchmittTrigger::Params::onThreshold)
+        .def_readwrite("off_threshold", &SchmittTrigger::Params::offThreshold)
+        .def_readwrite("switch_on_after", &SchmittTrigger::Params::switchOnAfter)
+        .def_readwrite("switch_off_after", &SchmittTrigger::Params::switchOffAfter)
+        .def_readwrite("time_comparison_threshold", &SchmittTrigger::Params::timeComparisonThreshold);
+
+    schmittTrigger.def(py::init())
+        .def("set_state", &SchmittTrigger::setState, py::arg("state"))
+        .def("initialize",
+             py::overload_cast<const SchmittTrigger::Params&>(&SchmittTrigger::initialize),
+             py::arg("parameters"));
+}
+} // namespace Math
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/src/Contacts/include/BipedalLocomotion/ContactDetectors/ContactDetector.h
+++ b/src/Contacts/include/BipedalLocomotion/ContactDetectors/ContactDetector.h
@@ -8,11 +8,11 @@
 #ifndef BIPEDAL_LOCOMOTION_CONTACT_DETECTORS_CONTACT_DETECTOR_H
 #define BIPEDAL_LOCOMOTION_CONTACT_DETECTORS_CONTACT_DETECTOR_H
 
+#include <unordered_map>
+
 #include <BipedalLocomotion/Contacts/Contact.h>
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotion/System/Source.h>
-
-#include <unordered_map>
 
 namespace BipedalLocomotion
 {
@@ -25,21 +25,6 @@ class ContactDetector : public BipedalLocomotion::System::Source<EstimatedContac
 {
 public:
     virtual ~ContactDetector() = default;
-
-    /**
-     * Configure generic parameters
-     * @param[in] handler configure the generic parameters for the estimator
-     * @return True in case of success, false otherwise.
-     */
-    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
-
-    /**
-     * Compute one step of the detector
-     * The derived class must implement its own methods for setting measurements
-     * and update states to be called within the advance() method
-     * @return True in case of success, false otherwise.
-     */
-    bool advance() final;
 
     /**
      * Determines the validity of the object retrieved with get()
@@ -75,20 +60,6 @@ public:
     Contacts::EstimatedContact get(const std::string& contactName) const;
 
 protected:
-    /**
-     * These custom parameter specifications should be specified by the derived class.
-     * @param[in] handler configure the custom parameters for the estimator
-     * @return True if success, false otherwise
-     */
-    virtual bool
-    customInitialization(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
-
-    /**
-     * The derived class must implement the contact detection technique to update the contact states
-     * @return True if success, false otherwise
-     */
-    virtual bool updateContactStates() = 0;
-
     /**
      * Enumerator used to determine the running state of the estimator
      */

--- a/src/Contacts/include/BipedalLocomotion/ContactDetectors/FixedFootDetector.h
+++ b/src/Contacts/include/BipedalLocomotion/ContactDetectors/FixedFootDetector.h
@@ -51,9 +51,12 @@ namespace Contacts
  *
  * // initialize the detector
  * detector.initialize(paramsHandler);
+ *
+ * detector.resetTime(contactPhaseList.firstPhase()->beginTime);
  * detector.setContactPhaseList(contactPhaseList);
  *
  * // get the fixed frame at initial time instant (t = t_i)
+ * detector.advance();
  * auto fixedFoot = detector.getFixedFoot();
  *
  * // get the fixed frame at initial time + sampling time instant (t = t_i + dt)
@@ -69,24 +72,6 @@ class FixedFootDetector : public ContactDetector
     EstimatedContact m_dummyContact; /**< A dummy esitmated contact */
 
     /**
-     * Initialize the detector.
-     * @param handler pointer to the parameter handler.
-     * @note the following parameters are required by the class
-     * |   Parameter Name  |    Type    |                Description                 | Mandatory |
-     * |:-----------------:|:----------:|:------------------------------------------:|:---------:|
-     * |  `sampling_time`  |  `double`  |  Sampling time of the detector is seconds  |    Yes    |
-     * @return true in case of success/false otherwise.
-     */
-    bool customInitialization(std::weak_ptr<const //
-                                            ParametersHandler::IParametersHandler> handler) final;
-
-    /**
-     * Update the contact state. This function advance the current time stored in the class.
-     * @return true in case of success/false otherwise.
-     */
-    bool updateContactStates() final;
-
-    /**
      * Update the fixed foot.
      * @return true in case of success/false otherwise.
      */
@@ -95,10 +80,33 @@ class FixedFootDetector : public ContactDetector
 public:
 
     /**
+     * Initialize the detector.
+     * @param handler pointer to the parameter handler.
+     * @note the following parameters are required by the class
+     * |   Parameter Name  |    Type    |                Description                 | Mandatory |
+     * |:-----------------:|:----------:|:------------------------------------------:|:---------:|
+     * |  `sampling_time`  |  `double`  |  Sampling time of the detector is seconds  |    Yes    |
+     * @return true in case of success/false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
+
+    /**
+     * Update the contact state. This function advance the current time stored in the class.
+     * @return true in case of success/false otherwise.
+     */
+    bool advance() override;
+
+    /**
      * Set the contact phase list
      * @param phaseList a contact phase list
      */
-    bool setContactPhaseList(const ContactPhaseList& phaseList);
+    void setContactPhaseList(const ContactPhaseList& phaseList);
+
+    /**
+     * Reset the time
+     * @param time the time in seconds
+     */
+    void resetTime(const double& time);
 
     /**
      * Get the fixed foot

--- a/src/Contacts/include/BipedalLocomotion/ContactDetectors/SchmittTriggerDetector.h
+++ b/src/Contacts/include/BipedalLocomotion/ContactDetectors/SchmittTriggerDetector.h
@@ -1,47 +1,66 @@
 /**
  * @file SchmittTriggerDetector.h
- * @authors Prashanth Ramadoss
- * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * @authors Prashanth Ramadoss, Giulio Romualdi
+ * @copyright 2020-2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef BIPEDAL_LOCOMOTION_CONTACT_DETECTORS_SCHMITT_TRIGGER_DETECTOR_H
 #define BIPEDAL_LOCOMOTION_CONTACT_DETECTORS_SCHMITT_TRIGGER_DETECTOR_H
 
-#include <BipedalLocomotion/ContactDetectors/ContactDetector.h>
-
-#include <iostream>
 #include <unordered_map>
+
+#include <BipedalLocomotion/ContactDetectors/ContactDetector.h>
+#include <BipedalLocomotion/Math/SchmittTrigger.h>
 
 namespace BipedalLocomotion
 {
 namespace Contacts
 {
 
-struct SchmittTriggerParams;
-struct SchmittTriggerInput;
-
 /**
- * Schmitt Trigger thresholding based contact detector
- * that maintains and updates the contact states for
- * a prescribed set of contacts
+ * Schmitt Trigger thresholding based contact detector that maintains and updates the contact states
+ * for a prescribed set of contacts.
  */
 class SchmittTriggerDetector : public ContactDetector
 {
 public:
+
+    /**
+     * Constructor.
+     * It is required by the pimpl idiom.
+     */
     SchmittTriggerDetector();
+
+    /**
+     * Destructor.
+     * It is required by the pimpl idiom.
+     */
     ~SchmittTriggerDetector();
+
+    /**
+    * Initialize the SchmittTriggerDetector witn a parameters handler.
+    * @param[in] handler configure the custom parameters for the detector.
+    * @note The following parameters are required
+    * |        Parameter Name        |       Type       |                                                                                             Description                                                                                             | Mandatory |
+    * |:----------------------------:|:----------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:---------:|
+    * |          `contacts`          | `vector<string>` |                               Vector containing the names of the contact. The name can be used to retrieve the current status of a contact with `ContactDetector::get`.                             |    Yes    |
+    * |   `contact_make_thresholds`  | `vector<double>` | Vector containing High-value thresholds to initiate an ON state switch after switchOnAfter time-units. For each contact specified in `contacts` the user needs to specify an element of the vector. |    Yes    |
+    * |  `contact_break_thresholds`  | `vector<double>` | Vector containing Low-value thresholds to initiate an ON state switch after switchOnAfter time-units. For each contact specified in `contacts`  the user needs to specify an element of the vector. |    Yes    |
+    * |  `contact_make_switch_times` | `vector<double>` |           Time units to wait for before switching to `contact` state from `no-contact` state. For each contact specified in `contacts` the user needs to specify an element of the vector.          |    Yes    |
+    * | `contact_break_switch_times` | `vector<double>` |          Time units to wait for before switching to `no-contact`  state from `contact`  state. For each contact specified in `contacts` the user needs to specify an element of the vector.         |    Yes    |
+    * @return True in case of success, false otherwise.
+    */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
 
     /**
      * Set trigger input and time stamp for an existing SchmittTrigger unit
      * @param[in] contactName name of the contact
-     * @param[in] time time of measurement
-     * @param[in] force contact force intensity (typically contact normal force)
+     * @param[in] input the imput of the trigger containing the contact force and the time instant
      * @return True in case of success, false otherwise.
      */
-    bool setTimedTriggerInput(const std::string& contactName,
-                              const double& time,
-                              const double& triggerInput);
+    bool setTimedTriggerInput(const std::string& contactName, //
+                              const Math::SchmittTriggerInput& input);
 
     /**
      * Set trigger input and time stamp for existing units
@@ -49,19 +68,8 @@ public:
      * @note any unit names in the input container that does not already exist will be ignored
      * @return True in case of success, false otherwise.
      */
-    bool setTimedTriggerInputs(const std::unordered_map<std::string, SchmittTriggerInput>& timedInputs);
-
-    /**
-     * Add a contact whose contact state need to be tracked
-     * @param[in] contactName name of the contact
-     * @param[in] initialState initial contact state
-     * @param[in] params Schmitt Trigger parameters
-     * @note this method does not reset the state and parameters if the contact already exists
-     * @return True in case of success, false otherwise.
-     */
-    bool addContact(const std::string& contactName,
-                    const bool& initialState,
-                    const SchmittTriggerParams& params);
+    bool setTimedTriggerInputs(const std::unordered_map<std::string, //
+                                                        Math::SchmittTriggerInput>& timedInputs);
 
     /**
      * Add a contact whose contact state need to be tracked
@@ -73,9 +81,8 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool addContact(const std::string& contactName,
-                    const bool& initialState,
-                    const SchmittTriggerParams& params,
-                    const double& time_now);
+                    const BipedalLocomotion::Math::SchmittTriggerState& initialState,
+                    const BipedalLocomotion::Math::SchmittTrigger::Params& params);
 
     /**
      * Reset a contact's state
@@ -83,8 +90,7 @@ public:
      * @param[in] initialState contact state
      * @return True in case of success, false if contact does not exist/otherwise.
      */
-    bool resetState(const std::string& contactName,
-                    const bool& state);
+    bool resetState(const std::string& contactName, const bool& state);
 
     /**
      * Reset a contact's parameters
@@ -94,8 +100,8 @@ public:
      * @return True in case of success, false if contact does not exist/otherwise.
      */
     bool resetContact(const std::string& contactName,
-                      const bool& state,
-                      const SchmittTriggerParams& params);
+                      const bool state,
+                      const BipedalLocomotion::Math::SchmittTrigger::Params& params);
 
     /**
      * Remove contact from the Detector
@@ -103,113 +109,22 @@ public:
      * @return True in case of success, false if does not exist/otherwise.
      */
     bool removeContact(const std::string& contactName);
-protected:
-    /**
-    * These custom parameter specifications should be specified by the derived class.
-    * @param[in] handler configure the custom parameters for the detector
-    * @return True in case of success, false otherwise.
-    */
-    virtual bool customInitialization(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
 
     /**
-    * Update contact states based on thresholding of contact normal forces and timing parameters
-    * @return True in case of success, false otherwise.
-    */
-    virtual bool updateContactStates() override;
+     * Compute one step of the detector.
+     * This method uses all the inputs and evaluate the contact status considering the Schmitt
+     * trigger output.
+     * @return True in case of success, false otherwise.
+     */
+    bool advance() final;
 
 private:
+
     /**
     * Private implementation of the class
     */
     class Impl;
     std::unique_ptr<Impl> m_pimpl; /**< Pointer to implementation */
-};
-
-
-/**
- * Struct holding switching parameters for the Schmitt Trigger
- */
-struct SchmittTriggerParams
-{
-    double onThreshold{0.0};      /**< high value threshold to initiate an ON state switch after switchOnAfter time-units*/
-    double offThreshold{0.0};     /**< low value threshold to initiate an OFF state switch after switchOffAfter time-units*/
-    double switchOnAfter{0.0};    /**< time units to wait for before switching to ON state from OFF state. Ensure it's greater than sampling time. */
-    double switchOffAfter{0.0};   /**< time units to wait for before switching to OFF state from ON state. Ensure it's greater than sampling time. */
-};
-
-/**
- * Struct holding Schmitt Trigger inputs
- */
-struct SchmittTriggerInput
-{
-    double time{0.0};    /**< time stamp*/
-    double value{0.0};   /**< signal input*/
-};
-
-/**
- * Schmitt trigger unit that switches state using threshold and timing parameters
- */
-class SchmittTriggerUnit
-{
-public:
-    /**
-     * Set current state  of the Schmitt trigger
-     * @param state current state
-     */
-    void setState(const bool& state);
-
-    /**
-     * Set current state  of the Schmitt trigger
-     * @param state current state
-     * @param time_now time unit to set the timer parameters
-     */
-    void setState(const bool& state, const double& time_now);
-
-    /**
-     * Set configuration parameters of the Schmitt trigger
-     * @param params struct holding Schmitt trigger parameters
-     */
-    void setParams(const SchmittTriggerParams& params);
-
-    /**
-     * Update the state of Schmitt trigger with the measurements
-     * @param currentTime time of measurement
-     * @param rawValue measurement
-     * @return True in case of success, false otherwise.
-     */
-    void update(const double& currentTime, const double& rawValue);
-
-    /**
-     * Reset the state of Schmitt trigger to false
-     */
-    void reset();
-
-    /**
-     * Get the current state of the Schmitt trigger
-     * @return state - true/false
-     */
-    bool getState();
-
-    /**
-     * Get the current state of the Schmitt trigger
-     * @param[out] swtichTime
-     * @return state - true/false
-     */
-    bool getState(double& switchTime);
-
-    /**
-     * Get currently configuration of Schmitt trigger
-     * @return struct holding the parameters
-     */
-    SchmittTriggerParams getParams();
-
-private:
-    SchmittTriggerParams params; /**< Schmitt Trigger parameters*/
-    bool state{false}; /**< current state*/
-    double switchTime{0.}; /**> time instant at which the state was toggled */
-    double previousTime{0.}; /**< previous update time*/
-    double timer{0.}; /**< elapsed timer for current state*/
-    double initialTime{0.}; /**< initialization time*/
 };
 
 } // namespace Contacts

--- a/src/Contacts/include/BipedalLocomotion/ContactDetectors/SchmittTriggerDetector.h
+++ b/src/Contacts/include/BipedalLocomotion/ContactDetectors/SchmittTriggerDetector.h
@@ -39,7 +39,7 @@ public:
     ~SchmittTriggerDetector();
 
     /**
-    * Initialize the SchmittTriggerDetector witn a parameters handler.
+    * Initialize the SchmittTriggerDetector with a parameters handler.
     * @param[in] handler configure the custom parameters for the detector.
     * @note The following parameters are required
     * |        Parameter Name        |       Type       |                                                                                             Description                                                                                             | Mandatory |

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
@@ -111,10 +111,13 @@ public:
      * It returns the contact phase with the highest begin time lower than time.
      * If no contacts phase has a begin time lower than time, it returns an iterator to the end.
      * @param time The present time.
+     * @param tolerance positive parameter used for the comparison of two time instants. Given two
+     * instants if the error between the two is lower than the tolerance, the time instants are
+     * considered equal. Default value 0.
      * @return an iterator to the last phase having an activation time lower than time.
      * If no phase satisfies this condition, it returns a pointer to the end.
      */
-    const_iterator getPresentPhase(double time) const;
+    const_iterator getPresentPhase(double time, double tolerance = 0) const;
 
     /**
      * @brief A reference to the lists stored in this class.

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
@@ -113,11 +113,12 @@ public:
      * @param time The present time.
      * @param tolerance positive parameter used for the comparison of two time instants. Given two
      * instants if the error between the two is lower than the tolerance, the time instants are
-     * considered equal. Default value 0.
+     * considered equal. Default value
+     * [`std::numeric_limits<double>::min()`](https://en.cppreference.com/w/cpp/types/numeric_limits/min).
      * @return an iterator to the last phase having an activation time lower than time.
      * If no phase satisfies this condition, it returns a pointer to the end.
      */
-    const_iterator getPresentPhase(double time, double tolerance = 0) const;
+    const_iterator getPresentPhase(double time, double tolerance = std::numeric_limits<double>::min()) const;
 
     /**
      * @brief A reference to the lists stored in this class.

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
@@ -11,6 +11,7 @@
 #include <BipedalLocomotion/Contacts/Contact.h>
 #include <BipedalLocomotion/Contacts/ContactList.h>
 #include <BipedalLocomotion/Contacts/ContactPhase.h>
+#include <BipedalLocomotion/Math/Constants.h>
 
 #include <initializer_list>
 #include <vector>
@@ -113,12 +114,12 @@ public:
      * @param time The present time.
      * @param tolerance positive parameter used for the comparison of two time instants. Given two
      * instants if the error between the two is lower than the tolerance, the time instants are
-     * considered equal. Default value
-     * [`std::numeric_limits<double>::min()`](https://en.cppreference.com/w/cpp/types/numeric_limits/min).
+     * considered equal. Default value BipedalLocomotion::Math::AbsoluteEqualityDoubleTolerance
      * @return an iterator to the last phase having an activation time lower than time.
      * If no phase satisfies this condition, it returns a pointer to the end.
      */
-    const_iterator getPresentPhase(double time, double tolerance = std::numeric_limits<double>::min()) const;
+    const_iterator getPresentPhase(double time, //
+                                   double tolerance = BipedalLocomotion::Math::AbsoluteEqualityDoubleTolerance) const;
 
     /**
      * @brief A reference to the lists stored in this class.

--- a/src/Contacts/src/ContactDetector.cpp
+++ b/src/Contacts/src/ContactDetector.cpp
@@ -1,7 +1,7 @@
 /**
  * @file ContactDetector.cpp
  * @authors Prashanth Ramadoss, Giulio Romualdi
- * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * @copyright 2020-2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the BSD-3-Clause license.
  */
 
@@ -10,61 +10,6 @@
 
 using namespace BipedalLocomotion::ParametersHandler;
 using namespace BipedalLocomotion::Contacts;
-
-bool ContactDetector::initialize(std::weak_ptr<const IParametersHandler> handler)
-{
-    constexpr auto printPrefix = "[ContactDetector::initialize]";
-    if (m_detectorState != State::NotInitialized)
-    {
-        log()->error("{} The contact detector already seems to be initialized.", printPrefix);
-        return false;
-    }
-
-    auto handle = handler.lock();
-    if (handle == nullptr)
-    {
-        log()->error("{} The parameter handler has expired. Please check its scope.", printPrefix);
-        return false;
-    }
-
-    if (!this->customInitialization(handler))
-    {
-        log()->error("{} Could not run custom initialization of the contact detector.",
-                     printPrefix);
-        return false;
-    }
-
-    log()->info("{} Contact detector initialization is successful.", printPrefix);
-
-    m_detectorState = State::Initialized;
-    return true;
-}
-
-bool ContactDetector::customInitialization(std::weak_ptr<const IParametersHandler> handler)
-{
-    return true;
-}
-
-bool ContactDetector::advance()
-{
-    constexpr auto printPrefix = "[ContactDetector::advance]";
-    if (m_detectorState == State::NotInitialized)
-    {
-        log()->error("{} Please initialize the contact detector before running advance.",
-                     printPrefix);
-        return false;
-    } else
-    {
-        m_detectorState = State::Running;
-    }
-
-    if (!this->updateContactStates())
-    {
-        log()->error("{} Unable to update the contact state.", printPrefix);
-        return false;
-    }
-    return true;
-}
 
 bool ContactDetector::resetContacts()
 {
@@ -83,28 +28,30 @@ const EstimatedContactList& ContactDetector::getOutput() const
 
 bool ContactDetector::get(const std::string& contactName, EstimatedContact& contact) const
 {
-    if (m_contactStates.find(contactName) == m_contactStates.end())
+    auto iterator = m_contactStates.find(contactName);
+    if (iterator == m_contactStates.end())
     {
         log()->error("[ContactDetector::get] Contact not found.");
         return false;
     }
 
-    contact = m_contactStates.at(contactName);
+    contact = iterator->second;
     return true;
 }
 
 EstimatedContact ContactDetector::get(const std::string& contactName) const
 {
-    if (m_contactStates.find(contactName) == m_contactStates.end())
+    auto iterator = m_contactStates.find(contactName);
+    if (iterator == m_contactStates.end())
     {
         log()->error("[ContactDetector::get] Contact not found.");
         return EstimatedContact();
     }
 
-    return m_contactStates.at(contactName);
+    return iterator->second;
 }
 
 bool ContactDetector::isOutputValid() const
 {
-    return (m_detectorState == State::Running);
+    return m_detectorState == State::Running;
 }

--- a/src/Contacts/src/ContactPhaseList.cpp
+++ b/src/Contacts/src/ContactPhaseList.cpp
@@ -140,12 +140,12 @@ bool ContactPhaseList::setLists(const std::initializer_list<ContactList>& contac
     return true;
 }
 
-ContactPhaseList::const_iterator ContactPhaseList::getPresentPhase(double time) const
+ContactPhaseList::const_iterator ContactPhaseList::getPresentPhase(double time, double tolerance /*= 0*/) const
 {
     // With the reverse iterator we find the last phase such that the begin time is smaller that
     // time
-    auto presentReverse = std::find_if(rbegin(), rend(), [time](const ContactPhase& a) -> bool {
-        return a.beginTime <= time;
+    auto presentReverse = std::find_if(rbegin(), rend(), [time, tolerance](const ContactPhase& a) -> bool {
+        return a.beginTime < time || std::abs(a.beginTime - time) <= tolerance;
     });
 
     if (presentReverse == rend())

--- a/src/Contacts/src/ContactPhaseList.cpp
+++ b/src/Contacts/src/ContactPhaseList.cpp
@@ -140,13 +140,16 @@ bool ContactPhaseList::setLists(const std::initializer_list<ContactList>& contac
     return true;
 }
 
-ContactPhaseList::const_iterator ContactPhaseList::getPresentPhase(double time, double tolerance /*= 0*/) const
+ContactPhaseList::const_iterator
+ContactPhaseList::getPresentPhase(double time,
+                                  double tolerance /*= std::numeric_limits<double>::min();*/) const
 {
     // With the reverse iterator we find the last phase such that the begin time is smaller that
     // time
-    auto presentReverse = std::find_if(rbegin(), rend(), [time, tolerance](const ContactPhase& a) -> bool {
-        return a.beginTime < time || std::abs(a.beginTime - time) <= tolerance;
-    });
+    auto presentReverse
+        = std::find_if(rbegin(), rend(), [time, tolerance](const ContactPhase& a) -> bool {
+              return a.beginTime <= time + tolerance;
+          });
 
     if (presentReverse == rend())
     {

--- a/src/Contacts/src/ContactPhaseList.cpp
+++ b/src/Contacts/src/ContactPhaseList.cpp
@@ -140,9 +140,9 @@ bool ContactPhaseList::setLists(const std::initializer_list<ContactList>& contac
     return true;
 }
 
-ContactPhaseList::const_iterator
-ContactPhaseList::getPresentPhase(double time,
-                                  double tolerance /*= std::numeric_limits<double>::min();*/) const
+ContactPhaseList::const_iterator ContactPhaseList::getPresentPhase(
+    double time,
+    double tolerance /*= BipedalLocomotion::Math::AbsoluteEqualityDoubleTolerance*/) const
 {
     // With the reverse iterator we find the last phase such that the begin time is smaller that
     // time

--- a/src/Contacts/src/FixedFootDetector.cpp
+++ b/src/Contacts/src/FixedFootDetector.cpp
@@ -56,8 +56,7 @@ bool FixedFootDetector::updateFixedFoot()
     constexpr auto logPrefix = "[FixedFootDetector::updateFixedFoot]";
 
     // search the phase associated to the current time
-    constexpr auto tolerance = std::numeric_limits<double>::min();
-    auto phase = m_contactPhaselist.getPresentPhase(m_currentTime, tolerance);
+    auto phase = m_contactPhaselist.getPresentPhase(m_currentTime);
 
     if(phase == m_contactPhaselist.end())
     {

--- a/src/Contacts/src/SchmittTriggerDetector.cpp
+++ b/src/Contacts/src/SchmittTriggerDetector.cpp
@@ -96,9 +96,7 @@ bool SchmittTriggerDetector::initialize(std::weak_ptr<const IParametersHandler> 
         params.offThreshold = offThreshold[idx];
 
         // set the initial state for the trigger
-        constexpr blf::Math::SchmittTriggerState initialState{.state = false,
-                                                              .switchTime = 0,
-                                                              .edgeTime = 0};
+        constexpr blf::Math::SchmittTriggerState initialState{false, 0, 0};
         if (!this->addContact(contacts[idx], initialState, params))
         {
             log()->error("{} Could not add Schmitt Trigger unit for specified contact.", logPrefix);
@@ -255,7 +253,9 @@ bool SchmittTriggerDetector::resetContact(const std::string& contactName,
                      contactName);
         return false;
     }
-    trigger.setState(blf::Math::SchmittTriggerState{.state = state});
+    blf::Math::SchmittTriggerState triggerState;
+    triggerState.state = state;
+    trigger.setState(triggerState);
     m_contactStates.at(contactName).isActive = state;
     m_contactStates.at(contactName).switchTime = 0.0;
 
@@ -271,7 +271,9 @@ bool SchmittTriggerDetector::resetState(const std::string& contactName, const bo
         return false;
     }
 
-    m_pimpl->manager.at(contactName).setState(blf::Math::SchmittTriggerState{.state = state});
+    blf::Math::SchmittTriggerState triggerState;
+    triggerState.state = state;
+    m_pimpl->manager.at(contactName).setState(triggerState);
     m_contactStates.at(contactName).isActive = state;
     m_contactStates.at(contactName).switchTime = 0.0;
 

--- a/src/Contacts/src/SchmittTriggerDetector.cpp
+++ b/src/Contacts/src/SchmittTriggerDetector.cpp
@@ -79,6 +79,11 @@ bool SchmittTriggerDetector::initialize(std::weak_ptr<const IParametersHandler> 
     std::vector<double> switchOffAfter;
     ok = ok && setupParam("contact_break_switch_times", switchOffAfter);
 
+    if (!ok)
+    {
+        return false;
+    }
+
     if ((contacts.size() != onThreshold.size()) || (contacts.size() != offThreshold.size())
         || (contacts.size() != switchOnAfter.size()) || (contacts.size() != switchOffAfter.size()))
     {

--- a/src/Contacts/tests/ContactDetectors/FixedFootDetectorUnitTest.cpp
+++ b/src/Contacts/tests/ContactDetectors/FixedFootDetectorUnitTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @file FixedFootDetectorUnitTest.cpp
  * @authors Giulio Romualdi
- * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * @copyright 2021-2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the BSD-3-Clause license.
  */
 
@@ -141,11 +141,14 @@ TEST_CASE("Fixed Foot Detector")
     REQUIRE(detector.initialize(handler));
 
     const auto phaseList = createContactList();
-    double currentTime = phaseList.firstPhase()->beginTime;
     detector.setContactPhaseList(phaseList);
 
-    for (; currentTime < horizon;)
+    for (double currentTime = phaseList.firstPhase()->beginTime; currentTime < horizon;
+         currentTime += dT)
     {
+        // advance is used to advance the time stored in the detector and to evaluate the outputs
+        REQUIRE(detector.advance());
+
         auto state = getFixedFootState(currentTime, phaseList.lists());
 
         REQUIRE(detector.getOutput().find("right_foot")->second.isActive
@@ -163,10 +166,5 @@ TEST_CASE("Fixed Foot Detector")
             // Error this should never happen
             REQUIRE(false);
         }
-
-        // advance is used to advance the time stored in the detector
-        REQUIRE(detector.advance());
-
-        currentTime += dT;
     }
 }

--- a/src/Contacts/tests/ContactDetectors/FixedFootDetectorUnitTest.cpp
+++ b/src/Contacts/tests/ContactDetectors/FixedFootDetectorUnitTest.cpp
@@ -33,35 +33,35 @@ FixedFootState getFixedFootState(double t, const ContactListMap& listMap)
     state.leftFoot.pose = listMap.find("left_foot")->second.getPresentContact(t)->pose;
     state.rightFoot.pose = listMap.find("right_foot")->second.getPresentContact(t)->pose;
 
-    if (t <= 1)
+    if (t < 1)
     {
         state.leftFoot.isActive = true;
         state.rightFoot.isActive = false;
-    } else if (t <= 3)
+    } else if (t < 3)
     {
         state.leftFoot.isActive = false;
         state.rightFoot.isActive = true;
-    } else if (t <= 5)
+    } else if (t < 5)
     {
         state.leftFoot.isActive = true;
         state.rightFoot.isActive = false;
-    } else if (t <= 7)
+    } else if (t < 7)
     {
         state.leftFoot.isActive = false;
         state.rightFoot.isActive = true;
-    } else if (t <= 9)
+    } else if (t < 9)
     {
         state.leftFoot.isActive = true;
         state.rightFoot.isActive = false;
-    } else if (t <= 11)
+    } else if (t < 11)
     {
         state.leftFoot.isActive = false;
         state.rightFoot.isActive = true;
-    } else if (t <= 13)
+    } else if (t < 13)
     {
         state.leftFoot.isActive = true;
         state.rightFoot.isActive = false;
-    } else if (t <= 15)
+    } else if (t < 15)
     {
         state.leftFoot.isActive = false;
         state.rightFoot.isActive = true;
@@ -143,16 +143,15 @@ TEST_CASE("Fixed Foot Detector")
     const auto phaseList = createContactList();
     detector.setContactPhaseList(phaseList);
 
-    for (double currentTime = phaseList.firstPhase()->beginTime; currentTime < horizon;
-         currentTime += dT)
+    for (int i = 0; i < horizon / dT; i++)
     {
         // advance is used to advance the time stored in the detector and to evaluate the outputs
         REQUIRE(detector.advance());
 
+        const double currentTime = phaseList.firstPhase()->beginTime + i * dT;
         auto state = getFixedFootState(currentTime, phaseList.lists());
 
-        REQUIRE(detector.getOutput().find("right_foot")->second.isActive
-                == state.rightFoot.isActive);
+        REQUIRE(detector.getOutput().find("right_foot")->second.isActive == state.rightFoot.isActive);
         REQUIRE(detector.getOutput().find("left_foot")->second.isActive == state.leftFoot.isActive);
 
         if (state.leftFoot.isActive)

--- a/src/Contacts/tests/ContactDetectors/SchmittTriggerDetectorUnitTest.cpp
+++ b/src/Contacts/tests/ContactDetectors/SchmittTriggerDetectorUnitTest.cpp
@@ -40,11 +40,11 @@ TEST_CASE("Schmitt Trigger Detector")
     REQUIRE(detector.resetContacts());
 
     // rise signal
-    detector.setTimedTriggerInput("right", SchmittTriggerInput{.time = 0.1, .rawValue = 120});
+    detector.setTimedTriggerInput("right", {0.1 ,120});
     detector.advance();
-    detector.setTimedTriggerInput("right", SchmittTriggerInput{.time = 0.2, .rawValue = 120});
+    detector.setTimedTriggerInput("right", {0.2, 120});
     detector.advance();
-    detector.setTimedTriggerInput("right", SchmittTriggerInput{.time = 0.3, .rawValue = 120});
+    detector.setTimedTriggerInput("right", {0.3, 120});
     detector.advance();
 
     // contact state should turn true
@@ -54,11 +54,11 @@ TEST_CASE("Schmitt Trigger Detector")
     REQUIRE(rightContact.switchTime == 0.3);
 
     // fall signal
-    detector.setTimedTriggerInput("right", SchmittTriggerInput{.time = 0.4, .rawValue = 7});
+    detector.setTimedTriggerInput("right", {0.4, 7});
     detector.advance();
-    detector.setTimedTriggerInput("right", SchmittTriggerInput{.time = 0.5, .rawValue = 7});
+    detector.setTimedTriggerInput("right", {0.5, 7});
     detector.advance();
-    detector.setTimedTriggerInput("right", SchmittTriggerInput{.time = 0.6, .rawValue = 7});
+    detector.setTimedTriggerInput("right", {0.6, 7});
     detector.advance();
 
     // contact state should turn false
@@ -74,9 +74,7 @@ TEST_CASE("Schmitt Trigger Detector")
     params.switchOffAfter = 0.2;
     params.switchOnAfter = 0.2;
 
-    detector.addContact("left",
-                        SchmittTriggerState{.state = false, .switchTime = 0.6, .edgeTime = 0.6},
-                        params);
+    detector.addContact("left", {false, 0.6, 0.6}, params);
     auto contacts = detector.getOutput();
     REQUIRE(contacts.size() == 2);
 

--- a/src/Math/CMakeLists.txt
+++ b/src/Math/CMakeLists.txt
@@ -10,10 +10,11 @@ if(FRAMEWORK_COMPILE_Math)
     NAME                  Math
     PUBLIC_HEADERS        ${H_PREFIX}/CARE.h ${H_PREFIX}/Constants.h
                           ${H_PREFIX}/LinearizedFrictionCone.h ${H_PREFIX}/ContactWrenchCone.h
-                          ${H_PREFIX}/Wrench.h
+                          ${H_PREFIX}/Wrench.h ${H_PREFIX}/SchmittTrigger.h
     SOURCES               src/CARE.cpp  src/LinearizedFrictionCone.cpp src/ContactWrenchCone.cpp
+                          src/SchmittTrigger.cpp
     PUBLIC_LINK_LIBRARIES Eigen3::Eigen BipedalLocomotion::ParametersHandler
-                          BipedalLocomotion::TextLogging MANIF::manif
+                          BipedalLocomotion::TextLogging BipedalLocomotion::System MANIF::manif
     SUBDIRECTORIES        tests)
 
 endif()

--- a/src/Math/include/BipedalLocomotion/Math/Constants.h
+++ b/src/Math/include/BipedalLocomotion/Math/Constants.h
@@ -18,6 +18,12 @@ namespace Math
  * acceleration of an object in a vacuum near the surface of the Earth.
  */
 constexpr double StandardAccelerationOfGravitation = 9.80665;
+
+/**
+ * The Absolute tolerance used to consider two double equal.
+ */
+constexpr double AbsoluteEqualityDoubleTolerance = 1e-8;
+
 } // namespace Math
 } // namespace BipedalLocomotion
 

--- a/src/Math/include/BipedalLocomotion/Math/SchmittTrigger.h
+++ b/src/Math/include/BipedalLocomotion/Math/SchmittTrigger.h
@@ -1,0 +1,137 @@
+/**
+ * @file SchmittTrigger.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_MATH_SCHMITT_TRIGGER_H
+#define BIPEDAL_LOCOMOTION_MATH_SCHMITT_TRIGGER_H
+
+#include <memory>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/System/Advanceable.h>
+
+namespace BipedalLocomotion
+{
+namespace Math
+{
+
+/**
+ * SchmittTriggerState contains the internal state of the trigger,
+ */
+struct SchmittTriggerState
+{
+    bool state{false}; /**< current state*/
+    double switchTime{0.0}; /**< time instant at which the state was toggled in seconds */
+    double edgeTime{0.0}; /**< Time instant at which the raw value transited from low to high of
+                             from high to low in seconds.*/
+};
+
+/**
+ * SchmittTriggerState contains the input of the SchmittTrigger class.
+ */
+struct SchmittTriggerInput
+{
+    double time{0.0}; /**< Current time instant in seconds */
+    double rawValue{0.0} ; /**< Raw value that should  */
+};
+
+/**
+ * SchmittTrigger implements a discrete version of a SchmittTrigger
+ * See [here](https://en.wikipedia.org/wiki/Schmitt_trigger) for further details.
+ */
+class SchmittTrigger
+    : public BipedalLocomotion::System::Advanceable<SchmittTriggerInput, SchmittTriggerState>
+{
+public:
+    /**
+     * Struct holding switching parameters for the Schmitt Trigger
+     */
+    struct Params
+    {
+        double onThreshold{0.0}; /**< high value threshold to initiate an ON state switch after
+                                    switchOnAfter time-units*/
+        double offThreshold{0.0}; /**< low value threshold to initiate an OFF state switch after
+                                     switchOffAfter time-units*/
+        double switchOnAfter{0.0}; /**< time units to wait for before switching to ON state from OFF
+                                      state. Ensure it's greater than sampling time. */
+        double switchOffAfter{0.0}; /**< time units to wait for before switching to OFF state from
+                                       ON state. Ensure it's greater than sampling time. */
+
+        /** Threshold used for the comparison of two time instant. Given two time instants if the
+         * error between the two is lower than the threshold, the time instants are considered
+         * equal. */
+        double timeComparisonThreshold{std::numeric_limits<double>::epsilon()};
+    };
+
+    /**
+     * Initialize the SchmittTrigger block.
+     * @param handler pointer to the parameter handler.
+     * @note The following parameters are required
+     * |  Parameter Name  |   Type   |                                     Description                                     | Mandatory |
+     * |:----------------:|:--------:|:-----------------------------------------------------------------------------------:|:---------:|
+     * |  `on_threshold`  | `double` | High value threshold to initiate an ON state switch after switchOnAfter time-units  |    Yes    |
+     * | `off_threshold`  | `double` | Low value threshold to initiate an OFF state switch after switchOffAfter time-units |    Yes    |
+     * | `switch_on_after`| `double` | Time units to wait for before switching to ON state from OFF state. Ensure it's greater than sampling time. |     Yes    |
+     * |`switch_off_after`| `double` | Time units to wait for before switching to OFF state from ON state. Ensure it's greater than sampling time. |     Yes    |
+     * | `time_comparison_threshold`| `double` | Threshold used for the comparison of two time instants. Given two time instants, if the error between the two is lower than the threshold, the time instants are considered equal. Default value [`std::numeric_limits<double>::epsilon()`](https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon) |     No    |
+     * @return true in case of success/false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
+
+    /**
+     * Initialize the SchmittTrigger block.
+     * @param parameters parameter required to initialize the block.
+     * @return true in case of success/false otherwise.
+     */
+    bool initialize(const Params& parameters);
+
+    /**
+     * Set the state of the SchmittTrigger.
+     * @param state the state of the SchmittTrigger
+     * @note When the state is set the internal timer is reset as well. This function should be
+     * called only if the user want to force the state of the system.
+     */
+    void setState(const SchmittTriggerState& state);
+
+    /**
+     * Perform one step of the trigger.
+     * @return true in case of success, false otherwise.
+     */
+    bool advance() override;
+
+    /**
+     * Check if the output of the trigger is valid.
+     * @return true in case of success, false otherwise.
+     */
+    bool isOutputValid() const override;
+
+    /**
+     * Get the internal state of the SchmittTrigger.
+     * @return a const reference to the state of the trigger.
+     */
+    const SchmittTriggerState& getOutput() const override;
+
+    /**
+     * Set the input of the trigger.
+     * @param input the input of the system. It contains the raw value and the current time instant.
+     * @return true in case of success, false otherwise.
+     */
+    bool setInput(const SchmittTriggerInput& input) override;
+
+private:
+    SchmittTriggerInput m_input; /**< Last input stored in the trigger */
+    SchmittTriggerState m_state; /**< Current state stored in the trigger */
+    Params m_params; /**< Set of switching parameters */
+    double m_timer{0}; /**< Internal timer used by the switcher to understand if it is the time to
+                          switch */
+    double m_risingEdgeTimeInstant{-1}; /**< Internal quantity used to store the previous time */
+    double m_fallingEdgeTimeInstant{-1}; /**< Internal quantity used to store the previous time */
+};
+
+} // namespace Math
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_MATH_SCHMITT_TRIGGER_H

--- a/src/Math/include/BipedalLocomotion/Math/SchmittTrigger.h
+++ b/src/Math/include/BipedalLocomotion/Math/SchmittTrigger.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include <BipedalLocomotion/Math/Constants.h>
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotion/System/Advanceable.h>
 
@@ -63,7 +64,7 @@ public:
         /** Threshold used for the comparison of two time instant. Given two time instants if the
          * error between the two is lower than the threshold, the time instants are considered
          * equal. */
-        double timeComparisonThreshold{std::numeric_limits<double>::epsilon()};
+        double timeComparisonThreshold{BipedalLocomotion::Math::AbsoluteEqualityDoubleTolerance};
     };
 
     /**

--- a/src/Math/src/SchmittTrigger.cpp
+++ b/src/Math/src/SchmittTrigger.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file SchmittTrigger.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/Math/SchmittTrigger.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+using namespace BipedalLocomotion::Math;
+
+bool SchmittTrigger::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler)
+{
+    constexpr auto logPrefix = "[SchmittTrigger::initialize]";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} Invalid parameter handler.", logPrefix);
+        return false;
+    }
+
+    auto populateparameter
+        = [logPrefix, ptr](const std::string& paramName, auto& parameter) -> bool {
+        if (!ptr->getParameter(paramName, parameter))
+        {
+            log()->error("{} Unable to find the parameter '{}'", logPrefix, paramName);
+            return false;
+        }
+        return true;
+    };
+
+    Params params;
+    bool ok = populateparameter("on_threshold", params.onThreshold);
+    ok = ok && populateparameter("off_threshold", params.offThreshold);
+    ok = ok && populateparameter("switch_on_after", params.switchOnAfter);
+    ok = ok && populateparameter("switch_off_after", params.switchOffAfter);
+
+    if (ok && !ptr->getParameter("time_comparison_threshold", params.timeComparisonThreshold))
+    {
+        log()->warn("{} The parameter 'time_comparison_threshold' is not found. The default one "
+                    "will be used. Default: {} seconds.",
+                    logPrefix,
+                    params.timeComparisonThreshold);
+    }
+
+    return ok && this->initialize(params);
+}
+
+bool SchmittTrigger::initialize(const Params& params)
+{
+
+    constexpr auto logPrefix = "[SchmittTrigger::initialize]";
+
+    if (params.offThreshold > params.onThreshold)
+    {
+        log()->error("{} The ON threshold must be greater than the OFF threshold", logPrefix);
+        return false;
+    }
+
+    if (params.switchOnAfter < 0 || params.switchOffAfter < 0)
+    {
+        log()->error("{} The time thresholds must be positive numbers", logPrefix);
+        return false;
+    }
+
+    m_params = params;
+
+    return true;
+}
+
+bool SchmittTrigger::advance()
+{
+
+    auto robustEqual = [this](double a, double b) -> bool {
+        return (std::abs(a - b) <= this->m_params.timeComparisonThreshold);
+    };
+
+    // if the trigger is not active
+    if (!m_state.state)
+    {
+        // the state is deactivate this means that we can reset the fallingEdgeTimeInstant. We can
+        // avoid to do this at every instant. However, coping a double is not the bootlneck. :)
+        m_fallingEdgeTimeInstant = -1;
+
+        // check if the input is higher of the threshold
+        if (m_input.rawValue >= m_params.onThreshold)
+        {
+            // We detected a rising edge
+            if (m_risingEdgeTimeInstant < 0)
+            {
+                m_risingEdgeTimeInstant = m_input.time;
+            }
+
+            // integrate the timer
+            m_timer = m_input.time - m_risingEdgeTimeInstant;
+
+            // if the timer is greater than a threshold is time to switch
+            if (m_timer > m_params.switchOnAfter || robustEqual(m_timer, m_params.switchOnAfter))
+            {
+                m_state.state = true;
+                m_state.switchTime = m_input.time;
+                m_state.edgeTime = m_risingEdgeTimeInstant;
+                m_timer = 0;
+            }
+        }
+    } else
+    {
+
+        // the state is deactivate this means that we can reset the risingEdgeTimeInstant. We can
+        // avoid to do this at every instant. However, coping a double is not the bootlneck. :)
+        m_risingEdgeTimeInstant = -1;
+
+        // check if the input is lower of the threshold
+        if (m_input.rawValue <= m_params.offThreshold)
+        {
+            // We detected a falling edge
+            if (m_fallingEdgeTimeInstant < 0)
+            {
+                m_fallingEdgeTimeInstant = m_input.time;
+            }
+
+            // here a small delta is added to the timer
+            m_timer = m_input.time - m_fallingEdgeTimeInstant;
+
+            // if the value is lower the threshold for more than switchOffAfter seconds is time to
+            // switch!
+            if (m_timer > m_params.switchOffAfter || robustEqual(m_timer, m_params.switchOffAfter))
+            {
+                m_state.state = false;
+                m_state.switchTime = m_input.time;
+                m_state.edgeTime = m_fallingEdgeTimeInstant;
+                m_timer = 0;
+            }
+        }
+    }
+    return true;
+}
+
+bool SchmittTrigger::isOutputValid() const
+{
+    return true;
+}
+
+bool SchmittTrigger::setInput(const SchmittTriggerInput& input)
+{
+    m_input = input;
+    return true;
+}
+
+void SchmittTrigger::setState(const SchmittTriggerState& state)
+{
+    m_state = state;
+
+    // when the state is reset the timer is reset as well
+    m_timer = 0;
+}
+
+const SchmittTriggerState& SchmittTrigger::getOutput() const
+{
+    return m_state;
+}

--- a/src/Math/src/SchmittTrigger.cpp
+++ b/src/Math/src/SchmittTrigger.cpp
@@ -80,7 +80,7 @@ bool SchmittTrigger::advance()
     // if the trigger is not active
     if (!m_state.state)
     {
-        // the state is deactivate this means that we can reset the fallingEdgeTimeInstant. We can
+        // the state is inactive this means that we can reset the fallingEdgeTimeInstant. We can
         // avoid to do this at every instant. However, coping a double is not the bootlneck. :)
         m_fallingEdgeTimeInstant = -1;
 
@@ -108,7 +108,7 @@ bool SchmittTrigger::advance()
     } else
     {
 
-        // the state is deactivate this means that we can reset the risingEdgeTimeInstant. We can
+        // the state is inactive this means that we can reset the risingEdgeTimeInstant. We can
         // avoid to do this at every instant. However, coping a double is not the bootlneck. :)
         m_risingEdgeTimeInstant = -1;
 

--- a/src/Math/tests/CMakeLists.txt
+++ b/src/Math/tests/CMakeLists.txt
@@ -17,3 +17,9 @@ add_bipedal_test(
   NAME Wrench
   SOURCES WrenchTest.cpp
   LINKS BipedalLocomotion::Math)
+
+
+add_bipedal_test(
+  NAME SchmittTrigger
+  SOURCES SchmittTriggerTest.cpp
+  LINKS BipedalLocomotion::Math iDynTree::idyntree-estimation)

--- a/src/Math/tests/SchmittTriggerTest.cpp
+++ b/src/Math/tests/SchmittTriggerTest.cpp
@@ -1,0 +1,68 @@
+/**
+ * @file SchmittTriggerTest.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+// Catch2
+#include <catch2/catch.hpp>
+
+#include <BipedalLocomotion/Math/SchmittTrigger.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+using namespace BipedalLocomotion::Math;
+
+TEST_CASE("Schmitt trigger - Invalid threshold")
+{
+    SchmittTrigger trigger;
+    auto paramHandler = std::make_shared<BipedalLocomotion::ParametersHandler::StdImplementation>();
+    paramHandler->setParameter("on_threshold", 0.0);
+    paramHandler->setParameter("off_threshold", 0.1);
+    paramHandler->setParameter("switch_on_after", 0.5);
+    paramHandler->setParameter("switch_off_after", 0.5);
+
+    REQUIRE_FALSE(trigger.initialize(paramHandler));
+}
+
+TEST_CASE("Schmitt trigger - Same threshold")
+{
+    SchmittTrigger trigger;
+    auto paramHandler = std::make_shared<BipedalLocomotion::ParametersHandler::StdImplementation>();
+    constexpr double switchOffAfter = 0.2;
+    constexpr double switchOnAfter = 0.2;
+    constexpr double onThreshold = 0;
+    constexpr double offThreshold = 0;
+    paramHandler->setParameter("on_threshold", onThreshold);
+    paramHandler->setParameter("off_threshold", offThreshold);
+    paramHandler->setParameter("switch_on_after", switchOnAfter);
+    paramHandler->setParameter("switch_off_after", switchOffAfter);
+
+    REQUIRE(trigger.initialize(paramHandler));
+
+    SchmittTriggerState initialState;
+    trigger.setState(initialState);
+
+    constexpr double samplingTime = 0.01;
+    constexpr double timeWindow = 10;
+    for (unsigned int i = 0; i < timeWindow / samplingTime; i++)
+    {
+        const double t = samplingTime * i;
+        const double signal = 10 * std::sin(2 * M_PI * t);
+
+        trigger.setInput({t, signal});
+        REQUIRE(trigger.advance());
+
+        if (t < 0.2)
+        {
+            // In this time slot the output should be false
+            REQUIRE_FALSE(trigger.getOutput().state);
+        }
+        else if (t < 0.69)
+        {
+            // In this time slot the output should be true
+            REQUIRE(trigger.getOutput().state);
+        }
+
+    }
+}


### PR DESCRIPTION
This is the first PR that will bring the [CentroidalMPC](https://github.com/ami-iit/paper_romualdi_2022_icra_centroidal-mpc-walking) merged in master. 
While implementing the [`WholeBodyQPBlock`](https://github.com/ami-iit/paper_romualdi_2022_icra_centroidal-mpc-walking/blob/bd9f6a2537d45ca9c0c6bb6441bebbe4022087f3/src/centroidal-mpc-walking/src/WholeBodyQPBlock.cpp), I noticed that the behavior of `FixedFootDetector` (the class used to get the fixed foot given planned footsteps) was not coherent with the others advanceable in the project. Indeed, before this PR, a user had to call `FixedFootDetector::getFixedFoot()` before calling `FixedFootDetector::advance()`. This behavior was counterintuitive since the `Advanceable` should be able to provide its output only if `advance()` is called. Moreover, the `FixedFootDetector` internal timer was reset when a new sequence of contact was provided. This prevented the usage of `FixedFootDetector` without having a predefined contact sequence. 
Thanks to this refactory the `FixedFootDetector` usage becomes similar to the others
advanceable. Indeed now `advance()` considers the input set by the user and provides the
corresponding output.
⚠️   Even if this modification does not break the API the user may notice some strange behavior if `advance()` was called after getting the output of the detector. The only user affected by this modification should be (@GiulioRomualdi in [paper_romualdi_2022_icra_centroidal-mpc-walking](https://github.com/ami-iit/paper_romualdi_2022_icra_centroidal-mpc-walking))

While implementing [paper_romualdi_2022_icra_centroidal-mpc-walking](https://github.com/ami-iit/paper_romualdi_2022_icra_centroidal-mpc-walking)), I also noticed some undesired behavior due to the number representation of double. Indeed I noticed that the following code
```c++
double time = 0.0
double dt = 0.1;
time += dt;
time += dt;
time += dt;

bool is_lower_equal = time <= 0.3;
```
 was giving me `is_lower_equal == False`. This is due to [round-off error](https://en.wikipedia.org/wiki/Round-off_error) Indeed `time` was slightly lower than 0.3 (for instance `0.3 - 1e-8`). This commit https://github.com/ami-iit/bipedal-locomotion-framework/pull/624/commits/2b6ada8629517a2175dbdf32220be1ce7397590c robustifies the comparison by adding a tolerance (by default equal to 0) that considers the round-off error.

Last but not least in the refractory I also moved the implementation of the `SchmittTrigger` into the math component since it can be used also by other components.