### PR TITLE
Refactor how the time is handled in the entire framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 ### Added
 - Implement the `DiscreteGeometryContact` in Contacts component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/626)
 - Implement the `SchmittTrigger` in component `Math` and the associated python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/624)
+- Add the support of `std::chrono` in The text logging (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Add the possibility to retrieve and set duration from the `IParametersHandler` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 
 ### Changed
 - Update the `IK tutorial` to use `QPInverseKinematics::build` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/621)
@@ -13,6 +15,11 @@ All notable changes to this project are documented in this file.
   Thanks to this refactory the `FixedFootDetector` usage becomes similar to the others `advanceable`.
   Indeed now `FixedFootDetector::advace()` considers the input set by the user and provides the corresponding output.
   ⚠️  Even if this modification do not break the API the user may notice some strange behavior if `advance` was called after getting the output of the detector.
+- Restructure the `Contacts` component to handle time with `std::chrono::nanoseconds` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Restructure the `Planners` component to handle time with `std::chrono::nanoseconds` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Restructure the `FloatingBaseEstimator` component to handle time with `std::chrono::nanoseconds`(https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Update the `blf-position-tracking` to handle time with `std::chrono::nanoseconds` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Update the python bindings to consider the time with `std::chrono::nanoseconds` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 
 ### Fixed
 - Return an error if an invalid `KinDynComputations` object is passed to `QPInverseKinematics::build()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/622)

--- a/bindings/python/Contacts/src/ContactDetectors.cpp
+++ b/bindings/python/Contacts/src/ContactDetectors.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/chrono.h>
 
 #include <BipedalLocomotion/ContactDetectors/ContactDetector.h>
 #include <BipedalLocomotion/ContactDetectors/FixedFootDetector.h>

--- a/bindings/python/Contacts/src/Contacts.cpp
+++ b/bindings/python/Contacts/src/Contacts.cpp
@@ -5,11 +5,13 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <pybind11/chrono.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <iomanip>
+#include <chrono>
 
 #include <BipedalLocomotion/Contacts/Contact.h>
 #include <BipedalLocomotion/Contacts/ContactList.h>
@@ -40,8 +42,10 @@ std::string toString(const BipedalLocomotion::Contacts::PlannedContact& contact)
 
     std::stringstream description;
     description << "Contact (name = " << contact.name << ", pose = " << pose.str()
-                << std::setprecision(7) << ", activation_time = " << contact.activationTime
-                << ", deactivation_time = " << contact.deactivationTime
+                << std::setprecision(7) << ", activation_time = "
+                << std::chrono::duration<double>(contact.activationTime).count()
+                << ", deactivation_time = "
+                << std::chrono::duration<double>(contact.deactivationTime).count()
                 << ", type = " << static_cast<int>(contact.type) << ")";
 
     return description.str();
@@ -98,7 +102,9 @@ void CreateContactList(pybind11::module& module)
              py::overload_cast<const PlannedContact&>(&ContactList::addContact),
              py::arg("contact"))
         .def("add_contact",
-             py::overload_cast<const manif::SE3d&, double, double>(&ContactList::addContact),
+             py::overload_cast<const manif::SE3d&,
+                               const std::chrono::nanoseconds&,
+                               const std::chrono::nanoseconds&>(&ContactList::addContact),
              py::arg("transform"),
              py::arg("activation_time"),
              py::arg("deactivation_time"))
@@ -123,9 +129,8 @@ void CreateContactList(pybind11::module& module)
         .def("size", &ContactList::size)
         .def("__len__", &ContactList::size)
         .def("edit_contact", &ContactList::editContact, py::arg("element"), py::arg("new_contact"))
-        .def(
-            "get_present_contact",
-            [](const ContactList& l, const double time) -> PlannedContact {
+        .def("get_present_contact",
+            [](const ContactList& l, const std::chrono::nanoseconds& time) -> PlannedContact {
                 return *l.getPresentContact(time);
             },
             py::arg("time"))

--- a/bindings/python/Contacts/tests/test_contact.py
+++ b/bindings/python/Contacts/tests/test_contact.py
@@ -4,7 +4,7 @@ pytestmark = pytest.mark.planners
 import bipedal_locomotion_framework.bindings as blf
 import manifpy as manif
 import numpy as np
-
+from datetime import timedelta
 
 def test_contact():
 
@@ -12,8 +12,8 @@ def test_contact():
 
     # Default values
     assert contact.pose == manif.SE3(position=[0., 0, 0], quaternion=[0, 0, 0, 1])
-    assert contact.activation_time == 0.0
-    assert contact.deactivation_time == 0.0
+    assert contact.activation_time == timedelta(seconds=0)
+    assert contact.deactivation_time == timedelta(seconds=0)
     assert contact.name == "Contact"
     assert contact.type == blf.contacts.ContactType.Full
 
@@ -21,11 +21,8 @@ def test_contact():
     assert contact.pose.translation() == pytest.approx(np.array([1.0, -2.0, 3.3]))
     assert contact.pose.quat() == pytest.approx(np.array([0, 0, -1, 0]))
 
-    contact.activation_time = 42.0
-    assert contact.activation_time == 42.0
-
-    contact.deactivation_time = -42.0
-    assert contact.deactivation_time == -42.0
+    contact.activation_time = timedelta(seconds=42)
+    assert contact.activation_time == timedelta(seconds=42)
 
     contact.name = "MyNewContact"
     assert contact.name == "MyNewContact"
@@ -50,13 +47,13 @@ def test_contact_list():
 
     contact1 = blf.contacts.PlannedContact()
     contact1.name = "Contact1"
-    contact1.activation_time = 0.1
-    contact1.deactivation_time = 0.5
+    contact1.activation_time = timedelta(seconds=0.1)
+    contact1.deactivation_time = timedelta(seconds=0.5)
 
     contact2 = blf.contacts.PlannedContact()
     contact2.name = "Contact2"
-    contact2.activation_time = 1.0
-    contact2.deactivation_time = 1.5
+    contact2.activation_time = timedelta(seconds=1)
+    contact2.deactivation_time = timedelta(seconds=1.5)
 
     assert contact_list.add_contact(contact1)
     assert contact_list.add_contact(contact2)
@@ -66,8 +63,8 @@ def test_contact_list():
 
     contact3 = blf.contacts.PlannedContact()
     contact3.name = "Contact3"
-    contact3.activation_time = 0.6
-    contact3.deactivation_time = 0.8
+    contact3.activation_time = timedelta(seconds=0.6)
+    contact3.deactivation_time = timedelta(seconds=0.8)
 
     assert contact_list.add_contact(contact3)
     assert len(contact_list) == 3
@@ -75,8 +72,8 @@ def test_contact_list():
 
     contact3_bis = blf.contacts.PlannedContact()
     contact3_bis.name = "Contact3"
-    contact3_bis.activation_time = 0.9
-    contact3_bis.deactivation_time = 1.6
+    contact3_bis.activation_time = timedelta(seconds=0.9)
+    contact3_bis.deactivation_time = timedelta(seconds=1.6)
 
     assert not contact_list.add_contact(contact3_bis)
 
@@ -88,9 +85,9 @@ def test_contact_list():
     # contact_list[len(contact_list) - 1] = contact2_modified
     # assert contact_list[len(contact_list) - 1] == contact2_modified
 
-    assert contact2 == contact_list.get_present_contact(time=1.2)
-    assert contact2 == contact_list.get_present_contact(time=1.6)
-    assert contact3 == contact_list.get_present_contact(time=0.6)
+    assert contact2 == contact_list.get_present_contact(timedelta(seconds=1.2))
+    assert contact2 == contact_list.get_present_contact(timedelta(seconds=1.6))
+    assert contact3 == contact_list.get_present_contact(timedelta(seconds=0.6))
     # assert contact_list.get_present_contact(time=0.0) == \
     #        contact_list[len(contact_list) - 1]
 
@@ -117,8 +114,8 @@ def test_contact_phase():
     phase = blf.contacts.ContactPhase()
 
     # Default values
-    assert phase.begin_time == 0.0
-    assert phase.end_time == 0.0
+    assert phase.begin_time == timedelta(seconds=0)
+    assert phase.end_time == timedelta(seconds=0)
     assert phase.active_contacts == dict()
 
     list1 = blf.contacts.ContactList()

--- a/bindings/python/Contacts/tests/test_schmitt_trigger_detector.py
+++ b/bindings/python/Contacts/tests/test_schmitt_trigger_detector.py
@@ -2,6 +2,7 @@ import pytest
 pytestmark = pytest.mark.contact_detectors
 
 import bipedal_locomotion_framework.bindings as blf
+from datetime import timedelta
 
 
 def test_schmitt_trigger_detector():
@@ -10,54 +11,57 @@ def test_schmitt_trigger_detector():
     parameters_handler.set_parameter_vector_string("contacts", ["right"])
     parameters_handler.set_parameter_vector_float("contact_make_thresholds", [100.0])
     parameters_handler.set_parameter_vector_float("contact_break_thresholds", [10.0])
-    parameters_handler.set_parameter_vector_float("contact_make_switch_times", [0.2])
-    parameters_handler.set_parameter_vector_float("contact_break_switch_times", [0.2, 0.2])
+    parameters_handler.set_parameter_vector_datetime("contact_make_switch_times", [timedelta(seconds=0.2)])
+    parameters_handler.set_parameter_vector_datetime("contact_break_switch_times", [timedelta(seconds=0.2),
+                                                                                    timedelta(seconds=0.2)])
 
     detector = blf.contacts.SchmittTriggerDetector()
     assert(detector.initialize(parameters_handler) == False)
 
-    parameters_handler.set_parameter_vector_float("contact_break_switch_times", [0.2])
+    parameters_handler.set_parameter_vector_datetime("contact_break_switch_times", [timedelta(seconds=0.2)])
     assert(detector.initialize(parameters_handler))
 
     assert(detector.reset_contacts())
 
     # rise signal
     assert(detector.set_timed_trigger_input("right",
-                                            blf.math.SchmittTriggerInput(time=0.1, raw_value=120.0)))
+                                            blf.math.SchmittTriggerInput(time=timedelta(seconds=0.1), raw_value=120.0)))
     assert(detector.advance())
     assert(detector.set_timed_trigger_input("right",
-                                            blf.math.SchmittTriggerInput(time=0.2, raw_value=120.0)))
+                                            blf.math.SchmittTriggerInput(time=timedelta(seconds=0.2), raw_value=120.0)))
     assert(detector.advance())
     assert(detector.set_timed_trigger_input("right",
-                                            blf.math.SchmittTriggerInput(time=0.3, raw_value=120.0)))
+                                            blf.math.SchmittTriggerInput(time=timedelta(seconds=0.3), raw_value=120.0)))
     assert(detector.advance())
 
     # contact state should turn true
     right_contact = detector.get("right")
     assert(right_contact.is_active)
-    assert(right_contact.switch_time == 0.3)
+    assert(right_contact.switch_time == timedelta(seconds=0.3))
 
     # fall signal
     assert(detector.set_timed_trigger_input("right",
-                                            blf.math.SchmittTriggerInput(time=0.4, raw_value=7.0)))
+                                            blf.math.SchmittTriggerInput(time=timedelta(seconds=0.4), raw_value=7.0)))
     assert(detector.advance())
     assert(detector.set_timed_trigger_input("right",
-                                            blf.math.SchmittTriggerInput(time=0.5, raw_value=7.0)))
+                                            blf.math.SchmittTriggerInput(time=timedelta(seconds=0.5), raw_value=7.0)))
     assert(detector.advance())
     assert(detector.set_timed_trigger_input("right",
-                                            blf.math.SchmittTriggerInput(time=0.6, raw_value=7.0)))
+                                            blf.math.SchmittTriggerInput(time=timedelta(seconds=0.6), raw_value=7.0)))
     assert(detector.advance())
 
     # contact state should turn false
     right_contact = detector.get("right")
     assert(right_contact.is_active == False)
-    assert(right_contact.switch_time == 0.6)
+    assert(right_contact.switch_time == timedelta(seconds=0.6))
 
     # add a new contact
     params = blf.math.SchmittTrigger.Params(off_threshold=10, on_threshold=100,
-                                            switch_off_after=0.2, switch_on_after=0.2)
+                                            switch_off_after=timedelta(seconds=0.2),
+                                            switch_on_after=timedelta(seconds=0.2))
     detector.add_contact("left",
-                         blf.math.SchmittTriggerState(state=False, switch_time=0.6, edge_time=0.6),
+                         blf.math.SchmittTriggerState(state=False, switch_time=timedelta(seconds=0.6),
+                                                      edge_time=timedelta(seconds=0.6)),
                          params)
     contacts = detector.get_output()
     assert(len(contacts) == 2)
@@ -65,12 +69,12 @@ def test_schmitt_trigger_detector():
 
     # test multiple measurement updates
     right_input = blf.math.SchmittTriggerInput()
-    right_input.time = 0.7
+    right_input.time = timedelta(seconds=0.7)
     right_input.raw_value = 120
     left_input = blf.math.SchmittTriggerInput()
-    left_input.time = 0.7
+    left_input.time = timedelta(seconds=0.7)
     left_input.raw_value = 120
-    timed_inputs = {"right":right_input, "left":left_input}
+    timed_inputs = {"right": right_input, "left": left_input}
     assert(detector.set_timed_trigger_inputs(timed_inputs))
 
 

--- a/bindings/python/FloatingBaseEstimators/src/FloatingBaseEstimators.cpp
+++ b/bindings/python/FloatingBaseEstimators/src/FloatingBaseEstimators.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <pybind11/chrono.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/bindings/python/FloatingBaseEstimators/src/LeggedOdometry.cpp
+++ b/bindings/python/FloatingBaseEstimators/src/LeggedOdometry.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <pybind11/chrono.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/bindings/python/FloatingBaseEstimators/tests/test_legged_odometry.py
+++ b/bindings/python/FloatingBaseEstimators/tests/test_legged_odometry.py
@@ -5,13 +5,20 @@ import bipedal_locomotion_framework.bindings as blf
 import numpy as np
 import icub_models
 import idyntree.swig as idyn
+from datetime import timedelta
+
+
+def timerange(initial_time, end_time, dt):
+    for n in range(int((end_time - initial_time) / dt)):
+        yield initial_time + dt * n
+
 
 def get_kindyn():
 
     joints_list = ["neck_pitch", "neck_roll", "neck_yaw",
                    "torso_pitch", "torso_roll", "torso_yaw",
-                   "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw","l_elbow",
-                   "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw","r_elbow",
+                   "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow",
+                   "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",
                    "l_hip_pitch", "l_hip_roll", "l_hip_yaw","l_knee", "l_ankle_pitch", "l_ankle_roll",
                    "r_hip_pitch", "r_hip_roll", "r_hip_yaw","r_knee", "r_ankle_pitch", "r_ankle_roll"]
 
@@ -36,7 +43,7 @@ def test_legged_odometry():
     assert kindyn.getNrOfDegreesOfFreedom() == len(joints_list)
 
     # Set the joint positions to random values
-    joint_values = [np.random.uniform(-0.5,0.5) for _ in range(kindyn.getNrOfDegreesOfFreedom())]
+    joint_values = [np.random.uniform(-0.5, 0.5) for _ in range(kindyn.getNrOfDegreesOfFreedom())]
     assert kindyn.setJointPos(joint_values)
 
     # Set the robot state
@@ -92,7 +99,8 @@ def test_legged_odometry():
                          -0.5695, -0.3771, -0.0211])
     encoder_speeds = np.zeros_like(encoders)
 
-    for time in np.arange(start=0, step=dt, stop=10*dt):
+    for time in timerange(initial_time=timedelta(seconds=0), end_time=timedelta(seconds=10*dt), dt=timedelta(seconds=dt)):
+
         fixed_frame_idx = legged_odom.get_fixed_frame_index()
 
         # here we only fill measurement buffers

--- a/bindings/python/Math/src/SchmittTrigger.cpp
+++ b/bindings/python/Math/src/SchmittTrigger.cpp
@@ -5,7 +5,10 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
+
 #include <pybind11/pybind11.h>
+#include <pybind11/chrono.h>
 
 #include <BipedalLocomotion/Math/SchmittTrigger.h>
 #include <BipedalLocomotion/System/Advanceable.h>
@@ -25,23 +28,25 @@ void CreateSchmittTrigger(pybind11::module& module)
     namespace py = ::pybind11;
 
     py::class_<SchmittTriggerState>(module, "SchmittTriggerState")
-        .def(py::init([](bool state, double switchTime, double edgeTime) -> SchmittTriggerState {
+        .def(py::init([](bool state,
+                         std::chrono::nanoseconds switchTime,
+                         std::chrono::nanoseconds edgeTime) -> SchmittTriggerState {
                  return SchmittTriggerState{std::move(state),
                                             std::move(switchTime),
                                             std::move(edgeTime)};
              }),
              py::arg("state") = false,
-             py::arg("switch_time") = 0.0,
-             py::arg("edge_time") = 0.0)
+             py::arg("switch_time") = std::chrono::nanoseconds::zero(),
+             py::arg("edge_time") = std::chrono::nanoseconds::zero())
         .def_readwrite("state", &SchmittTriggerState::state)
         .def_readwrite("switch_time", &SchmittTriggerState::switchTime)
         .def_readwrite("edge_time", &SchmittTriggerState::edgeTime);
 
     py::class_<SchmittTriggerInput>(module, "SchmittTriggerInput")
-        .def(py::init([](double time, double rawValue) -> SchmittTriggerInput {
+        .def(py::init([](std::chrono::nanoseconds time, double rawValue) -> SchmittTriggerInput {
                  return SchmittTriggerInput{std::move(time), std::move(rawValue)};
              }),
-             py::arg("time") = 0.0,
+            py::arg("time") = std::chrono::nanoseconds::zero(),
              py::arg("raw_value") = 0.0)
         .def_readwrite("time", &SchmittTriggerInput::time)
         .def_readwrite("raw_value", &SchmittTriggerInput::rawValue);
@@ -58,28 +63,23 @@ void CreateSchmittTrigger(pybind11::module& module)
     py::class_<SchmittTrigger::Params>(schmittTrigger, "Params")
         .def(py::init([](double onThreshold,
                          double offThreshold,
-                         double switchOnAfter,
-                         double switchOffAfter,
-                         double timeComparisonThreshold) -> SchmittTrigger::Params {
+                         std::chrono::nanoseconds switchOnAfter,
+                         std::chrono::nanoseconds switchOffAfter) -> SchmittTrigger::Params {
                  SchmittTrigger::Params params;
                  params.onThreshold = std::move(onThreshold);
                  params.offThreshold = std::move(offThreshold);
                  params.switchOnAfter = std::move(switchOnAfter);
                  params.switchOffAfter = std::move(switchOffAfter);
-                 params.timeComparisonThreshold = std::move(timeComparisonThreshold);
                  return params;
              }),
              py::arg("on_threshold") = 0.0,
              py::arg("off_threshold") = 0.0,
-             py::arg("switch_on_after") = 0.0,
-             py::arg("switch_off_after") = 0.0,
-             py::arg("time_comparison_threshold") = std::numeric_limits<double>::epsilon())
+             py::arg("switch_on_after") = std::chrono::nanoseconds::zero(),
+             py::arg("switch_off_after") = std::chrono::nanoseconds::zero())
         .def_readwrite("on_threshold", &SchmittTrigger::Params::onThreshold)
         .def_readwrite("off_threshold", &SchmittTrigger::Params::offThreshold)
         .def_readwrite("switch_on_after", &SchmittTrigger::Params::switchOnAfter)
-        .def_readwrite("switch_off_after", &SchmittTrigger::Params::switchOffAfter)
-        .def_readwrite("time_comparison_threshold",
-                       &SchmittTrigger::Params::timeComparisonThreshold);
+        .def_readwrite("switch_off_after", &SchmittTrigger::Params::switchOffAfter);
 
     schmittTrigger.def(py::init())
         .def("set_state", &SchmittTrigger::setState, py::arg("state"))

--- a/bindings/python/ParametersHandler/src/ParametersHandler.cpp
+++ b/bindings/python/ParametersHandler/src/ParametersHandler.cpp
@@ -5,9 +5,12 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
+
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/chrono.h>
 
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
@@ -44,6 +47,11 @@ void CreateIParameterHandler(pybind11::module& module)
                  &IParametersHandler::setParameter),
              py::arg("name"),
              py::arg("value"))
+        .def("set_parameter_datetime",
+             py::overload_cast<const std::string&, const std::chrono::nanoseconds&>(
+                 &IParametersHandler::setParameter),
+             py::arg("name"),
+             py::arg("value"))
         .def("set_parameter_string",
              py::overload_cast<const std::string&, const std::string&>(
                  &IParametersHandler::setParameter),
@@ -73,6 +81,13 @@ void CreateIParameterHandler(pybind11::module& module)
             [](IParametersHandler& impl,
                const std::string& name,
                const std::vector<std::string>& vec) { impl.setParameter(name, vec); },
+            py::arg("name"),
+            py::arg("value"))
+        .def(
+            "set_parameter_vector_datetime",
+            [](IParametersHandler& impl,
+               const std::string& name,
+               const std::vector<std::chrono::nanoseconds>& vec) { impl.setParameter(name, vec); },
             py::arg("name"),
             py::arg("value"))
         .def("set_group", &IParametersHandler::setGroup, py::arg("name"), py::arg("new_group"))
@@ -105,6 +120,19 @@ void CreateIParameterHandler(pybind11::module& module)
             "get_parameter_int",
             [](const IParametersHandler& impl, const std::string& name) -> int {
                 int ret;
+
+                if (!impl.getParameter(name, ret))
+                {
+                    throw py::value_error("Failed to find a parameter that matches the type");
+                }
+
+                return ret;
+            },
+            py::arg("name"))
+        .def(
+            "get_parameter_datetime",
+            [](const IParametersHandler& impl, const std::string& name) -> std::chrono::nanoseconds {
+                std::chrono::nanoseconds ret;
 
                 if (!impl.getParameter(name, ret))
                 {
@@ -180,6 +208,18 @@ void CreateIParameterHandler(pybind11::module& module)
             "get_parameter_vector_string",
             [](const IParametersHandler& impl, const std::string& name) {
                 if (std::vector<std::string> ret; !impl.getParameter(name, ret))
+                {
+                    throw py::value_error("Failed to find a parameter that matches the type");
+                } else
+                {
+                    return ret;
+                }
+            },
+            py::arg("name"))
+        .def(
+            "get_parameter_vector_datetime",
+            [](const IParametersHandler& impl, const std::string& name) {
+                if (std::vector<std::chrono::nanoseconds> ret; !impl.getParameter(name, ret))
                 {
                     throw py::value_error("Failed to find a parameter that matches the type");
                 } else

--- a/bindings/python/Planners/CMakeLists.txt
+++ b/bindings/python/Planners/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_Planners AND FRAMEWORK_COMPILE_Unicycle)
+if(FRAMEWORK_COMPILE_Planners)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/Planners)
 
@@ -13,25 +13,35 @@ if(FRAMEWORK_COMPILE_Planners AND FRAMEWORK_COMPILE_Unicycle)
     src/TimeVaryingDCMPlanner.cpp
     src/Spline.cpp
     src/SwingFootPlanner.cpp
-    src/UnicyclePlanner.cpp
     src/Module.cpp
     HEADERS
     ${H_PREFIX}/DCMPlanner.h
     ${H_PREFIX}/TimeVaryingDCMPlanner.h
     ${H_PREFIX}/Spline.h
     ${H_PREFIX}/SwingFootPlanner.h
-    ${H_PREFIX}/UnicyclePlanner.h
     ${H_PREFIX}/Module.h
     LINK_LIBRARIES
     BipedalLocomotion::System
     BipedalLocomotion::Planners
-    BipedalLocomotion::Unicycle
     BipedalLocomotion::Contacts
     TESTS
     tests/test_quintic_spline.py
     tests/test_swing_foot_planner.py
     tests/test_time_verying_dcm_planner.py
-    tests/test_unicycle_planner.py
+    )
+
+endif()
+
+if(FRAMEWORK_COMPILE_Unicycle)
+
+  set(H_PREFIX include/BipedalLocomotion/bindings/Planners)
+
+  add_bipedal_locomotion_python_module(
+    NAME UnicycleBindings
+    SOURCES src/UnicyclePlanner.cpp src/UnicycleModule.cpp
+    HEADERS  ${H_PREFIX}/UnicyclePlanner.h ${H_PREFIX}/UnicycleModule.h
+    LINK_LIBRARIES BipedalLocomotion::Unicycle
+    TESTS tests/test_unicycle_planner.py
     )
 
 endif()

--- a/bindings/python/Planners/CMakeLists.txt
+++ b/bindings/python/Planners/CMakeLists.txt
@@ -27,7 +27,7 @@ if(FRAMEWORK_COMPILE_Planners)
     TESTS
     tests/test_quintic_spline.py
     tests/test_swing_foot_planner.py
-    tests/test_time_verying_dcm_planner.py
+    tests/test_time_varying_dcm_planner.py
     )
 
 endif()

--- a/bindings/python/Planners/include/BipedalLocomotion/bindings/Planners/UnicycleModule.h
+++ b/bindings/python/Planners/include/BipedalLocomotion/bindings/Planners/UnicycleModule.h
@@ -1,0 +1,26 @@
+/**
+ * @file UnicycleModule.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_PLANNERS_UNICYCLE_MODULE_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_PLANNERS_UNICYCLE_MODULE_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace Planners
+{
+
+void CreateUnicycleModule(pybind11::module& module);
+
+} // namespace Planners
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_PLANNERS_UNICYCLE_MODULE_H

--- a/bindings/python/Planners/src/Module.cpp
+++ b/bindings/python/Planners/src/Module.cpp
@@ -1,5 +1,5 @@
 /**
- * @file ParametersHandler.cpp
+ * @file Module.cpp
  * @authors Giulio Romualdi, Diego Ferigo
  * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the BSD-3-Clause license.
@@ -12,7 +12,6 @@
 #include <BipedalLocomotion/bindings/Planners/Spline.h>
 #include <BipedalLocomotion/bindings/Planners/SwingFootPlanner.h>
 #include <BipedalLocomotion/bindings/Planners/TimeVaryingDCMPlanner.h>
-#include <BipedalLocomotion/bindings/Planners/UnicyclePlanner.h>
 
 namespace BipedalLocomotion
 {
@@ -30,7 +29,6 @@ void CreateModule(pybind11::module& module)
     CreateDCMPlanner(module);
     CreateTimeVaryingDCMPlanner(module);
     CreateSwingFootPlanner(module);
-    CreateUnicyclePlanner(module);
 }
 } // namespace Planners
 } // namespace bindings

--- a/bindings/python/Planners/src/Spline.cpp
+++ b/bindings/python/Planners/src/Spline.cpp
@@ -7,9 +7,11 @@
 
 #include <Eigen/Dense>
 
+#include <chrono>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/chrono.h>
 
 #include <BipedalLocomotion/Planners/QuinticSpline.h>
 #include <BipedalLocomotion/Planners/CubicSpline.h>
@@ -47,7 +49,7 @@ void CreateSpline(pybind11::module& module)
              py::arg("velocity"),
              py::arg("acceleration"))
         .def("evaluate_point",
-             py::overload_cast<const double&,
+             py::overload_cast<const std::chrono::nanoseconds&,
                                Eigen::Ref<Eigen::VectorXd>,
                                Eigen::Ref<Eigen::VectorXd>,
                                Eigen::Ref<Eigen::VectorXd>>(&Spline::evaluatePoint),

--- a/bindings/python/Planners/src/UnicycleModule.cpp
+++ b/bindings/python/Planners/src/UnicycleModule.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file UnicycleModule.cpp
+ * @authors Giulio Romualdi, Diego Ferigo
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include <BipedalLocomotion/bindings/Planners/UnicycleModule.h>
+#include <BipedalLocomotion/bindings/Planners/UnicyclePlanner.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace Planners
+{
+void CreateUnicycleModule(pybind11::module& module)
+{
+    CreateUnicyclePlanner(module);
+}
+} // namespace Planners
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/Planners/tests/test_swing_foot_planner.py
+++ b/bindings/python/Planners/tests/test_swing_foot_planner.py
@@ -4,6 +4,7 @@ pytestmark = pytest.mark.planners
 import bipedal_locomotion_framework.bindings as blf
 import manifpy as manif
 import numpy as np
+from datetime import timedelta
 
 
 def test_swing_foot_planner_state():
@@ -36,41 +37,40 @@ def test_swing_foot_planner():
     tf1 = manif.SE3(position=[0.9, 0, 0],
                     quaternion=R.from_euler(seq="z", angles=np.pi / 2).as_quat())
     assert contact_list.add_contact(transform=tf1,
-                                    activation_time=0.0,
-                                    deactivation_time=0.3)
+                                    activation_time=timedelta(seconds=0),
+                                    deactivation_time=timedelta(seconds=0.3))
 
     # Second footstep
     tf2 = manif.SE3(position=[0.8899, 0.1345, 0.0600],
                     quaternion=R.from_euler(seq="z", angles=1.7208).as_quat())
     assert contact_list.add_contact(transform=tf2,
-                                    activation_time=0.6,
-                                    deactivation_time=1.5)
+                                    activation_time=timedelta(seconds=0.6),
+                                    deactivation_time=timedelta(seconds=1.5))
 
     # Third footstep
     tf3 = manif.SE3(position=[0.8104, 0.3915, 0.1800],
                     quaternion=R.from_euler(seq="z", angles=2.0208).as_quat())
     assert contact_list.add_contact(transform=tf3,
-                                    activation_time=1.8,
-                                    deactivation_time=2.7)
+                                    activation_time=timedelta(seconds=1.8),
+                                    deactivation_time=timedelta(seconds=2.7))
 
     # Fourth footstep
     tf4 = manif.SE3(position=[0.6585, 0.6135, 0.3000],
                     quaternion=R.from_euler(seq="z", angles=2.3208).as_quat())
     assert contact_list.add_contact(transform=tf4,
-                                    activation_time=3.0,
-                                    deactivation_time=3.9)
+                                    activation_time=timedelta(seconds=3.0),
+                                    deactivation_time=timedelta(seconds=3.9))
 
     # Fifth footstep
     tf5 = manif.SE3(position=[0.3261, 0.8388, 0.4800],
                     quaternion=R.from_euler(seq="z", angles=2.7708).as_quat())
     assert contact_list.add_contact(transform=tf5,
-                                    activation_time=4.2,
-                                    deactivation_time=6.0)
+                                    activation_time=timedelta(seconds=4.2),
+                                    deactivation_time=timedelta(seconds=6))
 
-    dT = 0.01
-
+    dT = timedelta(seconds=0.01)
     parameters_handler = blf.parameters_handler.StdParametersHandler()
-    parameters_handler.set_parameter_float("sampling_time", dT)
+    parameters_handler.set_parameter_datetime("sampling_time", dT)
     parameters_handler.set_parameter_float("step_height", 0.1)
     parameters_handler.set_parameter_float("foot_apex_time", 0.5)
     parameters_handler.set_parameter_float("foot_landing_velocity", 0.0)
@@ -82,7 +82,7 @@ def test_swing_foot_planner():
     assert planner.initialize(handler=parameters_handler)
     planner.set_contact_list(contact_list=contact_list)
 
-    num_of_iterations = (contact_list[len(contact_list) - 1].deactivation_time + 1) / dT
+    num_of_iterations = (contact_list[len(contact_list) - 1].deactivation_time.total_seconds() + 1) / dT.total_seconds()
 
     for i in range(int(num_of_iterations)):
 

--- a/bindings/python/Planners/tests/test_time_varying_dcm_planner.py
+++ b/bindings/python/Planners/tests/test_time_varying_dcm_planner.py
@@ -4,6 +4,7 @@ pytestmark = pytest.mark.planners
 import bipedal_locomotion_framework.bindings as blf
 import manifpy as manif
 import numpy as np
+from datetime import timedelta
 
 
 def test_dcm_planner_state():
@@ -38,15 +39,15 @@ def test_time_varying_dcm_planner():
     assert contact_list_map["left"].add_contact(
         transform=manif.SE3(position=np.array([0, -0.8, 0]),
                             quaternion=np.array([0, 0, 0, 1])),
-        activation_time=0.0,
-        deactivation_time=1.0)
+        activation_time=timedelta(seconds=0),
+        deactivation_time=timedelta(seconds=1))
 
     # L2: second footstep
     assert contact_list_map["left"].add_contact(
         transform=manif.SE3(position=np.array([0.25, -0.8, 0.2]),
                             quaternion=np.array([0, 0, 0, 1])),
-        activation_time=2.0,
-        deactivation_time=7.0)
+        activation_time=timedelta(seconds=2),
+        deactivation_time=timedelta(seconds=7))
 
     # Right foot
     contact_list_map["right"] = blf.contacts.ContactList()
@@ -55,15 +56,15 @@ def test_time_varying_dcm_planner():
     assert contact_list_map["right"].add_contact(
         transform=manif.SE3(position=np.array([0, 0.8, 0]),
                             quaternion=np.array([0, 0, 0, 1])),
-        activation_time=0.0,
-        deactivation_time=3.0)
+        activation_time=timedelta(seconds=0),
+        deactivation_time=timedelta(seconds=3))
 
     # R2: second footstep
     assert contact_list_map["right"].add_contact(
         transform=manif.SE3(position=np.array([0.25, 0.8, 0.2]),
                             quaternion=np.array([0, 0, 0, 1])),
-        activation_time=4.0,
-        deactivation_time=7.0)
+        activation_time=timedelta(seconds=4),
+        deactivation_time=timedelta(seconds=7))
 
     # Create the contact phase list
     phase_list = blf.contacts.ContactPhaseList()
@@ -71,7 +72,7 @@ def test_time_varying_dcm_planner():
 
     # Set the parameters
     handler = blf.parameters_handler.StdParametersHandler()
-    handler.set_parameter_float(name="planner_sampling_time", value=0.05)
+    handler.set_parameter_datetime(name="planner_sampling_time", value=timedelta(seconds=0.05))
     handler.set_parameter_int(name="number_of_foot_corners", value=4)
 
     # Set the foot corners

--- a/bindings/python/bipedal_locomotion_framework.cpp.in
+++ b/bindings/python/bipedal_locomotion_framework.cpp.in
@@ -50,6 +50,10 @@
 #include <BipedalLocomotion/bindings/Planners/Module.h>
 @endcmakeif FRAMEWORK_COMPILE_Planners
 
+@cmakeif FRAMEWORK_COMPILE_Unicycle
+#include <BipedalLocomotion/bindings/Planners/UnicycleModule.h>
+@endcmakeif FRAMEWORK_COMPILE_Unicycle
+
 @cmakeif FRAMEWORK_COMPILE_BINDINGS_RobotInterface
 #include <BipedalLocomotion/bindings/RobotInterface/Module.h>
 @endcmakeif FRAMEWORK_COMPILE_BINDINGS_RobotInterface
@@ -139,6 +143,10 @@ PYBIND11_MODULE(bindings, m)
     py::module plannersModule = m.def_submodule("planners");
     bindings::Planners::CreateModule(plannersModule);
     @endcmakeif FRAMEWORK_COMPILE_Planners
+
+    @cmakeif FRAMEWORK_COMPILE_Unicycle
+    bindings::Planners::CreateUnicycleModule(plannersModule);
+    @endcmakeif FRAMEWORK_COMPILE_Unicycle
 
     @cmakeif FRAMEWORK_COMPILE_BINDINGS_RobotInterface
     py::module robotInterfaceModule = m.def_submodule("robot_interface");

--- a/cmake/AddBipedalLocomotionUnitTest.cmake
+++ b/cmake/AddBipedalLocomotionUnitTest.cmake
@@ -52,7 +52,7 @@ function(add_bipedal_test)
           "${unit_test_files}")
 
       target_link_libraries(${targetname} PRIVATE CatchTestMain ${${prefix}_LINKS})
-      target_compile_definitions(${targetname} PRIVATE CATCH_CONFIG_FAST_COMPILE CATCH_CONFIG_DISABLE_MATCHERS)
+      target_compile_definitions(${targetname} PRIVATE CATCH_CONFIG_FAST_COMPILE CATCH_CONFIG_DISABLE_MATCHERS CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER)
       target_compile_features(${targetname} PUBLIC cxx_std_17)
       target_compile_definitions(${targetname} PRIVATE -D_USE_MATH_DEFINES)
 

--- a/cmake/Catch2Main.cpp.in
+++ b/cmake/Catch2Main.cpp.in
@@ -5,5 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#define CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER // this is not enabled by default as explained in
+                                               // https://github.com/catchorg/Catch2/issues/1039
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>

--- a/src/Contacts/include/BipedalLocomotion/ContactDetectors/FixedFootDetector.h
+++ b/src/Contacts/include/BipedalLocomotion/ContactDetectors/FixedFootDetector.h
@@ -13,6 +13,7 @@
 #include <BipedalLocomotion/Contacts/Contact.h>
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 
+#include <chrono>
 #include <memory>
 
 namespace BipedalLocomotion
@@ -67,8 +68,10 @@ namespace Contacts
 class FixedFootDetector : public ContactDetector
 {
     ContactPhaseList m_contactPhaselist; /**< List of the contacts */
-    double m_currentTime{0}; /**< Current time in seconds */
-    double m_dT{0}; /**< Fixed sampling time in seconds */
+    std::chrono::nanoseconds m_currentTime{std::chrono::nanoseconds::zero()}; /**< Current time in
+                                                                                 seconds */
+    std::chrono::nanoseconds m_dT{std::chrono::nanoseconds::zero()}; /**< Fixed sampling time in
+                                                                        seconds */
     EstimatedContact m_dummyContact; /**< A dummy esitmated contact */
 
     /**
@@ -83,9 +86,9 @@ public:
      * Initialize the detector.
      * @param handler pointer to the parameter handler.
      * @note the following parameters are required by the class
-     * |   Parameter Name  |    Type    |                Description                 | Mandatory |
-     * |:-----------------:|:----------:|:------------------------------------------:|:---------:|
-     * |  `sampling_time`  |  `double`  |  Sampling time of the detector is seconds  |    Yes    |
+     * |   Parameter Name  |           Type        |                Description                 | Mandatory |
+     * |:-----------------:|:---------------------:|:------------------------------------------:|:---------:|
+     * |  `sampling_time`  | `chrono::nanoseconds` |  Sampling time of the detector is seconds  |    Yes    |
      * @return true in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
@@ -104,9 +107,9 @@ public:
 
     /**
      * Reset the time
-     * @param time the time in seconds
+     * @param time time
      */
-    void resetTime(const double& time);
+    void resetTime(const std::chrono::nanoseconds& time);
 
     /**
      * Get the fixed foot

--- a/src/Contacts/include/BipedalLocomotion/Contacts/Contact.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/Contact.h
@@ -8,8 +8,11 @@
 #ifndef BIPEDAL_LOCOMOTION_CONTACTS_CONTACT_H
 #define BIPEDAL_LOCOMOTION_CONTACTS_CONTACT_H
 
+#include <cmath>
+#include <ratio>
 #include <string>
 #include <vector>
+#include <chrono>
 
 #include <Eigen/Dense>
 #include <manif/SE3.h>
@@ -71,12 +74,12 @@ struct PlannedContact : ContactBase
     /**
      * Instant from which the contact can be considered active.
      */
-    double activationTime{0.0};
+    std::chrono::nanoseconds activationTime{std::chrono::nanoseconds::zero()};
 
     /**
      * Instant after which the contact is no more active.
      */
-    double deactivationTime{0.0};
+    std::chrono::nanoseconds deactivationTime{std::chrono::nanoseconds::zero()};
 
     /**
      * @brief The equality operator.
@@ -96,7 +99,7 @@ struct EstimatedContact : ContactBase
     /**
      * Instant at which the contact state was toggled.
      */
-    double switchTime{0.0};
+    std::chrono::nanoseconds switchTime{std::chrono::nanoseconds::zero()};
 
     /**
      * Current state of contact
@@ -107,11 +110,11 @@ struct EstimatedContact : ContactBase
      * Time at which the contact details were last updated
      * This field helps in forgetting contacts
      */
-    double lastUpdateTime{0.0};
+    std::chrono::nanoseconds lastUpdateTime{std::chrono::nanoseconds::zero()};
 
-    std::pair<bool, double> getContactDetails() const;
+    std::pair<bool, std::chrono::nanoseconds> getContactDetails() const;
 
-    void setContactStateStamped(const std::pair<bool, double>& pair);
+    void setContactStateStamped(const std::pair<bool, std::chrono::nanoseconds>& pair);
 };
 
 /**

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactList.h
@@ -11,10 +11,10 @@
 // BipedalLocomotion
 #include <BipedalLocomotion/Contacts/Contact.h>
 
-//iDynTree
 #include <manif/manif.h>
 
 // std
+#include <chrono>
 #include <functional>
 #include <set>
 #include <string>
@@ -27,8 +27,9 @@ namespace Contacts
 
 /**
  * @brief Class containing a list of contacts.
- * The contact are added such that the activation time is strictly growing. In addition, contacts cannot be overlapping.
- * It represents a series of contact activations and deactivations of a single entity.
+ * The contact are added such that the activation time is strictly growing. In addition, contacts
+ * cannot be overlapping. It represents a series of contact activations and deactivations of a
+ * single entity.
  */
 class ContactList
 {
@@ -45,7 +46,8 @@ class ContactList
                                                      structure for inserting and ordering
                                                      contacts. **/
     std::string m_defaultName{"ContactList"}; /** Default name for the contact list. **/
-    BipedalLocomotion::Contacts::ContactType m_defaultContactType{BipedalLocomotion::Contacts::ContactType::FULL}; /** Default contact type. **/
+    BipedalLocomotion::Contacts::ContactType m_defaultContactType{
+        BipedalLocomotion::Contacts::ContactType::FULL}; /** Default contact type. **/
     int m_defaultIndex{-1}; /**< Default Frame index of the contact */
 
 public:
@@ -94,7 +96,8 @@ public:
      * @brief Add a new contact to the list.
      * @param newContact The new contact
      * @return false if it was not possible to insert the contact.
-     * Possible failures: the activation time is greater than the deactivation time, or the new contact ovelaps with an existing contact.
+     * Possible failures: the activation time is greater than the deactivation time, or the new
+     * contact overlaps with an existing contact.
      */
     bool addContact(const BipedalLocomotion::Contacts::PlannedContact& newContact);
 
@@ -106,9 +109,12 @@ public:
      * @param activationTime The activation time.
      * @param deactivationTime The deactivation time.
      * @return false if it was not possible to insert the contact.
-     * Possible failures: the activation time is greater than the deactivation time, or the new contact ovelaps with an existing contact.
+     * Possible failures: the activation time is greater than the deactivation time, or the new
+     * contact overlaps with an existing contact.
      */
-    bool addContact(const manif::SE3d& newTransform, double activationTime, double deactivationTime);
+    bool addContact(const manif::SE3d& newTransform,
+                    const std::chrono::nanoseconds& activationTime,
+                    const std::chrono::nanoseconds& deactivationTime);
 
     /**
      * @brief Erase a contact
@@ -128,12 +134,14 @@ public:
     const_iterator cbegin() const;
 
     /**
-     * @brief Return a const reverse iterator to the contacts (basically starting from the last contact going backward).
+     * @brief Return a const reverse iterator to the contacts (basically starting from the last
+     * contact going backward).
      */
     const_reverse_iterator rbegin() const;
 
     /**
-     * @brief Return a const reverse iterator to the contacts (basically starting from the last contact going backward).
+     * @brief Return a const reverse iterator to the contacts (basically starting from the last
+     * contact going backward).
      */
     const_reverse_iterator crbegin() const;
 
@@ -193,7 +201,8 @@ public:
      * @brief Edit an existing contact.
      * @param element Iterator to the element to edit.
      * @param newContact The new contact
-     * @return false if the element is not valid or if the new contact timing would require a reordering of the list.
+     * @return false if the element is not valid or if the new contact timing would require a
+     * reordering of the list.
      */
     bool editContact(const_iterator element,
                      const BipedalLocomotion::Contacts::PlannedContact& newContact);
@@ -208,14 +217,14 @@ public:
      * @return an iterator to the last contact  having an activation time lower than time.
      * If no contact satisfy this condition, it returns a pointer to the end.
      */
-    const_iterator getPresentContact(double time) const;
+    const_iterator getPresentContact(const std::chrono::nanoseconds& time) const;
 
     /**
      * @brief Clear all the steps, except the one returned by getPresentContact
      * @param time The present time.
      * @return false if no contact is available at this time.
      */
-    bool keepOnlyPresentContact(double time);
+    bool keepOnlyPresentContact(const std::chrono::nanoseconds& time);
 
     /**
      * @brief Clear the contacts.
@@ -226,7 +235,6 @@ public:
      * @brief Remove only the last contact.
      */
     void removeLastContact();
-
 };
 
 /**

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhase.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhase.h
@@ -10,6 +10,8 @@
 
 #include <BipedalLocomotion/Contacts/Contact.h>
 #include <BipedalLocomotion/Contacts/ContactList.h>
+
+#include <chrono>
 #include <unordered_map>
 #include <string>
 
@@ -33,12 +35,12 @@ struct ContactPhase
     /**
      * @brief The phase initial time.
      **/
-    double beginTime {0.0};
+    std::chrono::nanoseconds beginTime {std::chrono::nanoseconds::zero()};
 
     /**
      * @brief The phase end time.
      **/
-    double endTime {0.0};
+    std::chrono::nanoseconds endTime {std::chrono::nanoseconds::zero()};
 
     /**
      * @brief The set of contacts active during the phase.

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
@@ -11,7 +11,6 @@
 #include <BipedalLocomotion/Contacts/Contact.h>
 #include <BipedalLocomotion/Contacts/ContactList.h>
 #include <BipedalLocomotion/Contacts/ContactPhase.h>
-#include <BipedalLocomotion/Math/Constants.h>
 
 #include <initializer_list>
 #include <vector>
@@ -112,14 +111,10 @@ public:
      * It returns the contact phase with the highest begin time lower than time.
      * If no contacts phase has a begin time lower than time, it returns an iterator to the end.
      * @param time The present time.
-     * @param tolerance positive parameter used for the comparison of two time instants. Given two
-     * instants if the error between the two is lower than the tolerance, the time instants are
-     * considered equal. Default value BipedalLocomotion::Math::AbsoluteEqualityDoubleTolerance
      * @return an iterator to the last phase having an activation time lower than time.
      * If no phase satisfies this condition, it returns a pointer to the end.
      */
-    const_iterator getPresentPhase(double time, //
-                                   double tolerance = BipedalLocomotion::Math::AbsoluteEqualityDoubleTolerance) const;
+    const_iterator getPresentPhase(const std::chrono::nanoseconds& time) const;
 
     /**
      * @brief A reference to the lists stored in this class.

--- a/src/Contacts/src/Contact.cpp
+++ b/src/Contacts/src/Contact.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <BipedalLocomotion/Contacts/Contact.h>
+#include <chrono>
 
 using namespace BipedalLocomotion::Contacts;
 
@@ -22,12 +23,12 @@ bool PlannedContact::operator==(const PlannedContact& other) const
     return eq;
 }
 
-std::pair<bool, double> EstimatedContact::getContactDetails() const
+std::pair<bool, std::chrono::nanoseconds> EstimatedContact::getContactDetails() const
 {
     return std::make_pair(isActive, switchTime);
 }
 
-void EstimatedContact::setContactStateStamped(const std::pair<bool, double>& pair)
+void EstimatedContact::setContactStateStamped(const std::pair<bool, std::chrono::nanoseconds>& pair)
 {
     isActive = pair.first;
     switchTime = pair.second;

--- a/src/Contacts/src/ContactDetector.cpp
+++ b/src/Contacts/src/ContactDetector.cpp
@@ -7,6 +7,7 @@
 
 #include <BipedalLocomotion/ContactDetectors/ContactDetector.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
+#include <chrono>
 
 using namespace BipedalLocomotion::ParametersHandler;
 using namespace BipedalLocomotion::Contacts;
@@ -15,7 +16,7 @@ bool ContactDetector::resetContacts()
 {
     for (auto& [name, contact] : m_contactStates)
     {
-        contact.switchTime = 0.0;
+        contact.switchTime = std::chrono::nanoseconds::zero();
         contact.isActive = false;
     }
     return true;

--- a/src/Contacts/src/ContactListJsonParser.cpp
+++ b/src/Contacts/src/ContactListJsonParser.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
 #include <fstream>
 
 #include <nlohmann/json.hpp>
@@ -67,8 +68,10 @@ ContactListMap contactListMapFromJson(const std::string& filename)
 
                 tempContact.pose.quat(Eigen::Map<const manif::SO3d>(quaternion.data()));
                 tempContact.pose.translation(Eigen::Map<const Eigen::Vector3d>(position.data()));
-                tempContact.activationTime = contact.at("activation_time");
-                tempContact.deactivationTime = contact.at("deactivation_time");
+                tempContact.activationTime = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::duration<double>(contact.at("activation_time")));
+                tempContact.deactivationTime = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::duration<double>(contact.at("deactivation_time")));
                 tempContact.name = contact.at("name");
                 tempContact.index = contact.at("index");
             } catch (const nlohmann::json::out_of_range& exception)
@@ -117,8 +120,10 @@ bool contactListMapToJson(const ContactListMap& map, const std::string& filename
         {
             jsonContact["name"] = contact.name;
             jsonContact["index"] = contact.index;
-            jsonContact["activation_time"] = contact.activationTime;
-            jsonContact["deactivation_time"] = contact.deactivationTime;
+            jsonContact["activation_time"]
+                = std::chrono::duration<double>(contact.activationTime).count();
+            jsonContact["deactivation_time"]
+                = std::chrono::duration<double>(contact.deactivationTime).count();
 
             // copy the position
             for (int i = 0; i < 3; i++)

--- a/src/Contacts/src/ContactPhaseList.cpp
+++ b/src/Contacts/src/ContactPhaseList.cpp
@@ -34,8 +34,8 @@ void ContactPhaseList::createPhases()
 {
     m_phases.clear();
 
-    std::map<double, std::unordered_map<std::string, ContactList::const_iterator>> activations,
-        deactivations;
+    std::map<std::chrono::nanoseconds, std::unordered_map<std::string, ContactList::const_iterator>>
+        activations, deactivations;
 
     for (ContactListMap::iterator list = m_contactLists.begin(); list != m_contactLists.end();
          ++list)
@@ -140,16 +140,14 @@ bool ContactPhaseList::setLists(const std::initializer_list<ContactList>& contac
     return true;
 }
 
-ContactPhaseList::const_iterator ContactPhaseList::getPresentPhase(
-    double time,
-    double tolerance /*= BipedalLocomotion::Math::AbsoluteEqualityDoubleTolerance*/) const
+ContactPhaseList::const_iterator
+ContactPhaseList::getPresentPhase(const std::chrono::nanoseconds& time) const
 {
     // With the reverse iterator we find the last phase such that the begin time is smaller that
     // time
-    auto presentReverse
-        = std::find_if(rbegin(), rend(), [time, tolerance](const ContactPhase& a) -> bool {
-              return a.beginTime <= time + tolerance;
-          });
+    auto presentReverse = std::find_if(rbegin(), rend(), [time](const ContactPhase& a) -> bool {
+        return a.beginTime <= time;
+    });
 
     if (presentReverse == rend())
     {

--- a/src/Contacts/src/FixedFootDetector.cpp
+++ b/src/Contacts/src/FixedFootDetector.cpp
@@ -10,6 +10,7 @@
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
 
+#include <chrono>
 #include <limits>
 #include <memory>
 
@@ -39,7 +40,8 @@ bool FixedFootDetector::initialize(std::weak_ptr<const IParametersHandler> handl
         return false;
     }
 
-    if (m_dT <= 0)
+    // This should never happen
+    if (m_dT <= std::chrono::nanoseconds::zero())
     {
         log()->error("{} The parameter 'sampling_time' must be a strictly positive number.",
                      logPrefix);
@@ -243,7 +245,7 @@ void FixedFootDetector::setContactPhaseList(const ContactPhaseList& phaseList)
     }
 }
 
-void FixedFootDetector::resetTime(const double &time)
+void FixedFootDetector::resetTime(const std::chrono::nanoseconds &time)
 {
     m_currentTime = time;
 }

--- a/src/Contacts/src/SchmittTriggerDetector.cpp
+++ b/src/Contacts/src/SchmittTriggerDetector.cpp
@@ -10,6 +10,7 @@
 #include <BipedalLocomotion/Math/SchmittTrigger.h>
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
+#include <chrono>
 
 namespace blf = BipedalLocomotion;
 using namespace BipedalLocomotion::Contacts;
@@ -73,10 +74,10 @@ bool SchmittTriggerDetector::initialize(std::weak_ptr<const IParametersHandler> 
     std::vector<double> offThreshold;
     ok = ok && setupParam("contact_break_thresholds", offThreshold);
 
-    std::vector<double> switchOnAfter;
+    std::vector<std::chrono::nanoseconds> switchOnAfter;
     ok = ok && setupParam("contact_make_switch_times", switchOnAfter);
 
-    std::vector<double> switchOffAfter;
+    std::vector<std::chrono::nanoseconds> switchOffAfter;
     ok = ok && setupParam("contact_break_switch_times", switchOffAfter);
 
     if (!ok)
@@ -101,7 +102,9 @@ bool SchmittTriggerDetector::initialize(std::weak_ptr<const IParametersHandler> 
         params.offThreshold = offThreshold[idx];
 
         // set the initial state for the trigger
-        constexpr blf::Math::SchmittTriggerState initialState{false, 0, 0};
+        constexpr blf::Math::SchmittTriggerState initialState{false,
+                                                              std::chrono::nanoseconds::zero(),
+                                                              std::chrono::nanoseconds::zero()};
         if (!this->addContact(contacts[idx], initialState, params))
         {
             log()->error("{} Could not add Schmitt Trigger unit for specified contact.", logPrefix);
@@ -262,7 +265,7 @@ bool SchmittTriggerDetector::resetContact(const std::string& contactName,
     triggerState.state = state;
     trigger.setState(triggerState);
     m_contactStates.at(contactName).isActive = state;
-    m_contactStates.at(contactName).switchTime = 0.0;
+    m_contactStates.at(contactName).switchTime = std::chrono::nanoseconds::zero();
 
     return true;
 }
@@ -280,7 +283,7 @@ bool SchmittTriggerDetector::resetState(const std::string& contactName, const bo
     triggerState.state = state;
     m_pimpl->manager.at(contactName).setState(triggerState);
     m_contactStates.at(contactName).isActive = state;
-    m_contactStates.at(contactName).switchTime = 0.0;
+    m_contactStates.at(contactName).switchTime = std::chrono::nanoseconds::zero();
 
     return true;
 }

--- a/src/Contacts/tests/ContactDetectors/SchmittTriggerDetectorUnitTest.cpp
+++ b/src/Contacts/tests/ContactDetectors/SchmittTriggerDetectorUnitTest.cpp
@@ -5,6 +5,8 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
+
 #include <catch2/catch.hpp>
 
 #include <BipedalLocomotion/ContactDetectors/SchmittTriggerDetector.h>
@@ -20,85 +22,90 @@ TEST_CASE("Schmitt Trigger Detector")
 {
     SchmittTriggerDetector detector;
 
+    using namespace std::chrono_literals;
+
     std::shared_ptr<StdImplementation> originalHandler = std::make_shared<StdImplementation>();
     IParametersHandler::shared_ptr parameterHandler = originalHandler;
 
     parameterHandler->setParameter("contacts", std::vector<std::string>{"right"});
     parameterHandler->setParameter("contact_make_thresholds", std::vector<double>{100});
     parameterHandler->setParameter("contact_break_thresholds", std::vector<double>{10});
-    parameterHandler->setParameter("contact_make_switch_times", std::vector<double>{0.2});
-    parameterHandler->setParameter("contact_break_switch_times", std::vector<double>{0.2, 0.2});
+    parameterHandler->setParameter("contact_make_switch_times",
+                                   std::vector<std::chrono::nanoseconds>{200ms});
+    parameterHandler->setParameter("contact_break_switch_times",
+                                   std::vector<std::chrono::nanoseconds>{200ms, 200ms});
 
     // mismatch in parameter size shoulc cause initialization failure
     REQUIRE_FALSE(detector.initialize(parameterHandler));
 
     // initialization should pass
-    parameterHandler->setParameter("contact_break_switch_times", std::vector<double>{0.2});
+    parameterHandler->setParameter("contact_break_switch_times",
+                                   std::vector<std::chrono::nanoseconds>{200ms});
     REQUIRE(detector.initialize(parameterHandler));
 
     // set all contacts to false
     REQUIRE(detector.resetContacts());
 
     // rise signal
-    detector.setTimedTriggerInput("right", {0.1 ,120});
+    detector.setTimedTriggerInput("right", {100ms ,120});
     detector.advance();
-    detector.setTimedTriggerInput("right", {0.2, 120});
+    detector.setTimedTriggerInput("right", {200ms, 120});
     detector.advance();
-    detector.setTimedTriggerInput("right", {0.3, 120});
+    detector.setTimedTriggerInput("right", {300ms, 120});
     detector.advance();
 
     // contact state should turn true
     EstimatedContact rightContact;
     REQUIRE(detector.get("right", rightContact));
     REQUIRE(rightContact.isActive);
-    REQUIRE(rightContact.switchTime == 0.3);
+    REQUIRE(rightContact.switchTime == 300ms);
 
     // fall signal
-    detector.setTimedTriggerInput("right", {0.4, 7});
+    detector.setTimedTriggerInput("right", {400ms, 7});
     detector.advance();
-    detector.setTimedTriggerInput("right", {0.5, 7});
+    detector.setTimedTriggerInput("right", {500ms, 7});
     detector.advance();
-    detector.setTimedTriggerInput("right", {0.6, 7});
+    detector.setTimedTriggerInput("right", {600ms, 7});
     detector.advance();
 
     // contact state should turn false
     REQUIRE(detector.get("right", rightContact));
     REQUIRE(!rightContact.isActive);
-    REQUIRE(rightContact.switchTime == 0.6);
+    REQUIRE(rightContact.switchTime == 600ms);
 
     // add a new contact
     EstimatedContact newContact;
     SchmittTrigger::Params params;
     params.offThreshold = 10;
     params.onThreshold = 100;
-    params.switchOffAfter = 0.2;
-    params.switchOnAfter = 0.2;
+    params.switchOffAfter = 200ms;
+    params.switchOnAfter = 200ms;
 
-    detector.addContact("left", {false, 0.6, 0.6}, params);
+    detector.addContact("left", {false, 600ms, 600ms}, params);
     auto contacts = detector.getOutput();
     REQUIRE(contacts.size() == 2);
 
     // test multiple measurement updates
     std::unordered_map<std::string, SchmittTriggerInput> timedForces;
-    timedForces["right"] = {0.7, 120};
-    timedForces["left"] = {0.7, 120};
+    timedForces["right"] = {700ms, 120};
+    timedForces["left"] = {700ms, 120};
     detector.setTimedTriggerInputs(timedForces);
     detector.advance();
 
-    timedForces["right"] = {0.8, 120};
-    timedForces["left"] = {0.8, 120};
+    timedForces["right"] = {800ms, 120};
+    timedForces["left"] = {800ms, 120};
     detector.setTimedTriggerInputs(timedForces);
     detector.advance();
 
-    timedForces["right"] = {0.9, 120};
-    timedForces["left"] = {0.9, 120};
+    timedForces["right"] = {900ms, 120};
+    timedForces["left"] = {900ms, 120};
     detector.setTimedTriggerInputs(timedForces);
     detector.advance();
 
     contacts = detector.getOutput();
     REQUIRE(contacts["right"].isActive);
     REQUIRE(contacts["left"].isActive);
-    REQUIRE(contacts["right"].switchTime == 0.9);
+    REQUIRE(contacts["right"].switchTime == 900ms);
 
     // Test removing contact
     REQUIRE(detector.removeContact("left"));

--- a/src/Contacts/tests/Contacts/ContactListTest.cpp
+++ b/src/Contacts/tests/Contacts/ContactListTest.cpp
@@ -5,6 +5,8 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
+
 // Catch2
 #include <catch2/catch.hpp>
 
@@ -28,13 +30,15 @@ bool contactsAreEqual(const PlannedContact& c1, const PlannedContact& c2)
 
 TEST_CASE("ContactList")
 {
+    using namespace std::chrono_literals;
+
     ContactList list;
     PlannedContact p1, p2;
-    p1.activationTime = 0.1;
-    p1.deactivationTime = 0.5;
+    p1.activationTime = 100ms;
+    p1.deactivationTime = 500ms;
 
-    p2.activationTime = 1.0;
-    p2.deactivationTime = 1.5;
+    p2.activationTime = 1s;
+    p2.deactivationTime = 1s + 500ms;
 
     bool ok1 = list.addContact(p2);
     bool ok2 = list.addContact(p1);
@@ -51,8 +55,8 @@ TEST_CASE("ContactList")
         REQUIRE(contactsAreEqual(p2, *list.lastContact()));
 
         PlannedContact p3;
-        p3.activationTime = 0.6;
-        p3.deactivationTime = 0.8;
+        p3.activationTime = 600ms;
+        p3.deactivationTime = 800ms;
 
         REQUIRE(list.addContact(p3));
         REQUIRE(list.size() == 3);
@@ -67,8 +71,8 @@ TEST_CASE("ContactList")
     SECTION("Invalid insertion")
     {
         PlannedContact p3;
-        p3.activationTime = 0.9;
-        p3.deactivationTime = 1.6;
+        p3.activationTime = 900ms;
+        p3.deactivationTime = 1s + 600ms;
 
         REQUIRE_FALSE(list.addContact(p3));
     }
@@ -85,10 +89,10 @@ TEST_CASE("ContactList")
 
     SECTION("Present step")
     {
-        REQUIRE(contactsAreEqual(p2, *list.getPresentContact(1.2)));
-        REQUIRE(contactsAreEqual(p2, *list.getPresentContact(1.6)));
-        REQUIRE(contactsAreEqual(p1, *list.getPresentContact(0.6)));
-        bool same = list.getPresentContact(0.0) == list.end();
+        REQUIRE(contactsAreEqual(p2, *list.getPresentContact(1s + 200ms)));
+        REQUIRE(contactsAreEqual(p2, *list.getPresentContact(1s + 600ms)));
+        REQUIRE(contactsAreEqual(p1, *list.getPresentContact(600ms)));
+        bool same = list.getPresentContact(0s) == list.end();
         REQUIRE(same);
     }
 
@@ -103,7 +107,7 @@ TEST_CASE("ContactList")
         bool ok = true;
         for (size_t i = 0; i < 49; ++i)
         {
-            ok = ok && list.addContact(manif::SE3d::Identity(), 2.0 + i, 2.5 + i);
+            ok = ok && list.addContact(manif::SE3d::Identity(), 2s + i * 1s, 2s + 500ms + i * 1s);
         }
         REQUIRE(ok);
         REQUIRE(list.size() == 51);
@@ -120,13 +124,15 @@ TEST_CASE("ContactList")
 
 TEST_CASE("ContactList JSON parser")
 {
+    using namespace std::chrono_literals;
+
     ContactListMap contactListMap;
     contactListMap["left"].setDefaultName("left_foot");
-    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Random(), 0.0, 1.0));
-    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Random(), 2.0, 5.0));
+    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Random(), 0s, 1s));
+    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Random(), 2s, 5s));
 
     contactListMap["right"].setDefaultName("right_foot");
-    REQUIRE(contactListMap["right"].addContact(manif::SE3d::Random(), 0.0, 3.0));
+    REQUIRE(contactListMap["right"].addContact(manif::SE3d::Random(), 0s, 3s));
 
     REQUIRE(contactListMapToJson(contactListMap, "contact_list.json"));
 
@@ -137,6 +143,8 @@ TEST_CASE("ContactList JSON parser")
     for (const auto& [key, contacts] : newContactListMap)
     {
         for (int i = 0; i < contacts.size(); i++)
+        {
             REQUIRE(contactsAreEqual(contactListMap[key][i], contacts[i]));
+        }
     }
 }

--- a/src/Contacts/tests/Contacts/ContactPhaseListTest.cpp
+++ b/src/Contacts/tests/Contacts/ContactPhaseListTest.cpp
@@ -5,6 +5,8 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
+
 // Catch2
 #include <catch2/catch.hpp>
 
@@ -14,15 +16,17 @@ using namespace BipedalLocomotion::Contacts;
 
 TEST_CASE("Rule of five")
 {
+    using namespace std::chrono_literals;
+
     ContactPhaseList phaseList;
 
     ContactListMap contactListMap;
-    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 0.0, 1.0));
-    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 2.0, 5.0));
-    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 6.0, 7.0));
+    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 0s, 1s));
+    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 2s, 5s));
+    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 6s, 7s));
 
-    REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 0.0, 3.0));
-    REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 4.0, 7.0));
+    REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 0s, 3s));
+    REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 4s, 7s));
 
     phaseList.setLists(contactListMap);
 
@@ -68,17 +72,19 @@ TEST_CASE("Rule of five")
 
 TEST_CASE("ContactPhaseList")
 {
+    using namespace std::chrono_literals;
+
     ContactPhaseList phaseList;
 
     SECTION("Set from map")
     {
         ContactListMap contactListMap;
-        REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 0.0, 1.0));
-        REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 2.0, 5.0));
-        REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 6.0, 7.0));
+        REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 0s, 1s));
+        REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 2s, 5s));
+        REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 6s, 7s));
 
-        REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 0.0, 3.0));
-        REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 4.0, 7.0));
+        REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 0s, 3s));
+        REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 4s, 7s));
 
         phaseList.setLists(contactListMap);
     }
@@ -88,15 +94,15 @@ TEST_CASE("ContactPhaseList")
     contactListRight.setDefaultName("right");
     contactListAdditional.setDefaultName("additional");
 
-    REQUIRE(contactListLeft.addContact(manif::SE3d::Identity(), 0.0, 1.0));
-    REQUIRE(contactListLeft.addContact(manif::SE3d::Identity(), 2.0, 5.0));
-    REQUIRE(contactListLeft.addContact(manif::SE3d::Identity(), 6.0, 7.0));
+    REQUIRE(contactListLeft.addContact(manif::SE3d::Identity(), 0s, 1s));
+    REQUIRE(contactListLeft.addContact(manif::SE3d::Identity(), 2s, 5s));
+    REQUIRE(contactListLeft.addContact(manif::SE3d::Identity(), 6s, 7s));
 
-    REQUIRE(contactListRight.addContact(manif::SE3d::Identity(), 0.0, 3.0));
-    REQUIRE(contactListRight.addContact(manif::SE3d::Identity(), 4.0, 7.0));
+    REQUIRE(contactListRight.addContact(manif::SE3d::Identity(), 0s, 3s));
+    REQUIRE(contactListRight.addContact(manif::SE3d::Identity(), 4s, 7s));
 
-    REQUIRE(contactListAdditional.addContact(manif::SE3d::Identity(), 4.0, 5.0));
-    REQUIRE(contactListAdditional.addContact(manif::SE3d::Identity(), 6.0, 7.5));
+    REQUIRE(contactListAdditional.addContact(manif::SE3d::Identity(), 4s, 5s));
+    REQUIRE(contactListAdditional.addContact(manif::SE3d::Identity(), 6s, 7s + 500ms));
 
     REQUIRE(phaseList.setLists({contactListAdditional, contactListLeft, contactListRight}));
 
@@ -108,7 +114,7 @@ TEST_CASE("ContactPhaseList")
         REQUIRE(same);
 
         std::advance(it, 1);
-        same = phaseList.getPresentPhase((it->beginTime + it->endTime) / 2.0) == it;
+        same = phaseList.getPresentPhase(((it->beginTime + it->endTime).count() / 2)*1ns) == it;
         REQUIRE(same);
 
         std::advance(it, 1);
@@ -129,8 +135,8 @@ TEST_CASE("ContactPhaseList")
         ContactList::const_iterator expectedAdditional = contactListMap.at("additional").begin();
 
         ContactPhaseList::const_iterator phase = phaseList.begin();
-        REQUIRE(phase->beginTime == 0.0);
-        REQUIRE(phase->endTime == 1.0);
+        REQUIRE(phase->beginTime == 0s);
+        REQUIRE(phase->endTime == 1s);
         REQUIRE(phase->activeContacts.size() == 2);
         bool ok = phase->activeContacts.at("left") == expectedLeft;
         REQUIRE(ok);
@@ -140,16 +146,16 @@ TEST_CASE("ContactPhaseList")
         phase++;
         expectedLeft++;
 
-        REQUIRE(phase->beginTime == 1.0);
-        REQUIRE(phase->endTime == 2.0);
+        REQUIRE(phase->beginTime == 1s);
+        REQUIRE(phase->endTime == 2s);
         REQUIRE(phase->activeContacts.size() == 1);
         ok = phase->activeContacts.at("right") == expectedRight;
         REQUIRE(ok);
 
         phase++;
 
-        REQUIRE(phase->beginTime == 2.0);
-        REQUIRE(phase->endTime == 3.0);
+        REQUIRE(phase->beginTime == 2s);
+        REQUIRE(phase->endTime == 3s);
         REQUIRE(phase->activeContacts.size() == 2);
         ok = phase->activeContacts.at("left") == expectedLeft;
         REQUIRE(ok);
@@ -159,16 +165,16 @@ TEST_CASE("ContactPhaseList")
         phase++;
         expectedRight++;
 
-        REQUIRE(phase->beginTime == 3.0);
-        REQUIRE(phase->endTime == 4.0);
+        REQUIRE(phase->beginTime == 3s);
+        REQUIRE(phase->endTime == 4s);
         REQUIRE(phase->activeContacts.size() == 1);
         ok = phase->activeContacts.at("left") == expectedLeft;
         REQUIRE(ok);
 
         phase++;
 
-        REQUIRE(phase->beginTime == 4.0);
-        REQUIRE(phase->endTime == 5.0);
+        REQUIRE(phase->beginTime == 4s);
+        REQUIRE(phase->endTime == 5s);
         REQUIRE(phase->activeContacts.size() == 3);
         ok = phase->activeContacts.at("left") == expectedLeft;
         REQUIRE(ok);
@@ -181,16 +187,16 @@ TEST_CASE("ContactPhaseList")
         expectedLeft++;
         expectedAdditional++;
 
-        REQUIRE(phase->beginTime == 5.0);
-        REQUIRE(phase->endTime == 6.0);
+        REQUIRE(phase->beginTime == 5s);
+        REQUIRE(phase->endTime == 6s);
         REQUIRE(phase->activeContacts.size() == 1);
         ok = phase->activeContacts.at("right") == expectedRight;
         REQUIRE(ok);
 
         phase++;
 
-        REQUIRE(phase->beginTime == 6.0);
-        REQUIRE(phase->endTime == 7.0);
+        REQUIRE(phase->beginTime == 6s);
+        REQUIRE(phase->endTime == 7s);
         REQUIRE(phase->activeContacts.size() == 3);
         ok = phase->activeContacts.at("left") == expectedLeft;
         REQUIRE(ok);
@@ -203,8 +209,8 @@ TEST_CASE("ContactPhaseList")
         expectedLeft++;
         expectedRight++;
 
-        REQUIRE(phase->beginTime == 7.0);
-        REQUIRE(phase->endTime == 7.5);
+        REQUIRE(phase->beginTime == 7s);
+        REQUIRE(phase->endTime == 7s + 500ms);
         REQUIRE(phase->activeContacts.size() == 1);
         ok = phase->activeContacts.at("additional") == expectedAdditional;
         REQUIRE(ok);

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
@@ -13,6 +13,7 @@
 #include <BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimatorParams.h>
 #include <BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimatorIO.h>
 
+#include <chrono>
 #include <iDynTree/KinDynComputations.h>
 #include <iostream>
 #include <memory>
@@ -195,8 +196,8 @@ public:
     */
     bool setContactStatus(const std::string& name,
                           const bool& contactStatus,
-                          const double& switchTime,
-                          double timeNow = 0.);
+                          const std::chrono::nanoseconds& switchTime,
+                          const std::chrono::nanoseconds& = std::chrono::nanoseconds::zero());
 
     /**
     * Set kinematic measurements
@@ -220,7 +221,7 @@ public:
     bool setLandmarkRelativePose(const int& landmarkID,
                                  const Eigen::Quaterniond& quat,
                                  const Eigen::Vector3d& pos,
-                                 const double& timeNow);
+                                 const std::chrono::nanoseconds& timeNow);
 
     /**
     * Compute one step of the estimator

--- a/src/Estimators/src/FloatingBaseEstimator.cpp
+++ b/src/Estimators/src/FloatingBaseEstimator.cpp
@@ -5,10 +5,12 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
-
-#include <BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h>
 #include <BipedalLocomotion/Conversions/ManifConversions.h>
+#include <BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
+
+#include <chrono>
+
 #include <iDynTree/Model/Model.h>
 
 using namespace BipedalLocomotion;
@@ -19,8 +21,9 @@ FloatingBaseEstimator::FloatingBaseEstimator()
     m_state.imuOrientation.setIdentity();
 }
 
-bool FloatingBaseEstimator::initialize(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
-                                       std::shared_ptr<iDynTree::KinDynComputations> kindyn)
+bool FloatingBaseEstimator::initialize(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
+    std::shared_ptr<iDynTree::KinDynComputations> kindyn)
 {
     if (!m_modelComp.setKinDynObject(kindyn))
     {
@@ -37,7 +40,8 @@ bool FloatingBaseEstimator::initialize(std::weak_ptr<BipedalLocomotion::Paramete
     return true;
 }
 
-bool FloatingBaseEstimator::initialize(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+bool FloatingBaseEstimator::initialize(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
 {
     auto handle = handler.lock();
     if (handle == nullptr)
@@ -51,8 +55,10 @@ bool FloatingBaseEstimator::initialize(std::weak_ptr<BipedalLocomotion::Paramete
     {
         m_useModelInfo = true;
         log()->warn("[FloatingBaseEstimator::initialize] "
-                    "The parameter handler could not find \" use_model_info \" in the configuration file."
-                    "Setting to default value {}", m_useModelInfo);
+                    "The parameter handler could not find \" use_model_info \" in the "
+                    "configuration file."
+                    "Setting to default value {}",
+                    m_useModelInfo);
     }
 
     if (m_estimatorState != State::NotInitialized)
@@ -66,7 +72,8 @@ bool FloatingBaseEstimator::initialize(std::weak_ptr<BipedalLocomotion::Paramete
     if (!handle->getParameter("sampling_period_in_s", m_dt))
     {
         log()->error("[FloatingBaseEstimator::initialize] "
-                     "The parameter handler could not find \" sampling_period_in_s \" in the configuration file.");
+                     "The parameter handler could not find \" sampling_period_in_s \" in the "
+                     "configuration file.");
         return false;
     }
 
@@ -76,8 +83,10 @@ bool FloatingBaseEstimator::initialize(std::weak_ptr<BipedalLocomotion::Paramete
         {
             log()->error("[FloatingBaseEstimator::initialize] "
                          "The kindyn object with valid does not seem to be loaded."
-                         "Please either call initialize(handler, kindyncomputations) to set the kindyn object and re-initialize the estimator,"
-                         "or call modelComp()->setKinDynObject(kindyncomputations) to set the kindyn object only.");
+                         "Please either call initialize(handler, kindyncomputations) to set the "
+                         "kindyn object and re-initialize the estimator,"
+                         "or call modelComp()->setKinDynObject(kindyncomputations) to set the "
+                         "kindyn object only.");
             return false;
         }
 
@@ -122,8 +131,8 @@ bool FloatingBaseEstimator::advance()
     if (m_useModelInfo && m_options.kinematicsUpdateEnabled)
     {
         // update robot state with previous state estimates
-        if ( (m_meas.encoders.size() == m_modelComp.nrJoints()) ||
-             (m_meas.encodersSpeed.size() == m_modelComp.nrJoints()) )
+        if ((m_meas.encoders.size() == m_modelComp.nrJoints())
+            || (m_meas.encodersSpeed.size() == m_modelComp.nrJoints()))
         {
             if (!m_modelComp.kinDyn()->setRobotState(m_estimatorOut.basePose.transform(),
                                                      m_meas.encoders,
@@ -152,8 +161,11 @@ bool FloatingBaseEstimator::advance()
         }
     }
 
-    ok = ok && updateBaseStateFromIMUState(m_state, m_measPrev,
-                                           m_estimatorOut.basePose, m_estimatorOut.baseTwist);
+    ok = ok
+         && updateBaseStateFromIMUState(m_state,
+                                        m_measPrev,
+                                        m_estimatorOut.basePose,
+                                        m_estimatorOut.baseTwist);
 
     m_statePrev = m_state;
     m_measPrev = m_meas;
@@ -164,17 +176,18 @@ bool FloatingBaseEstimator::advance()
     // clear the map of landmark and contact measurements
     if (m_useModelInfo)
     {
-      m_meas.stampedContactsStatus.clear();
+        m_meas.stampedContactsStatus.clear();
     }
 
     if (m_options.staticLandmarksUpdateEnabled)
     {
-      m_meas.stampedRelLandmarkPoses.clear();
+        m_meas.stampedRelLandmarkPoses.clear();
     }
     return ok;
 }
 
-bool FloatingBaseEstimator::ModelComputations::setKinDynObject(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+bool FloatingBaseEstimator::ModelComputations::setKinDynObject(
+    std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
 {
     if (kinDyn != nullptr)
     {
@@ -215,10 +228,10 @@ bool FloatingBaseEstimator::ModelComputations::setBaseLinkAndIMU(const std::stri
     if (m_baseLinkIdx != m_kindyn->model().getFrameLink(m_baseImuIdx))
     {
         log()->error("[FloatingBaseEstimator::ModelComputations::setBaseLinkAndIMU] "
-                     "Specified IMU not rigidly attached to the base link. Please specify a base link colocated IMU.");
+                     "Specified IMU not rigidly attached to the base link. Please specify a base "
+                     "link colocated IMU.");
         return false;
     }
-
 
     if (m_kindyn->model().getDefaultBaseLink() != m_baseLinkIdx)
     {
@@ -233,8 +246,8 @@ bool FloatingBaseEstimator::ModelComputations::setBaseLinkAndIMU(const std::stri
     return true;
 }
 
-bool FloatingBaseEstimator::ModelComputations::setFeetContactFrames(const std::string& lFootContactFrame,
-                                                                    const std::string& rFootContactFrame)
+bool FloatingBaseEstimator::ModelComputations::setFeetContactFrames(
+    const std::string& lFootContactFrame, const std::string& rFootContactFrame)
 {
     m_lFootContactIdx = m_kindyn->model().getFrameIndex(lFootContactFrame);
     if (m_lFootContactIdx == iDynTree::FRAME_INVALID_INDEX)
@@ -260,41 +273,44 @@ bool FloatingBaseEstimator::ModelComputations::setFeetContactFrames(const std::s
 
 bool FloatingBaseEstimator::ModelComputations::isModelInfoLoaded()
 {
-    bool loaded = (m_baseLinkIdx != iDynTree::FRAME_INVALID_INDEX) &&
-             (m_baseImuIdx != iDynTree::FRAME_INVALID_INDEX);
+    bool loaded = (m_baseLinkIdx != iDynTree::FRAME_INVALID_INDEX)
+                  && (m_baseImuIdx != iDynTree::FRAME_INVALID_INDEX);
 
     return loaded;
 }
 
-bool FloatingBaseEstimator::ModelComputations::getBaseStateFromIMUState(const manif::SE3d& A_H_IMU,
-                                                                        Eigen::Ref<const Eigen::Matrix<double, 6, 1> > v_IMU,
-                                                                        manif::SE3d& A_H_B,
-                                                                        Eigen::Ref<Eigen::Matrix<double, 6, 1> > v_B)
+bool FloatingBaseEstimator::ModelComputations::getBaseStateFromIMUState(
+    const manif::SE3d& A_H_IMU,
+    Eigen::Ref<const Eigen::Matrix<double, 6, 1>> v_IMU,
+    manif::SE3d& A_H_B,
+    Eigen::Ref<Eigen::Matrix<double, 6, 1>> v_B)
 {
     if (!isModelInfoLoaded())
     {
         log()->error("[FloatingBaseEstimator::ModelComputations::getBaseStateFromIMUState] "
-                     "Please set required model info parameters, before calling getBaseStateFromIMUState()");
+                     "Please set required model info parameters, before calling "
+                     "getBaseStateFromIMUState()");
         return false;
     }
 
-    A_H_B = A_H_IMU*(m_base_H_imu.inverse());
+    A_H_B = A_H_IMU * (m_base_H_imu.inverse());
 
     // transform velocity (mixed-representation)
     auto A_o_BIMU = A_H_B.asSO3().act(m_base_H_imu.translation());
     manif::SE3d X(A_o_BIMU, Eigen::Quaterniond::Identity());
 
     // coordinate/adjoint transformation of the twist
-    v_B = X.adj()*v_IMU;
+    v_B = X.adj() * v_IMU;
 
     return true;
 }
 
-bool FloatingBaseEstimator::ModelComputations::getIMU_H_feet(Eigen::Ref<const Eigen::VectorXd> encoders,
-                                                             manif::SE3d& IMU_H_l_foot,
-                                                             manif::SE3d& IMU_H_r_foot)
+bool FloatingBaseEstimator::ModelComputations::getIMU_H_feet(
+    Eigen::Ref<const Eigen::VectorXd> encoders,
+    manif::SE3d& IMU_H_l_foot,
+    manif::SE3d& IMU_H_r_foot)
 {
-    if (!isModelInfoLoaded() && (encoders.size() !=nrJoints()))
+    if (!isModelInfoLoaded() && (encoders.size() != nrJoints()))
     {
         log()->error("[FloatingBaseEstimator::ModelComputations::getIMU_H_feet] "
                      "Please set required model info parameters, before calling getIMU_H_feet()");
@@ -306,17 +322,20 @@ bool FloatingBaseEstimator::ModelComputations::getIMU_H_feet(Eigen::Ref<const Ei
         log()->error("[FloatingBaseEstimator::ModelComputations::getIMU_H_feet] "
                      "Failed setting joint positions.");
     }
-    IMU_H_l_foot = Conversions::toManifPose(m_kindyn->getRelativeTransform(m_baseImuIdx, m_lFootContactIdx));
-    IMU_H_r_foot = Conversions::toManifPose(m_kindyn->getRelativeTransform(m_baseImuIdx, m_rFootContactIdx));
+    IMU_H_l_foot
+        = Conversions::toManifPose(m_kindyn->getRelativeTransform(m_baseImuIdx, m_lFootContactIdx));
+    IMU_H_r_foot
+        = Conversions::toManifPose(m_kindyn->getRelativeTransform(m_baseImuIdx, m_rFootContactIdx));
 
     return true;
 }
 
-bool FloatingBaseEstimator::ModelComputations::getIMU_H_feet(const Eigen::Ref<const Eigen::VectorXd> encoders,
-                                                             manif::SE3d& IMU_H_l_foot,
-                                                             manif::SE3d& IMU_H_r_foot,
-                                                             Eigen::Ref<Eigen::MatrixXd> J_IMULF,
-                                                             Eigen::Ref<Eigen::MatrixXd> J_IMURF)
+bool FloatingBaseEstimator::ModelComputations::getIMU_H_feet(
+    const Eigen::Ref<const Eigen::VectorXd> encoders,
+    manif::SE3d& IMU_H_l_foot,
+    manif::SE3d& IMU_H_r_foot,
+    Eigen::Ref<Eigen::MatrixXd> J_IMULF,
+    Eigen::Ref<Eigen::MatrixXd> J_IMURF)
 {
     if (!getIMU_H_feet(encoders, IMU_H_l_foot, IMU_H_r_foot))
     {
@@ -338,15 +357,14 @@ bool FloatingBaseEstimator::setIMUMeasurement(const Eigen::Vector3d& accMeas,
     return true;
 }
 
-
 bool FloatingBaseEstimator::setKinematics(const Eigen::VectorXd& encoders,
                                           const Eigen::VectorXd& encoderSpeeds)
 {
-    if ( (encoders.size() != encoderSpeeds.size()) ||
-        (encoders.size() != modelComputations().nrJoints()))
+    if ((encoders.size() != encoderSpeeds.size())
+        || (encoders.size() != modelComputations().nrJoints()))
     {
         log()->warn("[FloatingBaseEstimator::setKinematics] "
-                     "kinematic measurements size mismatch.");
+                    "kinematic measurements size mismatch.");
         return false;
     }
 
@@ -355,8 +373,7 @@ bool FloatingBaseEstimator::setKinematics(const Eigen::VectorXd& encoders,
     return true;
 }
 
-bool FloatingBaseEstimator::setContacts(const bool& lfInContact,
-                                        const bool& rfInContact)
+bool FloatingBaseEstimator::setContacts(const bool& lfInContact, const bool& rfInContact)
 {
     m_meas.lfInContact = lfInContact;
     m_meas.rfInContact = rfInContact;
@@ -365,14 +382,15 @@ bool FloatingBaseEstimator::setContacts(const bool& lfInContact,
 
 bool FloatingBaseEstimator::setContactStatus(const std::string& name,
                                              const bool& contactStatus,
-                                             const double& switchTime,
-                                             double timeNow)
+                                             const std::chrono::nanoseconds& switchTime,
+                                             const std::chrono::nanoseconds& timeNow)
 {
     auto idx = m_modelComp.kinDyn()->model().getFrameIndex(name);
     if (!m_modelComp.kinDyn()->model().isValidFrameIndex(idx))
     {
         log()->warn("[FloatingBaseEstimator::setContactStatus] "
-                     "Contact frame index: {} not found in loaded model, skipping measurement.", idx);
+                    "Contact frame index: {} not found in loaded model, skipping measurement.",
+                    idx);
         return false;
     }
 
@@ -392,7 +410,7 @@ bool FloatingBaseEstimator::setContactStatus(const std::string& name,
 bool FloatingBaseEstimator::setLandmarkRelativePose(const int& landmarkID,
                                                     const Eigen::Quaterniond& quat,
                                                     const Eigen::Vector3d& pos,
-                                                    const double& timeNow)
+                                                    const std::chrono::nanoseconds& timeNow)
 {
     auto& poses = m_meas.stampedRelLandmarkPoses;
 
@@ -408,14 +426,13 @@ FloatingBaseEstimator::ModelComputations& FloatingBaseEstimator::modelComputatio
     return m_modelComp;
 }
 
-
 const FloatingBaseEstimators::Output& FloatingBaseEstimator::getOutput() const
 {
     return m_estimatorOut;
 }
 
-
-bool FloatingBaseEstimator::setupModelParams(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+bool FloatingBaseEstimator::setupModelParams(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
 {
     auto handle = handler.lock();
     if (handle == nullptr)
@@ -430,14 +447,16 @@ bool FloatingBaseEstimator::setupModelParams(std::weak_ptr<BipedalLocomotion::Pa
     if (!handle->getParameter("base_link", baseLink))
     {
         log()->error("[FloatingBaseEstimator::setupModelParams] "
-                     "The parameter handler could not find \" base_link \" in the configuration file.");
+                     "The parameter handler could not find \" base_link \" in the configuration "
+                     "file.");
         return false;
     }
 
     if (!handle->getParameter("base_link_imu", imu))
     {
         log()->error("[FloatingBaseEstimator::setupModelParams] "
-                     "The parameter handler could not find \" base_link_imu \" in the configuration file.");
+                     "The parameter handler could not find \" base_link_imu \" in the "
+                     "configuration file.");
         return false;
     }
 
@@ -446,14 +465,16 @@ bool FloatingBaseEstimator::setupModelParams(std::weak_ptr<BipedalLocomotion::Pa
     if (!handle->getParameter("left_foot_contact_frame", lfContact))
     {
         log()->error("[FloatingBaseEstimator::setupModelParams] "
-                     "The parameter handler could not find \" left_foot_contact_frame \" in the configuration file.");
+                     "The parameter handler could not find \" left_foot_contact_frame \" in the "
+                     "configuration file.");
         return false;
     }
 
     if (!handle->getParameter("right_foot_contact_frame", rfContact))
     {
         log()->error("[FloatingBaseEstimator::setupModelParams] "
-                     "The parameter handler could not find \" right_foot_contact_frame \" in the configuration file.");
+                     "The parameter handler could not find \" right_foot_contact_frame \" in the "
+                     "configuration file.");
         return false;
     }
 
@@ -470,7 +491,8 @@ bool FloatingBaseEstimator::setupModelParams(std::weak_ptr<BipedalLocomotion::Pa
     return true;
 }
 
-bool FloatingBaseEstimator::setupOptions(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+bool FloatingBaseEstimator::setupOptions(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
 {
     auto handle = handler.lock();
     if (handle == nullptr)
@@ -484,27 +506,34 @@ bool FloatingBaseEstimator::setupOptions(std::weak_ptr<BipedalLocomotion::Parame
     {
         log()->error("[FloatingBaseEstimator::setupOptions] "
                      "The parameter handler has expired. Please check its scope.");
-        std::cout << "[FloatingBaseEstimator::setupOptions] The parameter handler could not find \" enable_imu_bias_estimation \" in the configuration file. Setting default value to false."
-        << std::endl;
+        std::cout << "[FloatingBaseEstimator::setupOptions] The parameter handler could not find "
+                     "\" enable_imu_bias_estimation \" in the configuration file. Setting default "
+                     "value to false."
+                  << std::endl;
         m_options.imuBiasEstimationEnabled = false;
     }
 
     if (m_options.imuBiasEstimationEnabled)
     {
-        if (!handle->getParameter("enable_static_imu_bias_initialization", m_options.staticImuBiasInitializationEnabled))
+        if (!handle->getParameter("enable_static_imu_bias_initialization",
+                                  m_options.staticImuBiasInitializationEnabled))
         {
             m_options.staticImuBiasInitializationEnabled = false;
             log()->warn("[FloatingBaseEstimator::setupOptions] "
-                        "The parameter handler could not find \" enable_static_imu_bias_initialization \"  "
-                        "in the configuration file. Setting to default value: {}.", m_options.staticImuBiasInitializationEnabled);
+                        "The parameter handler could not find \" "
+                        "enable_static_imu_bias_initialization \"  "
+                        "in the configuration file. Setting to default value: {}.",
+                        m_options.staticImuBiasInitializationEnabled);
         }
 
         if (m_options.staticImuBiasInitializationEnabled)
         {
-            if (!handle->getParameter("nr_samples_for_imu_bias_initialization", m_options.nrSamplesForImuBiasInitialization))
+            if (!handle->getParameter("nr_samples_for_imu_bias_initialization",
+                                      m_options.nrSamplesForImuBiasInitialization))
             {
                 log()->error("[FloatingBaseEstimator::setupOptions] "
-                             "The parameter handler could not find \" nr_samples_for_imu_bias_initialization \"  "
+                             "The parameter handler could not find \" "
+                             "nr_samples_for_imu_bias_initialization \"  "
                              "in the configuration file.  This is a required parameter since "
                              "the static_imu_bias_initialization_enabled is set to true.");
                 return false;
@@ -525,31 +554,29 @@ bool FloatingBaseEstimator::setupOptions(std::weak_ptr<BipedalLocomotion::Parame
                     "Please enable the update for expected performance.");
         m_options.kinematicsUpdateEnabled = false;
         m_options.staticLandmarksUpdateEnabled = false;
-    }
-    else
+    } else
     {
         if (!handle->getParameter("use_kinematics_measure", m_options.kinematicsUpdateEnabled))
         {
             m_options.kinematicsUpdateEnabled = true;
         }
 
-        if (!handle->getParameter("use_static_ldmks_pose_measure", m_options.staticLandmarksUpdateEnabled))
+        if (!handle->getParameter("use_static_ldmks_pose_measure",
+                                  m_options.staticLandmarksUpdateEnabled))
         {
             m_options.staticLandmarksUpdateEnabled = false;
         }
     }
 
-    std::vector<double> g;
-    g.resize(3);
-    if (handle->getParameter("acceleration_due_to_gravity", GenericContainer::make_vector(g, GenericContainer::VectorResizeMode::Fixed)))
-    {
-        m_options.accelerationDueToGravity << g[0], g[1], g[2];
-    }
+    // This parameter is optional
+    handle->getParameter("acceleration_due_to_gravity", //
+                         m_options.accelerationDueToGravity);
 
     return true;
 }
 
-bool FloatingBaseEstimator::setupSensorDevs(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+bool FloatingBaseEstimator::setupSensorDevs(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
 {
     auto handle = handler.lock();
     if (handle == nullptr)
@@ -562,51 +589,118 @@ bool FloatingBaseEstimator::setupSensorDevs(std::weak_ptr<BipedalLocomotion::Par
     std::string printPrefix{"setupSensorDevs"};
 
     std::vector<double> accNoise(3);
-    if (!setupFixedVectorParamPrivate("accelerometer_measurement_noise_std_dev", printPrefix, handler, accNoise)) { return false; }
+    if (!setupFixedVectorParamPrivate("accelerometer_measurement_noise_std_dev",
+                                      printPrefix,
+                                      handler,
+                                      accNoise))
+    {
+        return false;
+    }
 
     std::vector<double> gyroNoise(3);
-    if (!setupFixedVectorParamPrivate("gyroscope_measurement_noise_std_dev", printPrefix, handler, gyroNoise)) { return false; }
+    if (!setupFixedVectorParamPrivate("gyroscope_measurement_noise_std_dev",
+                                      printPrefix,
+                                      handler,
+                                      gyroNoise))
+    {
+        return false;
+    }
 
     if (m_useModelInfo)
     {
         std::vector<double> contactFootLinvelNoise(3);
-        if (!setupFixedVectorParamPrivate("contact_foot_linear_velocity_noise_std_dev", printPrefix, handler, contactFootLinvelNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("contact_foot_linear_velocity_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          contactFootLinvelNoise))
+        {
+            return false;
+        }
 
         std::vector<double> contactFootAngvelNoise(3);
-        if (!setupFixedVectorParamPrivate("contact_foot_angular_velocity_noise_std_dev", printPrefix, handler, contactFootAngvelNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("contact_foot_angular_velocity_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          contactFootAngvelNoise))
+        {
+            return false;
+        }
 
         std::vector<double> swingFootLinvelNoise(3);
-        if (!setupFixedVectorParamPrivate("swing_foot_linear_velocity_noise_std_dev", printPrefix, handler, swingFootLinvelNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("swing_foot_linear_velocity_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          swingFootLinvelNoise))
+        {
+            return false;
+        }
 
         std::vector<double> swingFootAngvelNoise(3);
-        if (!setupFixedVectorParamPrivate("swing_foot_angular_velocity_noise_std_dev", printPrefix, handler, swingFootAngvelNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("swing_foot_angular_velocity_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          swingFootAngvelNoise))
+        {
+            return false;
+        }
 
         std::vector<double> forwardKinematicsNoise(6);
-        if (!setupFixedVectorParamPrivate("forward_kinematic_measurement_noise_std_dev", printPrefix, handler, forwardKinematicsNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("forward_kinematic_measurement_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          forwardKinematicsNoise))
+        {
+            return false;
+        }
 
         std::vector<double> encodersNoise(m_modelComp.nrJoints());
-        if (!setupFixedVectorParamPrivate("encoders_measurement_noise_std_dev", printPrefix, handler, encodersNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("encoders_measurement_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          encodersNoise))
+        {
+            return false;
+        }
 
-        m_sensorsDev.contactFootLinvelNoise << contactFootLinvelNoise[0], contactFootLinvelNoise[1], contactFootLinvelNoise[2];
-        m_sensorsDev.contactFootAngvelNoise << contactFootAngvelNoise[0], contactFootAngvelNoise[1], contactFootAngvelNoise[2];
+        m_sensorsDev.contactFootLinvelNoise << contactFootLinvelNoise[0], contactFootLinvelNoise[1],
+            contactFootLinvelNoise[2];
+        m_sensorsDev.contactFootAngvelNoise << contactFootAngvelNoise[0], contactFootAngvelNoise[1],
+            contactFootAngvelNoise[2];
 
-        m_sensorsDev.swingFootLinvelNoise << swingFootLinvelNoise[0], swingFootLinvelNoise[1], swingFootLinvelNoise[2];
-        m_sensorsDev.swingFootAngvelNoise << swingFootAngvelNoise[0], swingFootAngvelNoise[1], swingFootAngvelNoise[2];
+        m_sensorsDev.swingFootLinvelNoise << swingFootLinvelNoise[0], swingFootLinvelNoise[1],
+            swingFootLinvelNoise[2];
+        m_sensorsDev.swingFootAngvelNoise << swingFootAngvelNoise[0], swingFootAngvelNoise[1],
+            swingFootAngvelNoise[2];
 
-        m_sensorsDev.forwardKinematicsNoise << forwardKinematicsNoise[0], forwardKinematicsNoise[1], forwardKinematicsNoise[2],
-                                            forwardKinematicsNoise[3], forwardKinematicsNoise[4], forwardKinematicsNoise[5];
+        m_sensorsDev.forwardKinematicsNoise << forwardKinematicsNoise[0], forwardKinematicsNoise[1],
+            forwardKinematicsNoise[2], forwardKinematicsNoise[3], forwardKinematicsNoise[4],
+            forwardKinematicsNoise[5];
 
         m_sensorsDev.encodersNoise.resize(encodersNoise.size());
-        m_sensorsDev.encodersNoise = Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(encodersNoise.data(), encodersNoise.size());
+        m_sensorsDev.encodersNoise
+            = Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(encodersNoise.data(),
+                                                            encodersNoise.size());
     }
 
     if (m_options.imuBiasEstimationEnabled)
     {
         std::vector<double> accBiasNoise(3);
-        if (!setupFixedVectorParamPrivate("accelerometer_measurement_bias_noise_std_dev", printPrefix, handler, accBiasNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("accelerometer_measurement_bias_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          accBiasNoise))
+        {
+            return false;
+        }
 
         std::vector<double> gyroBiasNoise(3);
-        if (!setupFixedVectorParamPrivate("gyroscope_measurement_bias_noise_std_dev", printPrefix, handler, gyroBiasNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("gyroscope_measurement_bias_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          gyroBiasNoise))
+        {
+            return false;
+        }
 
         m_sensorsDev.accelerometerBiasNoise << accBiasNoise[0], accBiasNoise[1], accBiasNoise[2];
         m_sensorsDev.gyroscopeBiasNoise << gyroBiasNoise[0], gyroBiasNoise[1], gyroBiasNoise[2];
@@ -618,22 +712,37 @@ bool FloatingBaseEstimator::setupSensorDevs(std::weak_ptr<BipedalLocomotion::Par
     if (m_options.staticLandmarksUpdateEnabled)
     {
         std::vector<double> ldmkPredictionNoise(6);
-        if (!setupFixedVectorParamPrivate("landmark_prediction_noise_std_dev", printPrefix, handler, ldmkPredictionNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("landmark_prediction_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          ldmkPredictionNoise))
+        {
+            return false;
+        }
 
         std::vector<double> ldmkMeasurmentNoise(6);
-        if (!setupFixedVectorParamPrivate("landmark_measurement_noise_std_dev", printPrefix, handler, ldmkMeasurmentNoise)) { return false; }
+        if (!setupFixedVectorParamPrivate("landmark_measurement_noise_std_dev",
+                                          printPrefix,
+                                          handler,
+                                          ldmkMeasurmentNoise))
+        {
+            return false;
+        }
 
-        m_sensorsDev.landmarkPredictionNoise << ldmkPredictionNoise[0], ldmkPredictionNoise[1], ldmkPredictionNoise[2],
-                                                ldmkPredictionNoise[3], ldmkPredictionNoise[4], ldmkPredictionNoise[5];
+        m_sensorsDev.landmarkPredictionNoise << ldmkPredictionNoise[0], ldmkPredictionNoise[1],
+            ldmkPredictionNoise[2], ldmkPredictionNoise[3], ldmkPredictionNoise[4],
+            ldmkPredictionNoise[5];
 
-        m_sensorsDev.landmarkMeasurementNoise << ldmkMeasurmentNoise[0], ldmkMeasurmentNoise[1], ldmkMeasurmentNoise[2],
-                                                 ldmkMeasurmentNoise[3], ldmkMeasurmentNoise[4], ldmkMeasurmentNoise[5];
+        m_sensorsDev.landmarkMeasurementNoise << ldmkMeasurmentNoise[0], ldmkMeasurmentNoise[1],
+            ldmkMeasurmentNoise[2], ldmkMeasurmentNoise[3], ldmkMeasurmentNoise[4],
+            ldmkMeasurmentNoise[5];
     }
 
     return true;
 }
 
-bool FloatingBaseEstimator::setupInitialStates(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+bool FloatingBaseEstimator::setupInitialStates(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
 {
     auto handle = handler.lock();
     if (handle == nullptr)
@@ -646,59 +755,129 @@ bool FloatingBaseEstimator::setupInitialStates(std::weak_ptr<BipedalLocomotion::
     std::string printPrefix{"setupInitialStates"};
 
     std::vector<double> imuOrientation(4);
-    if (!setupFixedVectorParamPrivate("imu_orientation_quaternion_wxyz", printPrefix, handler, imuOrientation)) { return false; }
+    if (!setupFixedVectorParamPrivate("imu_orientation_quaternion_wxyz",
+                                      printPrefix,
+                                      handler,
+                                      imuOrientation))
+    {
+        return false;
+    }
 
     std::vector<double> imuPosition(3);
-    if (!setupFixedVectorParamPrivate("imu_position_xyz", printPrefix, handler, imuPosition)) { return false; }
+    if (!setupFixedVectorParamPrivate("imu_position_xyz", printPrefix, handler, imuPosition))
+    {
+        return false;
+    }
 
     std::vector<double> imuLinearVelocity(3);
-    if (!setupFixedVectorParamPrivate("imu_linear_velocity_xyz", printPrefix, handler, imuLinearVelocity)) { return false; }
+    if (!setupFixedVectorParamPrivate("imu_linear_velocity_xyz",
+                                      printPrefix,
+                                      handler,
+                                      imuLinearVelocity))
+    {
+        return false;
+    }
 
     if (m_useModelInfo && m_isInvEKF)
     {
         // This conditional block will be soon deprecated
         std::vector<double> lContactFrameOrientation(4);
-        if (!setupFixedVectorParamPrivate("l_contact_frame_orientation_quaternion_wxyz", printPrefix, handler, lContactFrameOrientation)) { return false; }
+        if (!setupFixedVectorParamPrivate("l_contact_frame_orientation_quaternion_wxyz",
+                                          printPrefix,
+                                          handler,
+                                          lContactFrameOrientation))
+        {
+            return false;
+        }
 
         std::vector<double> lContactFramePosition(3);
-        if (!setupFixedVectorParamPrivate("l_contact_frame_position_xyz", printPrefix, handler, lContactFramePosition)) { return false; }
+        if (!setupFixedVectorParamPrivate("l_contact_frame_position_xyz",
+                                          printPrefix,
+                                          handler,
+                                          lContactFramePosition))
+        {
+            return false;
+        }
 
         std::vector<double> rContactFrameOrientation(4);
-        if (!setupFixedVectorParamPrivate("r_contact_frame_orientation_quaternion_wxyz", printPrefix, handler, rContactFrameOrientation)) { return false; }
+        if (!setupFixedVectorParamPrivate("r_contact_frame_orientation_quaternion_wxyz",
+                                          printPrefix,
+                                          handler,
+                                          rContactFrameOrientation))
+        {
+            return false;
+        }
 
         std::vector<double> rContactFramePosition(3);
-        if (!setupFixedVectorParamPrivate("r_contact_frame_position_xyz", printPrefix, handler, rContactFramePosition)) { return false; }
+        if (!setupFixedVectorParamPrivate("r_contact_frame_position_xyz",
+                                          printPrefix,
+                                          handler,
+                                          rContactFramePosition))
+        {
+            return false;
+        }
 
-        m_statePrev.lContactFrameOrientation = Eigen::Quaterniond(lContactFrameOrientation[0], lContactFrameOrientation[1], lContactFrameOrientation[2], lContactFrameOrientation[3]);  // here loaded as w x y z
-        m_statePrev.lContactFrameOrientation.normalize(); // normalize the user defined quaternion to respect internal tolerances for unit norm constraint
-        m_statePrev.lContactFramePosition << lContactFramePosition[0], lContactFramePosition[1], lContactFramePosition[2];
+        m_statePrev.lContactFrameOrientation
+            = Eigen::Quaterniond(lContactFrameOrientation[0],
+                                 lContactFrameOrientation[1],
+                                 lContactFrameOrientation[2],
+                                 lContactFrameOrientation[3]); // here loaded as w x y z
+        m_statePrev.lContactFrameOrientation.normalize(); // normalize the user defined quaternion
+                                                          // to respect internal tolerances for unit
+                                                          // norm constraint
+        m_statePrev.lContactFramePosition << lContactFramePosition[0], lContactFramePosition[1],
+            lContactFramePosition[2];
 
-        m_statePrev.rContactFrameOrientation = Eigen::Quaterniond(rContactFrameOrientation[0], rContactFrameOrientation[1], rContactFrameOrientation[2], rContactFrameOrientation[3]);  // here loaded as w x y z
-        m_statePrev.rContactFrameOrientation.normalize(); // normalize the user defined quaternion to respect internal tolerances for unit norm constraint
-        m_statePrev.rContactFramePosition << rContactFramePosition[0], rContactFramePosition[1], rContactFramePosition[2];
+        m_statePrev.rContactFrameOrientation
+            = Eigen::Quaterniond(rContactFrameOrientation[0],
+                                 rContactFrameOrientation[1],
+                                 rContactFrameOrientation[2],
+                                 rContactFrameOrientation[3]); // here loaded as w x y z
+        m_statePrev.rContactFrameOrientation.normalize(); // normalize the user defined quaternion
+                                                          // to respect internal tolerances for unit
+                                                          // norm constraint
+        m_statePrev.rContactFramePosition << rContactFramePosition[0], rContactFramePosition[1],
+            rContactFramePosition[2];
     }
 
     if (m_options.imuBiasEstimationEnabled)
     {
         std::vector<double> accelerometerBias(3);
-        if (!setupFixedVectorParamPrivate("accelerometer_bias", printPrefix, handler, accelerometerBias)) { return false; }
+        if (!setupFixedVectorParamPrivate("accelerometer_bias",
+                                          printPrefix,
+                                          handler,
+                                          accelerometerBias))
+        {
+            return false;
+        }
 
         std::vector<double> gyroscopeBias(3);
-        if (!setupFixedVectorParamPrivate("gyroscope_bias", printPrefix, handler, gyroscopeBias)) { return false; }
+        if (!setupFixedVectorParamPrivate("gyroscope_bias", printPrefix, handler, gyroscopeBias))
+        {
+            return false;
+        }
 
-        m_statePrev.accelerometerBias << accelerometerBias[0], accelerometerBias[1], accelerometerBias[2];
+        m_statePrev.accelerometerBias << accelerometerBias[0], accelerometerBias[1],
+            accelerometerBias[2];
         m_statePrev.gyroscopeBias << gyroscopeBias[0], gyroscopeBias[1], gyroscopeBias[2];
     }
 
-    m_statePrev.imuOrientation = Eigen::Quaterniond(imuOrientation[0], imuOrientation[1], imuOrientation[2], imuOrientation[3]); // here loaded as w x y z
-    m_statePrev.imuOrientation.normalize(); // normalize the user defined quaternion to respect internal tolerances for unit norm constraint
+    m_statePrev.imuOrientation = Eigen::Quaterniond(imuOrientation[0],
+                                                    imuOrientation[1],
+                                                    imuOrientation[2],
+                                                    imuOrientation[3]); // here loaded as w x y z
+    m_statePrev.imuOrientation.normalize(); // normalize the user defined quaternion to respect
+                                            // internal tolerances for unit norm constraint
     m_statePrev.imuPosition << imuPosition[0], imuPosition[1], imuPosition[2];
-    m_statePrev.imuLinearVelocity << imuLinearVelocity[0], imuLinearVelocity[1], imuLinearVelocity[2];
+    m_statePrev.imuLinearVelocity << imuLinearVelocity[0], imuLinearVelocity[1],
+        imuLinearVelocity[2];
 
     m_state = m_statePrev;
 
-    if (!updateBaseStateFromIMUState(m_state, m_measPrev,
-                                     m_estimatorOut.basePose, m_estimatorOut.baseTwist) )
+    if (!updateBaseStateFromIMUState(m_state,
+                                     m_measPrev,
+                                     m_estimatorOut.basePose,
+                                     m_estimatorOut.baseTwist))
     {
         log()->error("[FloatingBaseEstimator::setupInitialStates] "
                      "Failed to initialize base link state from IMU state.");
@@ -708,7 +887,8 @@ bool FloatingBaseEstimator::setupInitialStates(std::weak_ptr<BipedalLocomotion::
     return true;
 }
 
-bool FloatingBaseEstimator::setupPriorDevs(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+bool FloatingBaseEstimator::setupPriorDevs(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
 {
     auto handle = handler.lock();
     if (handle == nullptr)
@@ -721,45 +901,95 @@ bool FloatingBaseEstimator::setupPriorDevs(std::weak_ptr<BipedalLocomotion::Para
     std::string printPrefix{"setupPriorDevs"};
 
     std::vector<double> imuOrientation(3);
-    if (!setupFixedVectorParamPrivate("imu_orientation", printPrefix, handler, imuOrientation)) { return false; }
+    if (!setupFixedVectorParamPrivate("imu_orientation", printPrefix, handler, imuOrientation))
+    {
+        return false;
+    }
 
     std::vector<double> imuPosition(3);
-    if (!setupFixedVectorParamPrivate("imu_position", printPrefix, handler, imuPosition)) { return false; }
+    if (!setupFixedVectorParamPrivate("imu_position", printPrefix, handler, imuPosition))
+    {
+        return false;
+    }
 
     std::vector<double> imuLinearVelocity(3);
-    if (!setupFixedVectorParamPrivate("imu_linear_velocity", printPrefix, handler, imuLinearVelocity)) { return false; }
+    if (!setupFixedVectorParamPrivate("imu_linear_velocity",
+                                      printPrefix,
+                                      handler,
+                                      imuLinearVelocity))
+    {
+        return false;
+    }
 
     if (m_useModelInfo && m_isInvEKF)
     {
         // This conditional block will be soon deprecated
         std::vector<double> lContactFrameOrientation(3);
-        if (!setupFixedVectorParamPrivate("l_contact_frame_orientation", printPrefix, handler, lContactFrameOrientation)) { return false; }
+        if (!setupFixedVectorParamPrivate("l_contact_frame_orientation",
+                                          printPrefix,
+                                          handler,
+                                          lContactFrameOrientation))
+        {
+            return false;
+        }
 
         std::vector<double> lContactFramePosition(3);
-        if (!setupFixedVectorParamPrivate("l_contact_frame_position", printPrefix, handler, lContactFramePosition)) { return false; }
+        if (!setupFixedVectorParamPrivate("l_contact_frame_position",
+                                          printPrefix,
+                                          handler,
+                                          lContactFramePosition))
+        {
+            return false;
+        }
 
         std::vector<double> rContactFrameOrientation(3);
-        if (!setupFixedVectorParamPrivate("r_contact_frame_orientation", printPrefix, handler, rContactFrameOrientation)) { return false; }
+        if (!setupFixedVectorParamPrivate("r_contact_frame_orientation",
+                                          printPrefix,
+                                          handler,
+                                          rContactFrameOrientation))
+        {
+            return false;
+        }
 
         std::vector<double> rContactFramePosition(3);
-        if (!setupFixedVectorParamPrivate("r_contact_frame_position", printPrefix, handler, rContactFramePosition)) { return false; }
+        if (!setupFixedVectorParamPrivate("r_contact_frame_position",
+                                          printPrefix,
+                                          handler,
+                                          rContactFramePosition))
+        {
+            return false;
+        }
 
-        m_priors.lContactFrameOrientation << lContactFrameOrientation[0], lContactFrameOrientation[1], lContactFrameOrientation[2];
-        m_priors.lContactFramePosition << lContactFramePosition[0], lContactFramePosition[1], lContactFramePosition[2];
+        m_priors.lContactFrameOrientation << lContactFrameOrientation[0],
+            lContactFrameOrientation[1], lContactFrameOrientation[2];
+        m_priors.lContactFramePosition << lContactFramePosition[0], lContactFramePosition[1],
+            lContactFramePosition[2];
 
-        m_priors.rContactFrameOrientation << rContactFrameOrientation[0], rContactFrameOrientation[1], rContactFrameOrientation[2];
-        m_priors.rContactFramePosition << rContactFramePosition[0], rContactFramePosition[1], rContactFramePosition[2];
+        m_priors.rContactFrameOrientation << rContactFrameOrientation[0],
+            rContactFrameOrientation[1], rContactFrameOrientation[2];
+        m_priors.rContactFramePosition << rContactFramePosition[0], rContactFramePosition[1],
+            rContactFramePosition[2];
     }
 
     if (m_options.imuBiasEstimationEnabled)
     {
         std::vector<double> accelerometerBias(3);
-        if (!setupFixedVectorParamPrivate("accelerometer_bias", printPrefix, handler, accelerometerBias)) { return false; }
+        if (!setupFixedVectorParamPrivate("accelerometer_bias",
+                                          printPrefix,
+                                          handler,
+                                          accelerometerBias))
+        {
+            return false;
+        }
 
         std::vector<double> gyroscopeBias(3);
-        if (!setupFixedVectorParamPrivate("gyroscope_bias", printPrefix, handler, gyroscopeBias)) { return false; }
+        if (!setupFixedVectorParamPrivate("gyroscope_bias", printPrefix, handler, gyroscopeBias))
+        {
+            return false;
+        }
 
-        m_priors.accelerometerBias << accelerometerBias[0], accelerometerBias[1], accelerometerBias[2];
+        m_priors.accelerometerBias << accelerometerBias[0], accelerometerBias[1],
+            accelerometerBias[2];
         m_priors.gyroscopeBias << gyroscopeBias[0], gyroscopeBias[1], gyroscopeBias[2];
     }
 
@@ -770,10 +1000,11 @@ bool FloatingBaseEstimator::setupPriorDevs(std::weak_ptr<BipedalLocomotion::Para
     return true;
 }
 
-
-bool FloatingBaseEstimator::setupFixedVectorParamPrivate(const std::string& param, const std::string& prefix,
-                                                         std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
-                                                         std::vector<double>& vec)
+bool FloatingBaseEstimator::setupFixedVectorParamPrivate(
+    const std::string& param,
+    const std::string& prefix,
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
+    std::vector<double>& vec)
 {
     auto handle = handler.lock();
     if (handle == nullptr)
@@ -781,21 +1012,26 @@ bool FloatingBaseEstimator::setupFixedVectorParamPrivate(const std::string& para
         return false;
     }
 
-    if (!handle->getParameter(param, GenericContainer::make_vector(vec, GenericContainer::VectorResizeMode::Fixed)))
+    if (!handle->getParameter(param,
+                              GenericContainer::
+                                  make_vector(vec, GenericContainer::VectorResizeMode::Fixed)))
     {
-       log()->error("[FloatingBaseEstimator::{}] "
-                    "The parameter handler could not find \"{}\" in the configuration file."
-                    "This is a required parameter.", prefix, param);
+        log()->error("[FloatingBaseEstimator::{}] "
+                     "The parameter handler could not find \"{}\" in the configuration file."
+                     "This is a required parameter.",
+                     prefix,
+                     param);
         return false;
     }
 
     return true;
 }
 
-bool FloatingBaseEstimator::updateBaseStateFromIMUState(const FloatingBaseEstimators::InternalState& state,
-                                                        const FloatingBaseEstimators::Measurements& meas,
-                                                        manif::SE3d& basePose,
-                                                        Eigen::Ref<Eigen::Matrix<double, 6, 1>> baseTwist)
+bool FloatingBaseEstimator::updateBaseStateFromIMUState(
+    const FloatingBaseEstimators::InternalState& state,
+    const FloatingBaseEstimators::Measurements& meas,
+    manif::SE3d& basePose,
+    Eigen::Ref<Eigen::Matrix<double, 6, 1>> baseTwist)
 {
     manif::SE3d A_H_IMU(state.imuPosition, state.imuOrientation);
     Eigen::Matrix<double, 6, 1> v_IMU;
@@ -803,9 +1039,9 @@ bool FloatingBaseEstimator::updateBaseStateFromIMUState(const FloatingBaseEstima
     v_IMU.head<3>() = state.imuLinearVelocity;
     if (m_useIMUForAngVelEstimate)
     {
-        v_IMU.tail<3>() = state.imuOrientation.toRotationMatrix()*(meas.gyro - state.gyroscopeBias);
-    }
-    else
+        v_IMU.tail<3>()
+            = state.imuOrientation.toRotationMatrix() * (meas.gyro - state.gyroscopeBias);
+    } else
     {
         v_IMU.tail<3>() = state.imuAngularVelocity;
     }
@@ -824,8 +1060,7 @@ bool FloatingBaseEstimator::updateBaseStateFromIMUState(const FloatingBaseEstima
         {
             baseTwist = tempTwist;
         }
-    }
-    else
+    } else
     {
         basePose = A_H_IMU;
         baseTwist = v_IMU;
@@ -847,9 +1082,9 @@ bool FloatingBaseEstimator::resetEstimator(const Eigen::Quaterniond& newBaseOrie
         return false;
     }
 
-    auto A_H_IMU = A_H_B*m_modelComp.base_H_IMU();
-    auto A_H_RF = A_H_IMU*IMU_H_RF;
-    auto A_H_LF = A_H_IMU*IMU_H_LF;
+    auto A_H_IMU = A_H_B * m_modelComp.base_H_IMU();
+    auto A_H_RF = A_H_IMU * IMU_H_RF;
+    auto A_H_LF = A_H_IMU * IMU_H_LF;
 
     m_state.imuOrientation = A_H_IMU.quat();
     m_state.imuPosition = A_H_IMU.translation();

--- a/src/Estimators/src/InvariantEKFBaseEstimator.cpp
+++ b/src/Estimators/src/InvariantEKFBaseEstimator.cpp
@@ -194,7 +194,8 @@ public:
     friend class InvariantEKFBaseEstimator;
 };
 
-InvariantEKFBaseEstimator::InvariantEKFBaseEstimator() : m_pimpl(std::make_unique<Impl>())
+InvariantEKFBaseEstimator::InvariantEKFBaseEstimator()
+    : m_pimpl(std::make_unique<Impl>())
 {
     m_isInvEKF = true;
     m_state.imuOrientation.setIdentity();

--- a/src/Estimators/src/LeggedOdometry.cpp
+++ b/src/Estimators/src/LeggedOdometry.cpp
@@ -7,6 +7,7 @@
 
 #include <BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h>
 #include <BipedalLocomotion/Conversions/ManifConversions.h>
+#include <chrono>
 #include <iDynTree/Core/EigenHelpers.h>
 #include <iDynTree/Model/Model.h>
 #include <manif/manif.h>
@@ -345,7 +346,11 @@ iDynTree::FrameIndex LeggedOdometry::Impl::getLatestSwitchedContact(const std::m
 
     bool atleastOneActiveContact{false};
     int latestContactIdx{-1};
-    double latestTime{-1.0}; // assuming time cannot be negative
+
+    // we initialize latestTime = -1 so assuming no contact has a switch time lower than 0, we find
+    // the contact with the highest switch time
+    std::chrono::nanoseconds latestTime{-1}; // assuming time cannot be negative
+
     for (const auto& [idx, contact] : contacts)
     {
         if (contact.isActive)
@@ -385,7 +390,9 @@ iDynTree::FrameIndex LeggedOdometry::Impl::getLastActiveContact(const std::map<i
         }
     }
 
-    double latestTime{std::numeric_limits<double>::max()}; // assuming time cannot be negative
+    // here we are interested in finding the last active contact so we are looking for the minimum
+    // switchTime
+    std::chrono::nanoseconds latestTime{std::chrono::nanoseconds::max()};
     int latestContactIdx{-1};
     for (const auto& [idx, contact] : contacts)
     {

--- a/src/Math/include/BipedalLocomotion/Math/SchmittTrigger.h
+++ b/src/Math/include/BipedalLocomotion/Math/SchmittTrigger.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_MATH_SCHMITT_TRIGGER_H
 #define BIPEDAL_LOCOMOTION_MATH_SCHMITT_TRIGGER_H
 
+#include <chrono>
 #include <memory>
 
 #include <BipedalLocomotion/Math/Constants.h>
@@ -25,9 +26,12 @@ namespace Math
 struct SchmittTriggerState
 {
     bool state{false}; /**< current state*/
-    double switchTime{0.0}; /**< time instant at which the state was toggled in seconds */
-    double edgeTime{0.0}; /**< Time instant at which the raw value transited from low to high of
-                             from high to low in seconds.*/
+
+    /** Time instant at which the state was toggled */
+    std::chrono::nanoseconds switchTime{std::chrono::nanoseconds::zero()};
+
+    /** Time instant at which the raw value transited from low to high of from high to low .*/
+    std::chrono::nanoseconds edgeTime{std::chrono::nanoseconds::zero()};
 };
 
 /**
@@ -35,7 +39,8 @@ struct SchmittTriggerState
  */
 struct SchmittTriggerInput
 {
-    double time{0.0}; /**< Current time instant in seconds */
+    /** Current time instant in seconds */
+    std::chrono::nanoseconds time{std::chrono::nanoseconds::zero()};
     double rawValue{0.0} ; /**< Raw value that should  */
 };
 
@@ -56,15 +61,14 @@ public:
                                     switchOnAfter time-units*/
         double offThreshold{0.0}; /**< low value threshold to initiate an OFF state switch after
                                      switchOffAfter time-units*/
-        double switchOnAfter{0.0}; /**< time units to wait for before switching to ON state from OFF
-                                      state. Ensure it's greater than sampling time. */
-        double switchOffAfter{0.0}; /**< time units to wait for before switching to OFF state from
-                                       ON state. Ensure it's greater than sampling time. */
 
-        /** Threshold used for the comparison of two time instant. Given two time instants if the
-         * error between the two is lower than the threshold, the time instants are considered
-         * equal. */
-        double timeComparisonThreshold{BipedalLocomotion::Math::AbsoluteEqualityDoubleTolerance};
+        /** Time to wait before switching to ON state from OFF state. Ensure it's greater than
+         * sampling time. */
+        std::chrono::nanoseconds switchOnAfter{std::chrono::nanoseconds::zero()};
+
+        /** Time to wait before switching to OFF state from ON state. Ensure it's greater than
+         * sampling time. */
+        std::chrono::nanoseconds switchOffAfter{std::chrono::nanoseconds::zero()};
     };
 
     /**
@@ -73,11 +77,10 @@ public:
      * @note The following parameters are required
      * |  Parameter Name  |   Type   |                                     Description                                     | Mandatory |
      * |:----------------:|:--------:|:-----------------------------------------------------------------------------------:|:---------:|
-     * |  `on_threshold`  | `double` | High value threshold to initiate an ON state switch after switchOnAfter time-units  |    Yes    |
-     * | `off_threshold`  | `double` | Low value threshold to initiate an OFF state switch after switchOffAfter time-units |    Yes    |
-     * | `switch_on_after`| `double` | Time units to wait for before switching to ON state from OFF state. Ensure it's greater than sampling time. |     Yes    |
-     * |`switch_off_after`| `double` | Time units to wait for before switching to OFF state from ON state. Ensure it's greater than sampling time. |     Yes    |
-     * | `time_comparison_threshold`| `double` | Threshold used for the comparison of two time instants. Given two time instants, if the error between the two is lower than the threshold, the time instants are considered equal. Default value [`std::numeric_limits<double>::epsilon()`](https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon) |     No    |
+     * |  `on_threshold`  | `double` |     High value threshold to initiate an ON state switch after switchOnAfter         |    Yes    |
+     * | `off_threshold`  | `double` |     Low value threshold to initiate an OFF state switch after switchOffAfter        |    Yes    |
+     * | `switch_on_after`| `chrono:nanoseconds` | Nano seconds to wait for before switching to ON state from OFF state. Ensure it's greater than sampling time. |     Yes    |
+     * |`switch_off_after`| `chrono:nanoseconds` | Nano seconds to wait for before switching to OFF state from ON state. Ensure it's greater than sampling time. |     Yes    |
      * @return true in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
@@ -126,10 +129,15 @@ private:
     SchmittTriggerInput m_input; /**< Last input stored in the trigger */
     SchmittTriggerState m_state; /**< Current state stored in the trigger */
     Params m_params; /**< Set of switching parameters */
-    double m_timer{0}; /**< Internal timer used by the switcher to understand if it is the time to
-                          switch */
-    double m_risingEdgeTimeInstant{-1}; /**< Internal quantity used to store the previous time */
-    double m_fallingEdgeTimeInstant{-1}; /**< Internal quantity used to store the previous time */
+
+    /** Internal timer used by the switcher to understand if it is the time to switch */
+    std::chrono::nanoseconds m_timer{std::chrono::nanoseconds::zero()};
+    std::chrono::nanoseconds m_risingEdgeTimeInstant; /**< Internal quantity used to store the
+                                                         previous time */
+    std::chrono::nanoseconds m_fallingEdgeTimeInstant; /**< Internal quantity used to store the
+                                                          previous time */
+    bool m_risingDetected{false};
+    bool m_fallingDetected{false};
 };
 
 } // namespace Math

--- a/src/ParametersHandler/TomlImplementation/include/BipedalLocomotion/ParametersHandler/TomlImplementation.h
+++ b/src/ParametersHandler/TomlImplementation/include/BipedalLocomotion/ParametersHandler/TomlImplementation.h
@@ -114,8 +114,15 @@ public:
      * @param parameter parameter
      * @return true/false in case of success/failure
      */
-
     bool getParameter(const std::string& parameterName, bool& parameter) const final;
+
+    /**
+     * Get a parameter [std::chrono::nanoseconds]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     * @return true/false in case of success/failure
+     */
+    bool getParameter(const std::string& parameterName, std::chrono::nanoseconds& parameter) const final;
 
     /**
      * Get a parameter [std::vector<bool>]
@@ -148,6 +155,16 @@ public:
      * @return true/false in case of success/failure
      */
     bool getParameter(const std::string& parameterName, GenericContainer::Vector<std::string>::Ref parameter) const final;
+
+    /**
+     * Get a parameter [GenericContainer::Vector<std::chrono::nanoseconds>]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     * @return true/false in case of success/failure
+     */
+    bool
+    getParameter(const std::string& parameterName,
+                 GenericContainer::Vector<std::chrono::nanoseconds>::Ref parameter) const final;
 
     /**
      * Set a parameter [int]
@@ -187,6 +204,13 @@ public:
     void setParameter(const std::string& parameterName, const bool& parameter) final;
 
     /**
+     * Set a parameter [std::chrono::nanoseconds]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     */
+    void setParameter(const std::string& parameterName, const std::chrono::nanoseconds& parameter) final;
+
+    /**
      * Set a parameter [std::vector<bool>]
      * @param parameterName name of the parameter
      * @param parameter parameter
@@ -213,6 +237,15 @@ public:
      * @param parameter parameter
      */
     void setParameter(const std::string& parameterName, const GenericContainer::Vector<const std::string>::Ref parameter) final;
+
+    /**
+     * Get a parameter [GenericContainer::Vector<std::chrono::nanoseconds>]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     */
+    void setParameter(
+        const std::string& parameterName,
+        const GenericContainer::Vector<const std::chrono::nanoseconds>::Ref parameter) final;
 
     /**
      * Get a Group from the handler.

--- a/src/ParametersHandler/TomlImplementation/include/BipedalLocomotion/ParametersHandler/TomlImplementation.tpp
+++ b/src/ParametersHandler/TomlImplementation/include/BipedalLocomotion/ParametersHandler/TomlImplementation.tpp
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_PARAMETERS_HANDLER_TOML_IMPLEMENTATION_TPP
 #define BIPEDAL_LOCOMOTION_PARAMETERS_HANDLER_TOML_IMPLEMENTATION_TPP
 
+#include <chrono>
 #include <type_traits>
 
 #include <BipedalLocomotion/GenericContainer/TemplateHelpers.h>
@@ -25,7 +26,33 @@ bool TomlImplementation::getParameterPrivate(const std::string& parameterName, T
     constexpr auto logPrefix = "[TomlImplementation::getParameterPrivate]";
     auto paramToml = m_container[parameterName];
 
-    if constexpr (std::is_scalar<T>::value || is_string<T>::value)
+    if constexpr (std::is_same_v<T, std::chrono::nanoseconds>)
+    {
+        using namespace std::chrono_literals;
+        if (paramToml.is_time())
+        {
+
+            const toml::time time = paramToml.value<toml::time>().value();
+            parameter = time.hour * 1h //
+                        + time.minute * 1min //
+                        + time.second * 1s //
+                        + time.nanosecond * 1ns;
+            return true;
+        }
+
+        if (paramToml.is<double>())
+        {
+            parameter = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::duration<double>(paramToml.value<double>().value()));
+            return true;
+        }
+
+        BipedalLocomotion::log()->debug("{} The type of the parameter named {} is "
+                                        "different from expected one.",
+                                        logPrefix,
+                                        parameterName);
+        return false;
+    } else if constexpr (std::is_scalar<T>::value || is_string<T>::value)
     {
         if constexpr (std::is_integral<T>() && !std::is_same_v<T, bool>)
         {
@@ -51,6 +78,8 @@ bool TomlImplementation::getParameterPrivate(const std::string& parameterName, T
         }
         parameter = paramToml.value<T>().value();
         return true;
+
+
     } else // otherwise it is considered as a vector
     {
         using elementType = typename T::value_type;
@@ -109,6 +138,17 @@ bool TomlImplementation::getParameterPrivate(const std::string& parameterName, T
 
                 return false;
             }
+        } else if constexpr (std::is_same_v<elementType, std::chrono::nanoseconds>)
+        {
+            if (!array.is_homogeneous(toml::node_type::time) || !array.is_homogeneous<double>())
+            {
+                BipedalLocomotion::log()->debug("{} The type of the parameter named {} is "
+                                                "different from expected one.",
+                                                logPrefix,
+                                                parameterName);
+
+                return false;
+            }
         } else
         {
             if (!array.is_homogeneous<elementType>())
@@ -124,27 +164,79 @@ bool TomlImplementation::getParameterPrivate(const std::string& parameterName, T
 
         for (int i = 0; i < array.size(); i++)
         {
-            parameter[i] = array[i].value<elementType>().value();
+            if constexpr (std::is_same_v<elementType, std::chrono::nanoseconds>)
+            {
+                if (array[i].is_time())
+                {
+                    using namespace std::chrono_literals;
+                    const toml::time time = array[i].value<toml::time>().value();
+                    parameter[i] = time.hour * 1h //
+                                   + time.minute * 1min //
+                                   + time.second * 1s //
+                                   + time.nanosecond * 1ns;
+                } else // in this case is a double
+                {
+                    parameter[i] = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::duration<double>(array[i].value<double>().value()));
+                }
+            } else
+            {
+                parameter[i] = array[i].value<elementType>().value();
+            }
         }
 
-        return true;
+            return true;
     }
 }
 
 template <typename T>
 void TomlImplementation::setParameterPrivate(const std::string& parameterName, const T& parameter)
 {
-    if constexpr (std::is_scalar<T>::value || is_string<T>::value)
+    if constexpr (std::is_same<T, std::chrono::nanoseconds>::value)
+    {
+        toml::time time;
+        time.hour = std::chrono::duration_cast<std::chrono::hours>(parameter).count();
+        time.minute
+            = std::chrono::duration_cast<std::chrono::minutes>(parameter % std::chrono::hours(1))
+                  .count();
+        time.second
+            = std::chrono::duration_cast<std::chrono::seconds>(parameter % std::chrono::minutes(1))
+                  .count();
+        time.nanosecond = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                              parameter % std::chrono::seconds(1))
+                              .count();
+
+        m_container.insert_or_assign(parameterName, time);
+
+    } else if constexpr (std::is_scalar<T>::value || is_string<T>::value)
     {
         m_container.insert_or_assign(parameterName, parameter);
     } else // if it is a vector
     {
         m_container.insert_or_assign(parameterName, toml::array());
-        for(const auto& element : parameter)
-        {
-            m_container[parameterName].as_array()->push_back(element);
-        }
+        using elementType = typename T::value_type;
 
+        for (const auto& element : parameter)
+        {
+            if constexpr (std::is_same_v<elementType, std::chrono::nanoseconds>)
+            {
+                toml::time time;
+                time.hour = std::chrono::duration_cast<std::chrono::hours>(element).count();
+                time.minute = std::chrono::duration_cast<std::chrono::minutes>(
+                                  element % std::chrono::hours(1))
+                                  .count();
+                time.second = std::chrono::duration_cast<std::chrono::seconds>(
+                                  element % std::chrono::minutes(1))
+                                  .count();
+                time.nanosecond = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                      element % std::chrono::seconds(1)).count();
+
+                m_container[parameterName].as_array()->push_back(time);
+            } else
+            {
+                m_container[parameterName].as_array()->push_back(element);
+            }
+        }
     }
 }
 

--- a/src/ParametersHandler/TomlImplementation/src/TomlImplementation.cpp
+++ b/src/ParametersHandler/TomlImplementation/src/TomlImplementation.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
 #include <string>
 
 #include <BipedalLocomotion/ParametersHandler/TomlImplementation.h>
@@ -48,6 +49,12 @@ bool TomlImplementation::getParameter(const std::string& parameterName, bool& pa
 }
 
 bool TomlImplementation::getParameter(const std::string& parameterName,
+                                      std::chrono::nanoseconds& parameter) const
+{
+    return getParameterPrivate(parameterName, parameter);
+}
+
+bool TomlImplementation::getParameter(const std::string& parameterName,
                                       GenericContainer::Vector<int>::Ref parameter) const
 {
     return getParameterPrivate(parameterName, parameter);
@@ -67,6 +74,13 @@ bool TomlImplementation::getParameter(const std::string& parameterName,
 
 bool TomlImplementation::getParameter(const std::string& parameterName,
                                       std::vector<bool>& parameter) const
+{
+    return getParameterPrivate(parameterName, parameter);
+}
+
+bool TomlImplementation::getParameter(
+    const std::string& parameterName,
+    GenericContainer::Vector<std::chrono::nanoseconds>::Ref parameter) const
 {
     return getParameterPrivate(parameterName, parameter);
 }
@@ -98,10 +112,17 @@ void TomlImplementation::setParameter(const std::string& parameterName, const bo
 }
 
 void TomlImplementation::setParameter(const std::string& parameterName,
+                                      const std::chrono::nanoseconds& parameter)
+{
+    return setParameterPrivate(parameterName, parameter);
+}
+
+void TomlImplementation::setParameter(const std::string& parameterName,
                                       const GenericContainer::Vector<const int>::Ref parameter)
 {
     return setParameterPrivate(parameterName, parameter);
 }
+
 void TomlImplementation::setParameter(const std::string& parameterName,
                                       const GenericContainer::Vector<const double>::Ref parameter)
 {
@@ -117,6 +138,13 @@ void TomlImplementation::setParameter(
 
 void TomlImplementation::setParameter(const std::string& parameterName,
                                       const std::vector<bool>& parameter)
+{
+    return setParameterPrivate(parameterName, parameter);
+}
+
+void TomlImplementation::setParameter(
+    const std::string& parameterName,
+    const GenericContainer::Vector<const std::chrono::nanoseconds>::Ref parameter)
 {
     return setParameterPrivate(parameterName, parameter);
 }

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotion/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotion/ParametersHandler/YarpImplementation.h
@@ -9,6 +9,7 @@
 #define BIPEDAL_LOCOMOTION_PARAMETERS_HANDLER_YARP_IMPLEMENTATION_H
 
 // std
+#include <chrono>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -60,6 +61,17 @@ class YarpImplementation : public IParametersHandler
      * @return A pointer to YarpImplementation containing the content of the handler.
      */
     std::shared_ptr<YarpImplementation> clonePrivate() const;
+
+
+    /**
+     * Convert a formatted string into a std::chrono::nanoseconds.
+     */
+    static bool stringToDuration(const std::string& string, std::chrono::nanoseconds& time);
+
+    /**
+     * Convert a std::chrono::nanoseconds into a formatted string.
+     */
+    static std::string durationToString(const std::chrono::nanoseconds& parameter);
 
 public:
     /**
@@ -117,8 +129,15 @@ public:
      * @param parameter parameter
      * @return true/false in case of success/failure
      */
-
     bool getParameter(const std::string& parameterName, bool& parameter) const final;
+
+    /**
+     * Get a parameter [std::chrono::nanoseconds]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     * @return true/false in case of success/failure
+     */
+    bool getParameter(const std::string& parameterName, std::chrono::nanoseconds& parameter) const final;
 
     /**
      * Get a parameter [std::vector<bool>]
@@ -151,6 +170,15 @@ public:
      * @return true/false in case of success/failure
      */
     bool getParameter(const std::string& parameterName, GenericContainer::Vector<std::string>::Ref parameter) const final;
+
+    /**
+     * Get a parameter [GenericContainer::Vector<std::chrono::nanoseconds>]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     * @return true/false in case of success/failure
+     */
+    bool getParameter(const std::string& parameterName,
+                      GenericContainer::Vector<std::chrono::nanoseconds>::Ref parameter) const final;
 
     /**
      * Set a parameter [int]
@@ -190,6 +218,13 @@ public:
     void setParameter(const std::string& parameterName, const bool& parameter) final;
 
     /**
+     * Set a parameter [std::chrono::nanoseconds]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     */
+    void setParameter(const std::string& parameterName, const std::chrono::nanoseconds& parameter) final;
+
+    /**
      * Set a parameter [std::vector<bool>]
      * @param parameterName name of the parameter
      * @param parameter parameter
@@ -216,6 +251,15 @@ public:
      * @param parameter parameter
      */
     void setParameter(const std::string& parameterName, const GenericContainer::Vector<const std::string>::Ref parameter) final;
+
+    /**
+     * Get a parameter [GenericContainer::Vector<std::chrono::nanoseconds>]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     */
+    void setParameter(
+        const std::string& parameterName,
+        const GenericContainer::Vector<const std::chrono::nanoseconds>::Ref parameter) final;
 
     /**
      * Get a Group from the handler.

--- a/src/ParametersHandler/include/BipedalLocomotion/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotion/ParametersHandler/IParametersHandler.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_PARAMETERS_HANDLER_IPARAMETERS_HANDLER_H
 #define BIPEDAL_LOCOMOTION_PARAMETERS_HANDLER_IPARAMETERS_HANDLER_H
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -62,8 +63,15 @@ public:
      * @param parameter parameter
      * @return true/false in case of success/failure
      */
-
     virtual bool getParameter(const std::string& parameterName, bool& parameter) const = 0;
+
+    /**
+     * Get a parameter [int]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     * @return true/false in case of success/failure
+     */
+    virtual bool getParameter(const std::string& parameterName, std::chrono::nanoseconds& parameter) const = 0;
 
     /**
      * Get a parameter [std::vector<bool>]
@@ -100,6 +108,15 @@ public:
      */
     virtual bool getParameter(const std::string& parameterName,
                               GenericContainer::Vector<std::string>::Ref parameter) const = 0;
+
+    /**
+     * Get a parameter [GenericContainer::Vector<std::chrono::nanoseconds>]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     * @return true/false in case of success/failure
+     */
+    virtual bool getParameter(const std::string& parameterName,
+                              GenericContainer::Vector<std::chrono::nanoseconds>::Ref parameter) const = 0;
 
     /**
      * Set a parameter [int]
@@ -139,6 +156,14 @@ public:
     virtual void setParameter(const std::string& parameterName, const bool& parameter) = 0;
 
     /**
+     * Set a parameter [std::chrono::nanoseconds]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     */
+    virtual void setParameter(const std::string& parameterName, //
+                              const std::chrono::nanoseconds& parameter) = 0;
+
+    /**
      * Set a parameter [std::vector<bool>]
      * @param parameterName name of the parameter
      * @param parameter parameter
@@ -171,6 +196,16 @@ public:
      */
     virtual void setParameter(const std::string& parameterName,
                               const GenericContainer::Vector<const std::string>::Ref parameter)
+        = 0;
+
+    /**
+     * Get a parameter [GenericContainer::Vector<std::chrono::nanoseconds>]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     */
+    virtual void
+    setParameter(const std::string& parameterName,
+                 const GenericContainer::Vector<const std::chrono::nanoseconds>::Ref parameter)
         = 0;
 
     /**

--- a/src/ParametersHandler/include/BipedalLocomotion/ParametersHandler/StdImplementation.h
+++ b/src/ParametersHandler/include/BipedalLocomotion/ParametersHandler/StdImplementation.h
@@ -9,6 +9,7 @@
 #define BIPEDAL_LOCOMOTION_PARAMETERS_HANDLER_STD_IMPLEMENTATION_H
 
 #include <any>
+#include <chrono>
 #include <string>
 #include <unordered_map>
 
@@ -99,8 +100,15 @@ public:
      * @param parameter parameter
      * @return true/false in case of success/failure
      */
-
     bool getParameter(const std::string& parameterName, bool& parameter) const final;
+
+    /**
+     * Get a parameter [std::chrono::nanoseconds]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     * @return true/false in case of success/failure
+     */
+    bool getParameter(const std::string& parameterName, std::chrono::nanoseconds& parameter) const final;
 
     /**
      * Get a parameter [std::vector<bool>]
@@ -133,6 +141,15 @@ public:
      * @return true/false in case of success/failure
      */
     bool getParameter(const std::string& parameterName, GenericContainer::Vector<std::string>::Ref parameter) const final;
+
+    /**
+     * Get a parameter [GenericContainer::Vector<std::chrono::nanoseconds>]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     * @return true/false in case of success/failure
+     */
+    bool getParameter(const std::string& parameterName,
+                      GenericContainer::Vector<std::chrono::nanoseconds>::Ref parameter) const final;
 
     /**
      * Set a parameter [int]
@@ -172,6 +189,14 @@ public:
     void setParameter(const std::string& parameterName, const bool& parameter) final;
 
     /**
+     * Set a parameter [std::chrono::nanoseconds]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     */
+    void setParameter(const std::string& parameterName, //
+                      const std::chrono::nanoseconds& parameter) final;
+
+    /**
      * Set a parameter [std::vector<bool>]
      * @param parameterName name of the parameter
      * @param parameter parameter
@@ -183,21 +208,33 @@ public:
      * @param parameterName name of the parameter
      * @param parameter parameter
      */
-    void setParameter(const std::string& parameterName, const GenericContainer::Vector<const int>::Ref parameter) final;
+    void setParameter(const std::string& parameterName,
+                      const GenericContainer::Vector<const int>::Ref parameter) final;
 
     /**
      * Set a parameter [GenericContainer::Vector<double>]
      * @param parameterName name of the parameter
      * @param parameter parameter
      */
-    void setParameter(const std::string& parameterName, const GenericContainer::Vector<const double>::Ref parameter) final;
+    void setParameter(const std::string& parameterName,
+                      const GenericContainer::Vector<const double>::Ref parameter) final;
 
     /**
      * Set a parameter [GenericContainer::Vector<std::string>]
      * @param parameterName name of the parameter
      * @param parameter parameter
      */
-    void setParameter(const std::string& parameterName, const GenericContainer::Vector<const std::string>::Ref parameter) final;
+    void setParameter(const std::string& parameterName,
+                      const GenericContainer::Vector<const std::string>::Ref parameter) final;
+
+    /**
+     * Get a parameter [GenericContainer::Vector<std::chrono::nanoseconds>]
+     * @param parameterName name of the parameter
+     * @param parameter parameter
+     */
+    void setParameter(
+        const std::string& parameterName,
+        const GenericContainer::Vector<const std::chrono::nanoseconds>::Ref parameter) final;
 
     /**
      * Get a Group from the handler.

--- a/src/ParametersHandler/include/BipedalLocomotion/ParametersHandler/StdImplementation.tpp
+++ b/src/ParametersHandler/include/BipedalLocomotion/ParametersHandler/StdImplementation.tpp
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_PARAMETERS_HANDLER_STD_IMPLEMENTATION_TPP
 #define BIPEDAL_LOCOMOTION_PARAMETERS_HANDLER_STD_IMPLEMENTATION_TPP
 
+#include <chrono>
 #include <type_traits>
 
 #include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
@@ -30,7 +31,8 @@ bool StdImplementation::getParameterPrivate(const std::string& parameterName, T&
         return false;
     }
 
-    if constexpr (std::is_scalar<T>::value || is_string<T>::value)
+    if constexpr (std::is_scalar<T>::value || is_string<T>::value
+                  || std::is_same<T, std::chrono::nanoseconds>::value)
     {
         try
         {
@@ -89,7 +91,9 @@ bool StdImplementation::getParameterPrivate(const std::string& parameterName, T&
         }
 
         for (std::size_t index = 0; index < parameter.size(); index++)
+        {
             parameter[index] = castedParameter[index];
+        }
     }
     return true;
 }
@@ -98,7 +102,8 @@ template <typename T>
 void StdImplementation::setParameterPrivate(const std::string& parameterName, const T& parameter)
 {
     // a scalar element and a strings is retrieved using getElementFromSearchable() function
-    if constexpr (std::is_scalar<T>::value || is_string<T>::value)
+    if constexpr (std::is_scalar<T>::value || is_string<T>::value
+                  || std::is_same<T, std::chrono::nanoseconds>::value)
         m_map[parameterName] = parameter;
     else
     {

--- a/src/ParametersHandler/src/StdImplementation.cpp
+++ b/src/ParametersHandler/src/StdImplementation.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
 #include <string>
 
 #include <BipedalLocomotion/GenericContainer/Vector.h>
@@ -33,6 +34,13 @@ void StdImplementation::setParameter(
     return setParameterPrivate(parameterName, parameter);
 }
 
+void StdImplementation::setParameter(
+        const std::string& parameterName,
+        const GenericContainer::Vector<const std::chrono::nanoseconds>::Ref parameter)
+{
+    return setParameterPrivate(parameterName, parameter);
+}
+
 bool StdImplementation::getParameter(const std::string& parameterName,
                                      GenericContainer::Vector<int>::Ref parameter) const
 {
@@ -47,6 +55,13 @@ bool StdImplementation::getParameter(const std::string& parameterName,
 
 bool StdImplementation::getParameter(const std::string& parameterName,
                                      GenericContainer::Vector<std::string>::Ref parameter) const
+{
+    return getParameterPrivate(parameterName, parameter);
+}
+
+bool StdImplementation::getParameter(
+    const std::string& parameterName,
+    GenericContainer::Vector<std::chrono::nanoseconds>::Ref parameter) const
 {
     return getParameterPrivate(parameterName, parameter);
 }
@@ -67,6 +82,12 @@ bool StdImplementation::getParameter(const std::string& parameterName, std::stri
 }
 
 bool StdImplementation::getParameter(const std::string& parameterName, bool& parameter) const
+{
+    return getParameterPrivate(parameterName, parameter);
+}
+
+bool StdImplementation::getParameter(const std::string& parameterName,
+                                     std::chrono::nanoseconds& parameter) const
 {
     return getParameterPrivate(parameterName, parameter);
 }
@@ -98,6 +119,12 @@ void StdImplementation::setParameter(const std::string& parameterName, const std
 }
 
 void StdImplementation::setParameter(const std::string& parameterName, const bool& parameter)
+{
+    return setParameterPrivate(parameterName, parameter);
+}
+
+void StdImplementation::setParameter(const std::string& parameterName,
+                                     const std::chrono::nanoseconds& parameter)
 {
     return setParameterPrivate(parameterName, parameter);
 }

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -6,6 +6,7 @@
  */
 
 // std
+#include <chrono>
 #include <memory>
 
 // Catch2
@@ -29,6 +30,7 @@ using namespace BipedalLocomotion::GenericContainer;
 
 TEST_CASE("Get parameters")
 {
+    using namespace std::chrono_literals;
     std::vector<int> fibonacciNumbers{1, 1, 2, 3, 5, 8, 13, 21};
     std::vector<std::string> donaldsNephews{"Huey", "Dewey", "Louie"};
     bool flag = true;
@@ -36,12 +38,17 @@ TEST_CASE("Get parameters")
 
     std::shared_ptr<YarpImplementation> originalHandler = std::make_shared<YarpImplementation>();
     IParametersHandler::shared_ptr parameterHandler = originalHandler;
+    std::chrono::nanoseconds time = 13h + 39min + 51s + 523ms;
+    double timeAsDouble = 0.01;
+
     parameterHandler->setParameter("answer_to_the_ultimate_question_of_life", 42);
     parameterHandler->setParameter("pi", 3.14);
     parameterHandler->setParameter("John", "Smith");
     parameterHandler->setParameter("Fibonacci Numbers", fibonacciNumbers);
     parameterHandler->setParameter("flag", flag);
     parameterHandler->setParameter("flags", flags);
+    parameterHandler->setParameter("time", time);
+    parameterHandler->setParameter("time_as_double", timeAsDouble);
 
     SECTION("Get integer")
     {
@@ -64,12 +71,25 @@ TEST_CASE("Get parameters")
         REQUIRE(element == flag);
     }
 
-
     SECTION("Get String")
     {
         std::string element;
         REQUIRE(parameterHandler->getParameter("John", element));
         REQUIRE(element == "Smith");
+    }
+
+    SECTION("Get std::chrono::nanoseconds")
+    {
+        std::chrono::nanoseconds element;
+        REQUIRE(parameterHandler->getParameter("time", element));
+        REQUIRE(element == time);
+    }
+
+    SECTION("Get std::chrono::nanoseconds from double")
+    {
+        std::chrono::nanoseconds element;
+        REQUIRE(parameterHandler->getParameter("time_as_double", element));
+        REQUIRE(element == std::chrono::duration<double>(timeAsDouble));
     }
 
     SECTION("Change String")
@@ -93,7 +113,6 @@ TEST_CASE("Get parameters")
         REQUIRE(parameterHandler->getParameter("flags", element));
         REQUIRE(element == flags);
     }
-
 
     SECTION("Change Vector")
     {
@@ -254,6 +273,30 @@ TEST_CASE("Get parameters")
             REQUIRE(element == fibonacciNumbers);
         }
 
+        {
+            std::chrono::nanoseconds element;
+            REQUIRE(parameterHandler->getParameter("time", element));
+            REQUIRE(3 == std::chrono::duration_cast<std::chrono::hours>(element).count());
+            REQUIRE(
+                13
+                == std::chrono::duration_cast<std::chrono::minutes>(element % std::chrono::hours(1))
+                       .count());
+            REQUIRE(38
+                    == std::chrono::duration_cast<std::chrono::seconds>(element
+                                                                        % std::chrono::minutes(1))
+                           .count());
+            REQUIRE(21451
+                    == std::chrono::duration_cast<std::chrono::microseconds>(
+                           element % std::chrono::seconds(1))
+                           .count());
+        }
+
+        {
+            std::chrono::nanoseconds element;
+            REQUIRE(parameterHandler->getParameter("time_as_double", element));
+            REQUIRE(element == std::chrono::duration<double>(0.05));
+        }
+
         IParametersHandler::shared_ptr cartoonsGroup = parameterHandler->getGroup("CARTOONS").lock();
         REQUIRE(cartoonsGroup);
 
@@ -274,6 +317,34 @@ TEST_CASE("Get parameters")
             std::string element;
             REQUIRE(cartoonsGroup->getParameter("John", element));
             REQUIRE(element == "Doe");
+        }
+
+        IParametersHandler::shared_ptr timingsGroup = parameterHandler->getGroup("TIMINGS").lock();
+        REQUIRE(timingsGroup);
+
+        {
+            std::vector<std::chrono::nanoseconds> element;
+            REQUIRE(timingsGroup->getParameter("time", element));
+
+            using namespace std::chrono_literals;
+
+            // these are copied from the ini file
+            REQUIRE(element
+                    == std::vector<std::chrono::nanoseconds>{3h + 13min + 38s + 21451us,
+                                                             5h + 31min + 48s + 189405us});
+        }
+
+        {
+            std::vector<std::chrono::nanoseconds> element;
+            REQUIRE(timingsGroup->getParameter("time_as_double", element));
+
+            using namespace std::chrono_literals;
+
+            // these are copied from the ini file
+            REQUIRE(
+                element
+                == std::vector<std::chrono::nanoseconds>{std::chrono::duration_cast<std::chrono::nanoseconds>(0.03s),
+                                                         std::chrono::duration_cast<std::chrono::nanoseconds>(1.8s)});
         }
     }
 

--- a/src/ParametersHandler/tests/config.ini
+++ b/src/ParametersHandler/tests/config.ini
@@ -2,9 +2,14 @@ answer_to_the_ultimate_question_of_life 42
 pi                                      3.14
 John                                    Smith
 "Fibonacci Numbers"                     (1, 1, 2, 3, 5, 8, 13, 21)
+time                                    "03:13:38.021451"
+time_as_double                          0.05
 
 [CARTOONS]
 "Donald's nephews"                      ("Huey", "Dewey", "Louie")
 Fibonacci_Numbers                       (1, 1, 2, 3, 5, 8, 13, 21)
 John                                    Doe
 
+[TIMINGS]
+time                                    ("03:13:38.021451", "05:31:48.189405")
+time_as_double                          (0.03, 1.8)

--- a/src/Planners/include/BipedalLocomotion/Planners/CubicSpline.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/CubicSpline.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_PLANNERS_CUBIC_SPLINE_H
 #define BIPEDAL_LOCOMOTION_PLANNERS_CUBIC_SPLINE_H
 
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -48,7 +49,7 @@ public:
      * @param dt the time step of the advance block.
      * @return True in case of success, false otherwise.
      */
-    bool setAdvanceTimeStep(const double& dt) final;
+    bool setAdvanceTimeStep(const std::chrono::nanoseconds& dt) final;
 
     /**
      * Set the knots of the spline.
@@ -57,7 +58,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool setKnots(const std::vector<Eigen::VectorXd>& position, //
-                  const std::vector<double>& time) final;
+                  const std::vector<std::chrono::nanoseconds>& time) final;
 
     /**
      * Set the initial condition of the spline
@@ -101,7 +102,7 @@ public:
      * @param acceleration acceleration at time t
      * @return True in case of success, false otherwise.
      */
-    bool evaluatePoint(const double& t,
+    bool evaluatePoint(const std::chrono::nanoseconds& t,
                        Eigen::Ref<Eigen::VectorXd> position,
                        Eigen::Ref<Eigen::VectorXd> velocity,
                        Eigen::Ref<Eigen::VectorXd> acceleration) final;
@@ -112,7 +113,7 @@ public:
      * @param state of the system
      * @return True in case of success, false otherwise.
      */
-    bool evaluatePoint(const double& t, SplineState& state) final;
+    bool evaluatePoint(const std::chrono::nanoseconds& t, SplineState& state) final;
 
     /**
      * Get the state of the system.

--- a/src/Planners/include/BipedalLocomotion/Planners/QuinticSpline.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/QuinticSpline.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_PLANNERS_QUINTIC_SPLINE_H
 #define BIPEDAL_LOCOMOTION_PLANNERS_QUINTIC_SPLINE_H
 
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -48,7 +49,7 @@ public:
      * @param dt the time step of the advance block.
      * @return True in case of success, false otherwise.
      */
-    bool setAdvanceTimeStep(const double& dt) final;
+    bool setAdvanceTimeStep(const std::chrono::nanoseconds& dt) final;
 
     /**
      * Set the knots of the spline.
@@ -57,7 +58,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool setKnots(const std::vector<Eigen::VectorXd>& position, //
-                  const std::vector<double>& time) final;
+                  const std::vector<std::chrono::nanoseconds>& time) final;
 
     /**
      * Set the initial condition of the spline
@@ -85,7 +86,7 @@ public:
      * @param acceleration acceleration at time t
      * @return True in case of success, false otherwise.
      */
-    bool evaluatePoint(const double& t,
+    bool evaluatePoint(const std::chrono::nanoseconds& t,
                        Eigen::Ref<Eigen::VectorXd> position,
                        Eigen::Ref<Eigen::VectorXd> velocity,
                        Eigen::Ref<Eigen::VectorXd> acceleration) final;
@@ -96,7 +97,7 @@ public:
      * @param state of the system
      * @return True in case of success, false otherwise.
      */
-    bool evaluatePoint(const double& t, SplineState& state) final;
+    bool evaluatePoint(const std::chrono::nanoseconds& t, SplineState& state) final;
 
     /**
      * Get the state of the system.

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_H
 #define BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_H
 
+#include <chrono>
 #include <manif/SO3.h>
 
 #include <BipedalLocomotion/System/Source.h>
@@ -61,10 +62,14 @@ class SO3Planner : public System::Source<SO3PlannerState>
      * depends on the chosen Trivialization */
     manif::SO3d::Tangent m_distance{manif::SO3d::Tangent::Zero()};
 
-    double m_T{1.0}; /**< Trajectory duration in seconds */
+    std::chrono::nanoseconds m_T{std::chrono::nanoseconds::zero()}; /**< Trajectory duration in
+                                                                       seconds */
 
-    double m_advanceTimeStep{0.0}; /**< Time step of the advance interface. */
-    double m_advanceCurrentTime{0.0}; /**< Current time of the advance object. */
+    /** Time step of the advance interface. */
+    std::chrono::nanoseconds m_advanceTimeStep{std::chrono::nanoseconds::zero()};
+    /** Current time of the advance object. */
+    std::chrono::nanoseconds m_advanceCurrentTime{std::chrono::nanoseconds::zero()};
+
     SO3PlannerState m_state; /**< Current state of the planner. It is used by the advance
                                 capabilities. */
 
@@ -78,7 +83,7 @@ public:
      */
     bool setRotations(const manif::SO3d& initialRotation,
                       const manif::SO3d& finalRotation,
-                      const double& duration);
+                      const std::chrono::nanoseconds& duration);
 
     /**
      * Get the trajectory at a given time
@@ -86,7 +91,7 @@ public:
      * @param state state of the planner.
      * @return True in case of success/false otherwise.
      */
-    bool evaluatePoint(const double& time,
+    bool evaluatePoint(const std::chrono::nanoseconds& time,
                        SO3PlannerState& state) const;
 
     /**
@@ -100,7 +105,7 @@ public:
      * @return True in case of success/false otherwise.
      */
     template<class Derived>
-    bool evaluatePoint(const double& time,
+    bool evaluatePoint(const std::chrono::nanoseconds& time,
                        manif::SO3d& rotation,
                        manif::SO3TangentBase<Derived>& velocity,
                        manif::SO3TangentBase<Derived>& acceleration) const;
@@ -112,7 +117,7 @@ public:
      * @param dt the time step of the advance block.
      * @return True in case of success, false otherwise.
      */
-    bool setAdvanceTimeStep(const double& dt);
+    bool setAdvanceTimeStep(const std::chrono::nanoseconds& dt);
 
     /**
      * Get the state of the system.

--- a/src/Planners/include/BipedalLocomotion/Planners/Spline.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/Spline.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_PLANNERS_SPLINE_H
 #define BIPEDAL_LOCOMOTION_PLANNERS_SPLINE_H
 
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -44,7 +45,7 @@ public:
      * @param dt the time step of the advance block.
      * @return True in case of success, false otherwise.
      */
-    virtual bool setAdvanceTimeStep(const double& dt) = 0;
+    virtual bool setAdvanceTimeStep(const std::chrono::nanoseconds& dt) = 0;
 
     /**
      * Set the knots of the spline.
@@ -53,7 +54,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     virtual bool setKnots(const std::vector<Eigen::VectorXd>& position, //
-                          const std::vector<double>& time)
+                          const std::vector<std::chrono::nanoseconds>& time)
         = 0;
 
     /**
@@ -84,7 +85,7 @@ public:
      * @param acceleration acceleration at time t
      * @return True in case of success, false otherwise.
      */
-    virtual bool evaluatePoint(const double& t,
+    virtual bool evaluatePoint(const std::chrono::nanoseconds& t,
                                Eigen::Ref<Eigen::VectorXd> position,
                                Eigen::Ref<Eigen::VectorXd> velocity,
                                Eigen::Ref<Eigen::VectorXd> acceleration)
@@ -96,7 +97,7 @@ public:
      * @param state of the system
      * @return True in case of success, false otherwise.
      */
-    virtual bool evaluatePoint(const double& t, SplineState& state) = 0;
+    virtual bool evaluatePoint(const std::chrono::nanoseconds& t, SplineState& state) = 0;
 };
 } // namespace Planners
 } // namespace BipedalLocomotion

--- a/src/Planners/include/BipedalLocomotion/Planners/SwingFootPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SwingFootPlanner.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_PLANNERS_SWING_FOOT_PLANNER_H
 #define BIPEDAL_LOCOMOTION_PLANNERS_SWING_FOOT_PLANNER_H
 
+#include <chrono>
 #include <memory>
 
 #include <manif/manif.h>
@@ -43,8 +44,11 @@ class SwingFootPlanner : public System::Source<SwingFootPlannerState>
 {
     SwingFootPlannerState m_state; /**< State of the planner */
 
-    double m_dT{0.0}; /**< Sampling time of the planner in seconds*/
-    double m_currentTrajectoryTime{0.0}; /**< Current time of the planner in seconds */
+    std::chrono::nanoseconds m_dT{std::chrono::nanoseconds::zero()}; /**< Sampling time of the
+                                                                        planner */
+
+    /** Current time of the planner in seconds */
+    std::chrono::nanoseconds m_currentTrajectoryTime{std::chrono::nanoseconds::zero()};
 
     Contacts::ContactList m_contactList; /**< List of the contacts */
     Contacts::ContactList::const_iterator m_currentContactPtr; /**< Pointer to the current contact. (internal

--- a/src/Planners/src/CubicSpline.cpp
+++ b/src/Planners/src/CubicSpline.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <algorithm>
+#include <chrono>
 #include <iostream>
 
 #include <Eigen/Sparse>
@@ -14,6 +15,12 @@
 #include <BipedalLocomotion/TextLogging/Logger.h>
 
 using namespace BipedalLocomotion::Planners;
+
+template <class Rep, class Period>
+constexpr double durationToSeconds(const std::chrono::duration<Rep, Period>& d)
+{
+    return std::chrono::duration<double>(d).count();
+}
 
 struct CubicSpline::Impl
 {
@@ -35,7 +42,7 @@ struct CubicSpline::Impl
         Eigen::VectorXd velocity; /**< first derivative of spline computed at t@knot */
         Eigen::VectorXd acceleration; /**< second derivative of spline computed at t@knot */
 
-        double timeInstant; /**< Knot time (it is an absolute time ) */
+        std::chrono::nanoseconds timeInstant; /**< Knot time (it is an absolute time ) */
     };
 
     /**
@@ -52,7 +59,7 @@ struct CubicSpline::Impl
         const Knot* initialPoint;
         const Knot* finalPoint;
 
-        double duration;
+        std::chrono::nanoseconds duration;
     };
 
     BoundaryConditions initialCondition; /**< Initial condition */
@@ -64,34 +71,38 @@ struct CubicSpline::Impl
     bool areCoefficientsComputed{false}; /**< If true the coefficients are computed and updated */
 
     SplineState currentTrajectory; /**< Current trajectory stored in the advance state */
-    double advanceTimeStep{0.0}; /**< Time step of the advance interface. */
-    double advanceCurrentTime{0.0}; /**< current time of the advance object. */
+    std::chrono::nanoseconds advanceTimeStep{std::chrono::nanoseconds::zero()}; /**< Time step of
+                                                                                   the advance
+                                                                                   interface. */
+    std::chrono::nanoseconds advanceCurrentTime{std::chrono::nanoseconds::zero()}; /**< current time
+                                                                                      of the advance
+                                                                                      object. */
 
     /**
      * Reset a given knot with a time instant and a position
      */
-    void resetKnot(const double& timeInstant,
+    void resetKnot(const std::chrono::nanoseconds& timeInstant,
                    Eigen::Ref<const Eigen::VectorXd> position,
                    Knot& knot);
 
     /**
      * Get the position at given time for a sub-trajectory
      */
-    void getPositionAtTime(const double& t,
+    void getPositionAtTime(const std::chrono::nanoseconds& t,
                            const Polynomial& poly,
                            Eigen::Ref<Eigen::VectorXd> position);
 
     /**
      * Get the velocity at given time for a sub-trajectory
      */
-    void getVelocityAtTime(const double& t,
+    void getVelocityAtTime(const std::chrono::nanoseconds& t,
                            const Polynomial& poly,
                            Eigen::Ref<Eigen::VectorXd> velocity);
 
     /**
      * Get the acceleration at given time for a sub-trajectory
      */
-    void getAccelerationAtTime(const double& t,
+    void getAccelerationAtTime(const std::chrono::nanoseconds& t,
                                const Polynomial& poly,
                                Eigen::Ref<Eigen::VectorXd> acceleration);
 
@@ -227,11 +238,12 @@ bool CubicSpline::setFinalConditions(Eigen::Ref<const Eigen::VectorXd> velocity)
     return true;
 }
 
-bool CubicSpline::setAdvanceTimeStep(const double& dt)
+bool CubicSpline::setAdvanceTimeStep(const std::chrono::nanoseconds& dt)
 {
     constexpr auto logPrefix = "[CubicSpline::setAdvanceTimeStep]";
 
-    if (dt <= 0)
+    // this should never happen
+    if (dt <= std::chrono::nanoseconds::zero())
     {
         log()->error("{} The time step of the advance object has to be a strictly positive number.",
                      logPrefix);
@@ -244,7 +256,7 @@ bool CubicSpline::setAdvanceTimeStep(const double& dt)
 }
 
 bool CubicSpline::setKnots(const std::vector<Eigen::VectorXd>& position,
-                           const std::vector<double>& time)
+                           const std::vector<std::chrono::nanoseconds>& time)
 {
     constexpr auto logPrefix = "[CubicSpline::setKnots]";
 
@@ -298,7 +310,7 @@ bool CubicSpline::setKnots(const std::vector<Eigen::VectorXd>& position,
     return true;
 }
 
-void CubicSpline::Impl::resetKnot(const double& timeInstant,
+void CubicSpline::Impl::resetKnot(const std::chrono::nanoseconds& timeInstant,
                                   Eigen::Ref<const Eigen::VectorXd> position,
                                   Knot& knot)
 {
@@ -319,7 +331,7 @@ bool CubicSpline::Impl::computePhasesDuration()
         polynomials[i].duration = knots[i + 1].timeInstant - knots[i].timeInstant;
 
         // This is required or stability purposes, the matrix A may not be invertible.
-        if (std::abs(polynomials[i].duration) <= std::numeric_limits<double>::epsilon())
+        if (polynomials[i].duration == std::chrono::nanoseconds::zero())
         {
             log()->error("{} Two consecutive points have the same time coordinate.", errorPrefix);
             return false;
@@ -452,14 +464,15 @@ void CubicSpline::Impl::addTripletCurrentKnot(const int& knotIndex,
 
     // The following triplet represent this matrix
     //  /      /   1      1\ \
-    //  |   4  |------ - --| |
+    //  |   4  |------ + --| |
     //  |      |T        T | |
     //  |      \ i - 1    i/ |
     //  \                    /
 
     tripletList.emplace_back(rowOffset,
                              columnOffset,
-                             4 * (1 / prevPoly.duration + 1 / poly.duration));
+                             4 * (1 / durationToSeconds(prevPoly.duration)
+                                    + 1 / durationToSeconds(poly.duration)));
 }
 
 void CubicSpline::Impl::addTripletPreviousKnot(const int& knotIndex,
@@ -475,7 +488,7 @@ void CubicSpline::Impl::addTripletPreviousKnot(const int& knotIndex,
     // |  T         |
     // \   i - 1    /
 
-    tripletList.emplace_back(rowOffset, columnOffset, 2 / poly.duration);
+    tripletList.emplace_back(rowOffset, columnOffset, 2 / durationToSeconds(poly.duration));
 }
 
 void CubicSpline::Impl::addTripletNextKnot(const int& knotIndex,
@@ -491,7 +504,7 @@ void CubicSpline::Impl::addTripletNextKnot(const int& knotIndex,
     // |   T      |
     // \    i     /
 
-    tripletList.emplace_back(rowOffset, columnOffset, 2 / poly.duration);
+    tripletList.emplace_back(rowOffset, columnOffset, 2 / durationToSeconds(poly.duration));
 }
 
 void CubicSpline::Impl::addKnownTermKnotPosition(const std::size_t& knotIndex,
@@ -504,8 +517,10 @@ void CubicSpline::Impl::addKnownTermKnotPosition(const std::size_t& knotIndex,
     const auto& j = coordinateIndex;
 
     b[0] += 6
-            * ((knots[i].position[j] - knots[i - 1].position[j]) / std::pow(poly[i - 1].duration, 2)
-               + (knots[i + 1].position[j] - knots[i].position[j]) / std::pow(poly[i].duration, 2));
+            * ((knots[i].position[j] - knots[i - 1].position[j])
+                   / std::pow(durationToSeconds(poly[i - 1].duration), 2)
+               + (knots[i + 1].position[j] - knots[i].position[j])
+                     / std::pow(durationToSeconds(poly[i].duration), 2));
 }
 
 void CubicSpline::Impl::addKnownTermNextKnot(const std::size_t& knotIndex,
@@ -515,7 +530,7 @@ void CubicSpline::Impl::addKnownTermNextKnot(const std::size_t& knotIndex,
     const auto& poly = polynomials;
     const auto& i = knotIndex;
     const auto& j = coordinateIndex;
-    b[0] -= 2 * knots[i + 1].velocity[j] / poly[i].duration;
+    b[0] -= 2 * knots[i + 1].velocity[j] / durationToSeconds(poly[i].duration);
 }
 
 void CubicSpline::Impl::addKnownTermPreviousKnot(const std::size_t& knotIndex,
@@ -527,12 +542,12 @@ void CubicSpline::Impl::addKnownTermPreviousKnot(const std::size_t& knotIndex,
     const auto& i = knotIndex;
     const auto& j = coordinateIndex;
 
-    b[0] -= 2 * knots[i - 1].velocity[j] / poly[i - 1].duration;
+    b[0] -= 2 * knots[i - 1].velocity[j] / durationToSeconds(poly[i - 1].duration);
 }
 
 void CubicSpline::Impl::setPolynomialCoefficients(Polynomial& poly)
 {
-    const auto& T = poly.duration;
+    const double T = durationToSeconds(poly.duration);
 
     const auto& x0 = poly.initialPoint->position;
     const auto& dx0 = poly.initialPoint->velocity;
@@ -663,32 +678,37 @@ void CubicSpline::Impl::computeIntermediateVelocities()
     }
 }
 
-void CubicSpline::Impl::getPositionAtTime(const double& t,
-                                            const Polynomial& poly,
-                                            Eigen::Ref<Eigen::VectorXd> position)
+void CubicSpline::Impl::getPositionAtTime(const std::chrono::nanoseconds& t,
+                                          const Polynomial& poly,
+                                          Eigen::Ref<Eigen::VectorXd> position)
 {
+
+    const double tS = durationToSeconds(t);
+
     // improve the readability of the code
     const auto& a0 = poly.a0;
     const auto& a1 = poly.a1;
     const auto& a2 = poly.a2;
     const auto& a3 = poly.a3;
 
-    position = a0 + a1 * t + a2 * std::pow(t, 2) + a3 * std::pow(t, 3);
+    position = a0 + a1 * tS + a2 * std::pow(tS, 2) + a3 * std::pow(tS, 3);
 }
 
-void CubicSpline::Impl::getVelocityAtTime(const double& t,
-                                            const Polynomial& poly,
-                                            Eigen::Ref<Eigen::VectorXd> velocity)
+void CubicSpline::Impl::getVelocityAtTime(const std::chrono::nanoseconds& t,
+                                          const Polynomial& poly,
+                                          Eigen::Ref<Eigen::VectorXd> velocity)
 {
+    const double tS = durationToSeconds(t);
+
     // improve the readability of the code
     const auto& a1 = poly.a1;
     const auto& a2 = poly.a2;
     const auto& a3 = poly.a3;
 
-    velocity = a1 + 2 * a2 * t + 3 * a3 * std::pow(t, 2);
+    velocity = a1 + 2 * a2 * tS + 3 * a3 * std::pow(tS, 2);
 }
 
-void CubicSpline::Impl::getAccelerationAtTime(const double& t,
+void CubicSpline::Impl::getAccelerationAtTime(const std::chrono::nanoseconds& t,
                                               const Polynomial& poly,
                                               Eigen::Ref<Eigen::VectorXd> acceleration)
 {
@@ -696,10 +716,10 @@ void CubicSpline::Impl::getAccelerationAtTime(const double& t,
     const auto& a2 = poly.a2;
     const auto& a3 = poly.a3;
 
-    acceleration = 2 * a2 + 2 * 3 * a3 * t;
+    acceleration = 2 * a2 + 2 * 3 * a3 * durationToSeconds(t);
 }
 
-bool CubicSpline::evaluatePoint(const double& t,
+bool CubicSpline::evaluatePoint(const std::chrono::nanoseconds& t,
                                 Eigen::Ref<Eigen::VectorXd> position,
                                 Eigen::Ref<Eigen::VectorXd> velocity,
                                 Eigen::Ref<Eigen::VectorXd> acceleration)
@@ -716,7 +736,7 @@ bool CubicSpline::evaluatePoint(const double& t,
 
     if (t < m_pimpl->polynomials.front().initialPoint->timeInstant)
     {
-        constexpr double initialTime = 0;
+        constexpr std::chrono::nanoseconds initialTime = std::chrono::nanoseconds::zero();
 
         m_pimpl->getPositionAtTime(initialTime, m_pimpl->polynomials.front(), position);
         m_pimpl->getVelocityAtTime(initialTime, m_pimpl->polynomials.front(), velocity);
@@ -728,14 +748,15 @@ bool CubicSpline::evaluatePoint(const double& t,
 
     if (t >= m_pimpl->polynomials.back().finalPoint->timeInstant)
     {
-        const double finalTime = m_pimpl->polynomials.back().finalPoint->timeInstant
-                                 - m_pimpl->polynomials.back().initialPoint->timeInstant;
+        const auto finalTime = m_pimpl->polynomials.back().finalPoint->timeInstant
+                               - m_pimpl->polynomials.back().initialPoint->timeInstant;
         m_pimpl->getPositionAtTime(finalTime, m_pimpl->polynomials.back(), position);
         m_pimpl->getVelocityAtTime(finalTime, m_pimpl->polynomials.back(), velocity);
         m_pimpl->getAccelerationAtTime(finalTime, m_pimpl->polynomials.back(), acceleration);
         return true;
     }
 
+    // TODO(Giulio) Change this algorithm with the reverse iterator
     const auto poly = std::find_if(m_pimpl->polynomials.begin(),
                                    m_pimpl->polynomials.end(),
                                    [&t](const auto& p) {
@@ -756,7 +777,7 @@ bool CubicSpline::evaluatePoint(const double& t,
     return true;
 }
 
-bool CubicSpline::evaluatePoint(const double& t, SplineState& state)
+bool CubicSpline::evaluatePoint(const std::chrono::nanoseconds& t, SplineState& state)
 {
     return this->evaluatePoint(t, state.position, state.velocity, state.acceleration);
 }
@@ -765,8 +786,8 @@ bool CubicSpline::isOutputValid() const
 {
     // if the time step is different from zero and the user already set the knots the advance
     // capabilities can be used
-    bool ok = (m_pimpl->advanceTimeStep != 0.0) && (!m_pimpl->knots.empty());
-    return ok;
+    return (m_pimpl->advanceTimeStep != std::chrono::nanoseconds::zero())
+           && (!m_pimpl->knots.empty());
 }
 
 bool CubicSpline::advance()

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -6,12 +6,19 @@
  */
 
 #include <algorithm>
+#include <chrono>
 #include <iostream>
 
 #include <Eigen/Sparse>
 
 #include <BipedalLocomotion/Planners/QuinticSpline.h>
 using namespace BipedalLocomotion::Planners;
+
+template <class Rep, class Period>
+constexpr double durationToSeconds(const std::chrono::duration<Rep, Period>& d)
+{
+    return std::chrono::duration<double>(d).count();
+}
 
 struct QuinticSpline::Impl
 {
@@ -33,7 +40,7 @@ struct QuinticSpline::Impl
         Eigen::VectorXd velocity; /**< first derivative of spline computed at t@knot */
         Eigen::VectorXd acceleration; /**< second derivative of spline computed at t@knot */
 
-        double timeInstant; /**< Knot time (it is an absolute time ) */
+        std::chrono::nanoseconds timeInstant; /**< Knot time (it is an absolute time ) */
     };
 
     /**
@@ -52,7 +59,7 @@ struct QuinticSpline::Impl
         const Knot* initialPoint;
         const Knot* finalPoint;
 
-        double duration;
+        std::chrono::nanoseconds duration;
     };
 
     BoundaryConditions initialCondition; /**< Initial condition */
@@ -64,34 +71,38 @@ struct QuinticSpline::Impl
     bool areCoefficientsComputed{false}; /**< If true the coefficients are computed and updated */
 
     SplineState currentTrajectory; /**< Current trajectory stored in the advance state */
-    double advanceTimeStep{0.0}; /**< Time step of the advance interface. */
-    double advanceCurrentTime{0.0}; /**< current time of the advance object. */
+    std::chrono::nanoseconds advanceTimeStep{std::chrono::nanoseconds::zero()}; /**< Time step of
+                                                                                   the advance
+                                                                                   interface. */
+    std::chrono::nanoseconds advanceCurrentTime{std::chrono::nanoseconds::zero()}; /**< current time
+                                                                                      of the advance
+                                                                                      object. */
 
     /**
      * Reset a given knot with a time instant and a position
      */
-    void resetKnot(const double& timeInstant,
+    void resetKnot(const std::chrono::nanoseconds& timeInstant,
                    Eigen::Ref<const Eigen::VectorXd> position,
                    Knot& knot);
 
     /**
      * Get the position at given time for a sub-trajectory
      */
-    void getPositionAtTime(const double& t,
+    void getPositionAtTime(const std::chrono::nanoseconds& t,
                            const Polynomial& poly,
                            Eigen::Ref<Eigen::VectorXd> position);
 
     /**
      * Get the velocity at given time for a sub-trajectory
      */
-    void getVelocityAtTime(const double& t,
+    void getVelocityAtTime(const std::chrono::nanoseconds& t,
                            const Polynomial& poly,
                            Eigen::Ref<Eigen::VectorXd> velocity);
 
     /**
      * Get the acceleration at given time for a sub-trajectory
      */
-    void getAccelerationAtTime(const double& t,
+    void getAccelerationAtTime(const std::chrono::nanoseconds& t,
                                const Polynomial& poly,
                                Eigen::Ref<Eigen::VectorXd> acceleration);
 
@@ -223,9 +234,10 @@ bool QuinticSpline::setFinalConditions(Eigen::Ref<const Eigen::VectorXd> velocit
     return true;
 }
 
-bool QuinticSpline::setAdvanceTimeStep(const double& dt)
+bool QuinticSpline::setAdvanceTimeStep(const std::chrono::nanoseconds& dt)
 {
-    if (dt <= 0)
+    // this cannot happen
+    if (dt <= std::chrono::nanoseconds::zero())
     {
         std::cerr << "[QuinticSpline::setAdvanceTimeStep] The time step of the advance object has "
                      "to be a strictly  positive number."
@@ -239,7 +251,7 @@ bool QuinticSpline::setAdvanceTimeStep(const double& dt)
 }
 
 bool QuinticSpline::setKnots(const std::vector<Eigen::VectorXd>& position,
-                             const std::vector<double>& time)
+                             const std::vector<std::chrono::nanoseconds>& time)
 {
     if (position.size() < 2)
     {
@@ -284,7 +296,7 @@ bool QuinticSpline::setKnots(const std::vector<Eigen::VectorXd>& position,
     return true;
 }
 
-void QuinticSpline::Impl::resetKnot(const double& timeInstant,
+void QuinticSpline::Impl::resetKnot(const std::chrono::nanoseconds& timeInstant,
                                     Eigen::Ref<const Eigen::VectorXd> position,
                                     Knot& knot)
 {
@@ -303,7 +315,7 @@ bool QuinticSpline::Impl::computePhasesDuration()
         polynomials[i].duration = knots[i + 1].timeInstant - knots[i].timeInstant;
 
         // This is required or stability purposes, the matrix A may not be invertible.
-        if (std::abs(polynomials[i].duration) <= std::numeric_limits<double>::epsilon())
+        if (polynomials[i].duration == std::chrono::nanoseconds::zero())
         {
             std::cerr << "[QuinticSpline::Impl::computePhasesDuration] Two consecutive points have "
                          "the same time coordinate."
@@ -433,6 +445,9 @@ void QuinticSpline::Impl::addTripletCurrentKnot(const int& knotIndex,
     const auto& poly = polynomials[knotIndex];
     const auto& prevPoly = polynomials[knotIndex - 1];
 
+    const double prevPolyDuration = durationToSeconds(prevPoly.duration);
+    const double polyDuration = durationToSeconds(poly.duration);
+
     // The following triplets represent this matrix
     // /    /   1      1\          /   1      1\ \
     // | 12 |------ - --|      -3  |------ + --| |
@@ -450,22 +465,20 @@ void QuinticSpline::Impl::addTripletCurrentKnot(const int& knotIndex,
     tripletList.push_back(
         {rowOffset,
          columnOffset,
-         12 * ((1 / std::pow(prevPoly.duration, 2)) - (1 / std::pow(poly.duration, 2)))});
+         12 * ((1 / std::pow(prevPolyDuration, 2)) - (1 / std::pow(polyDuration, 2)))});
 
     tripletList.push_back(
-        {rowOffset,
-         columnOffset + 1,
-         -3 * ((1 / prevPoly.duration) + (1 / poly.duration))});
+        {rowOffset, columnOffset + 1, -3 * ((1 / prevPolyDuration) + (1 / polyDuration))});
 
     tripletList.push_back(
         {rowOffset + 1,
          columnOffset,
-         16 * ((1 / std::pow(prevPoly.duration, 3)) + (1 / std::pow(poly.duration, 3)))});
+         16 * ((1 / std::pow(prevPolyDuration, 3)) + (1 / std::pow(polyDuration, 3)))});
 
     tripletList.push_back(
         {rowOffset + 1,
          columnOffset + 1,
-         3 * ((-1 / std::pow(prevPoly.duration, 2)) + (1 / std::pow(poly.duration, 2)))});
+         3 * ((-1 / std::pow(prevPolyDuration, 2)) + (1 / std::pow(polyDuration, 2)))});
 }
 
 void QuinticSpline::Impl::addTripletPreviousKnot(const int& knotIndex,
@@ -474,6 +487,7 @@ void QuinticSpline::Impl::addTripletPreviousKnot(const int& knotIndex,
                                                  std::vector<Eigen::Triplet<double>>& tripletList)
 {
     const auto& poly = polynomials[knotIndex - 1];
+    const double polyDuration = durationToSeconds(poly.duration);
 
     // The following triplets represent this matrix
     // /    8          1    \
@@ -489,10 +503,10 @@ void QuinticSpline::Impl::addTripletPreviousKnot(const int& knotIndex,
     // | T          T       |
     // \  i - 1      i - 1  /
 
-    tripletList.push_back({rowOffset, columnOffset, 8 / std::pow(poly.duration, 2)});
-    tripletList.push_back({rowOffset, columnOffset + 1, 1 / poly.duration});
-    tripletList.push_back({rowOffset + 1, columnOffset, 14 / std::pow(poly.duration, 3)});
-    tripletList.push_back({rowOffset + 1, columnOffset + 1, 2 / std::pow(poly.duration, 2)});
+    tripletList.push_back({rowOffset, columnOffset, 8 / std::pow(polyDuration, 2)});
+    tripletList.push_back({rowOffset, columnOffset + 1, 1 / polyDuration});
+    tripletList.push_back({rowOffset + 1, columnOffset, 14 / std::pow(polyDuration, 3)});
+    tripletList.push_back({rowOffset + 1, columnOffset + 1, 2 / std::pow(polyDuration, 2)});
 }
 
 void QuinticSpline::Impl::addTripletNextKnot(const int& knotIndex,
@@ -501,6 +515,7 @@ void QuinticSpline::Impl::addTripletNextKnot(const int& knotIndex,
                                              std::vector<Eigen::Triplet<double>>& tripletList)
 {
     const auto& poly = polynomials[knotIndex];
+    const double polyDuration = durationToSeconds(poly.duration);
 
     // The following triplets represent this matrix
     // /    8          1    \
@@ -516,10 +531,10 @@ void QuinticSpline::Impl::addTripletNextKnot(const int& knotIndex,
     // |  T            T    |
     // \   i            i   /
 
-    tripletList.push_back({rowOffset, columnOffset, -8 / std::pow(poly.duration, 2)});
-    tripletList.push_back({rowOffset, columnOffset + 1, 1 / poly.duration});
-    tripletList.push_back({rowOffset + 1, columnOffset, 14 / std::pow(poly.duration, 3)});
-    tripletList.push_back({rowOffset + 1, columnOffset + 1, -2 / std::pow(poly.duration, 2)});
+    tripletList.push_back({rowOffset, columnOffset, -8 / std::pow(polyDuration, 2)});
+    tripletList.push_back({rowOffset, columnOffset + 1, 1 / polyDuration});
+    tripletList.push_back({rowOffset + 1, columnOffset, 14 / std::pow(polyDuration, 3)});
+    tripletList.push_back({rowOffset + 1, columnOffset + 1, -2 / std::pow(polyDuration, 2)});
 }
 
 void QuinticSpline::Impl::addKnownTermKnotPosition(const std::size_t& knotIndex,
@@ -532,15 +547,15 @@ void QuinticSpline::Impl::addKnownTermKnotPosition(const std::size_t& knotIndex,
     const auto& j = coordinateIndex;
 
     b[0] += 20
-            * (1 / std::pow(poly[i - 1].duration, 3)
+            * (1 / std::pow(durationToSeconds(poly[i - 1].duration), 3)
                    * (knots[i].position[j] - knots[i - 1].position[j])
-               + 1 / std::pow(poly[i].duration, 3)
+               + 1 / std::pow(durationToSeconds(poly[i].duration), 3)
                      * (knots[i].position[j] - knots[i + 1].position[j]));
 
     b[1] += 30
-            * (1 / std::pow(poly[i - 1].duration, 4)
+            * (1 / std::pow(durationToSeconds(poly[i - 1].duration), 4)
                    * (knots[i].position[j] - knots[i - 1].position[j])
-               - 1 / std::pow(poly[i].duration, 4)
+               - 1 / std::pow(durationToSeconds(poly[i].duration), 4)
                      * (knots[i].position[j] - knots[i + 1].position[j]));
 }
 
@@ -554,8 +569,10 @@ void QuinticSpline::Impl::addKnownTermNextKnot(const std::size_t& knotIndex,
     const auto& j = coordinateIndex;
 
     Eigen::Matrix2d tempMatrix;
-    tempMatrix << -8 / std::pow(poly[i].duration, 2), 1 / poly[i].duration,
-        14 / std::pow(poly[i].duration, 3), -2 / std::pow(poly[i].duration, 2);
+    tempMatrix << -8 / std::pow(durationToSeconds(poly[i].duration), 2),
+        1 / durationToSeconds(poly[i].duration),
+        14 / std::pow(durationToSeconds(poly[i].duration), 3),
+        -2 / std::pow(durationToSeconds(poly[i].duration), 2);
 
     Eigen::Vector2d tempVector;
     tempVector << knots[i + 1].velocity[j], knots[i + 1].acceleration[j];
@@ -572,8 +589,10 @@ void QuinticSpline::Impl::addKnownTermPreviousKnot(const std::size_t& knotIndex,
     const auto& j = coordinateIndex;
 
     Eigen::Matrix2d tempMatrix;
-    tempMatrix << 8 / std::pow(poly[i - 1].duration, 2), 1 / poly[i - 1].duration,
-        14 / std::pow(poly[i - 1].duration, 3), 2 / std::pow(poly[i - 1].duration, 2);
+    tempMatrix << 8 / std::pow(durationToSeconds(poly[i - 1].duration), 2),
+        1 / durationToSeconds(poly[i - 1].duration),
+        14 / std::pow(durationToSeconds(poly[i - 1].duration), 3),
+        2 / std::pow(durationToSeconds(poly[i - 1].duration), 2);
 
     Eigen::Vector2d tempVector;
     tempVector << knots[i - 1].velocity[j], knots[i - 1].acceleration[j];
@@ -582,7 +601,7 @@ void QuinticSpline::Impl::addKnownTermPreviousKnot(const std::size_t& knotIndex,
 
 void QuinticSpline::Impl::setPolynomialCoefficients(Polynomial& poly)
 {
-    const auto& T = poly.duration;
+    const double T = durationToSeconds(poly.duration);
 
     const auto& x0 = poly.initialPoint->position;
     const auto& dx0 = poly.initialPoint->velocity;
@@ -728,11 +747,14 @@ void QuinticSpline::Impl::computeIntermediateVelocitiesAndAcceleration()
     }
 }
 
-void QuinticSpline::Impl::getPositionAtTime(const double& t,
+void QuinticSpline::Impl::getPositionAtTime(const std::chrono::nanoseconds& t,
                                             const Polynomial& poly,
                                             Eigen::Ref<Eigen::VectorXd> position)
 {
     // improve the readability of the code
+
+    const double tS = durationToSeconds(t);
+
     const auto& a0 = poly.a0;
     const auto& a1 = poly.a1;
     const auto& a2 = poly.a2;
@@ -741,18 +763,21 @@ void QuinticSpline::Impl::getPositionAtTime(const double& t,
     const auto& a5 = poly.a5;
 
     position = a0
-             + a1 * t
-             + a2 * std::pow(t, 2)
-             + a3 * std::pow(t, 3)
-             + a4 * std::pow(t, 4)
-             + a5 * std::pow(t, 5);
+             + a1 * tS
+             + a2 * std::pow(tS, 2)
+             + a3 * std::pow(tS, 3)
+             + a4 * std::pow(tS, 4)
+             + a5 * std::pow(tS, 5);
 }
 
-void QuinticSpline::Impl::getVelocityAtTime(const double& t,
+void QuinticSpline::Impl::getVelocityAtTime(const std::chrono::nanoseconds& t,
                                             const Polynomial& poly,
                                             Eigen::Ref<Eigen::VectorXd> velocity)
 {
     // improve the readability of the code
+
+    const double tS = durationToSeconds(t);
+
     const auto& a0 = poly.a0;
     const auto& a1 = poly.a1;
     const auto& a2 = poly.a2;
@@ -761,17 +786,20 @@ void QuinticSpline::Impl::getVelocityAtTime(const double& t,
     const auto& a5 = poly.a5;
 
     velocity = a1
-             + 2 * a2 * t
-             + 3 * a3 * std::pow(t, 2)
-             + 4 * a4 * std::pow(t, 3)
-             + 5 * a5 * std::pow(t, 4);
+             + 2 * a2 * tS
+             + 3 * a3 * std::pow(tS, 2)
+             + 4 * a4 * std::pow(tS, 3)
+             + 5 * a5 * std::pow(tS, 4);
 }
 
-void QuinticSpline::Impl::getAccelerationAtTime(const double& t,
+void QuinticSpline::Impl::getAccelerationAtTime(const std::chrono::nanoseconds& t,
                                                 const Polynomial& poly,
                                                 Eigen::Ref<Eigen::VectorXd> acceleration)
 {
     // improve the readability of the code
+
+    const double tS = durationToSeconds(t);
+
     const auto& a0 = poly.a0;
     const auto& a1 = poly.a1;
     const auto& a2 = poly.a2;
@@ -780,12 +808,12 @@ void QuinticSpline::Impl::getAccelerationAtTime(const double& t,
     const auto& a5 = poly.a5;
 
     acceleration = 2 * a2
-                 + 2 * 3 * a3 * t
-                 + 3 * 4 * a4 * std::pow(t, 2)
-                 + 4 * 5 * a5 * std::pow(t, 3);
+                 + 2 * 3 * a3 * tS
+                 + 3 * 4 * a4 * std::pow(tS, 2)
+                 + 4 * 5 * a5 * std::pow(tS, 3);
 }
 
-bool QuinticSpline::evaluatePoint(const double& t,
+bool QuinticSpline::evaluatePoint(const std::chrono::nanoseconds& t,
                                   Eigen::Ref<Eigen::VectorXd> position,
                                   Eigen::Ref<Eigen::VectorXd> velocity,
                                   Eigen::Ref<Eigen::VectorXd> acceleration)
@@ -820,6 +848,7 @@ bool QuinticSpline::evaluatePoint(const double& t,
         return true;
     }
 
+    // TODO (Giulio) Reimplement with the reverse iterator
     const auto poly = std::find_if(m_pimpl->polynomials.begin(),
                                    m_pimpl->polynomials.end(),
                                    [&t](const auto& p) {
@@ -841,7 +870,7 @@ bool QuinticSpline::evaluatePoint(const double& t,
     return true;
 }
 
-bool QuinticSpline::evaluatePoint(const double& t, SplineState& state)
+bool QuinticSpline::evaluatePoint(const std::chrono::nanoseconds& t, SplineState& state)
 {
     return this->evaluatePoint(t, state.position, state.velocity, state.acceleration);
 }
@@ -850,8 +879,8 @@ bool QuinticSpline::isOutputValid() const
 {
     // if the time step is different from zero and the user already set the knots the advance
     // capabilities can be used
-    bool ok = (m_pimpl->advanceTimeStep != 0.0) && (!m_pimpl->knots.empty());
-    return ok;
+    return (m_pimpl->advanceTimeStep != std::chrono::nanoseconds::zero())
+           && (!m_pimpl->knots.empty());
 }
 
 bool QuinticSpline::advance()

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -12,6 +12,7 @@
 #include <BipedalLocomotion/Planners/QuinticSpline.h>
 #include <BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
+#include <chrono>
 
 using namespace BipedalLocomotion::Planners;
 using namespace BipedalLocomotion::Contacts;
@@ -109,7 +110,7 @@ struct TimeVaryingDCMPlanner::Impl
         unsigned long solverVerbosity{1}; /**< Verbosity of ipopt */
         std::string ipoptLinearSolver{"mumps"}; /**< Linear solved used by ipopt */
 
-        double plannerSamplingTime; /**< Sampling time of the planner in seconds */
+        std::chrono::nanoseconds plannerSamplingTime; /**< Sampling time of the planner in seconds */
         std::vector<Eigen::Vector3d> footCorners; /**< Position of the corner of the foot
                                                     expressed in a frame placed in the center of the
                                                     foot. The X axis points forward and the z
@@ -162,8 +163,12 @@ struct TimeVaryingDCMPlanner::Impl
         casadi::MX omegaDot = casadi::MX::sym("omega_dot");
 
         casadi::MX rhs = casadi::MX::vertcat(
-            {dcm + (omega - omegaDot / omega) * (dcm - vrp) * optiSettings.plannerSamplingTime,
-             omega + omegaDot * optiSettings.plannerSamplingTime});
+            {dcm
+                 + (omega - omegaDot / omega) * (dcm - vrp)
+                       * std::chrono::duration<double>(optiSettings.plannerSamplingTime).count(),
+             omega
+                 + omegaDot
+                       * std::chrono::duration<double>(optiSettings.plannerSamplingTime).count()});
 
         return casadi::Function("DCMDynamics", {state, vrp, omegaDot}, {rhs});
     }
@@ -379,7 +384,7 @@ struct TimeVaryingDCMPlanner::Impl
         for (std::size_t k = 0; k < this->optiVariables.vrp.columns(); k++)
         {
             // if the
-            if(k * this->optiSettings.plannerSamplingTime > contactPhaseListIt->endTime)
+            if (k * this->optiSettings.plannerSamplingTime > contactPhaseListIt->endTime)
             {
                 std::advance(contactPhaseListIt, 1);
                 feetAreInSamePlane = computeConstraintElementsECMP(*contactPhaseListIt,
@@ -412,7 +417,7 @@ struct TimeVaryingDCMPlanner::Impl
                                   const DCMPlannerState& initialState)
     {
         std::vector<Eigen::VectorXd> dcmKnots;
-        std::vector<double> timeKnots;
+        std::vector<std::chrono::nanoseconds> timeKnots;
 
         // first point
         timeKnots.push_back(contactPhaseList.cbegin()->beginTime);
@@ -477,11 +482,10 @@ struct TimeVaryingDCMPlanner::Impl
 
         for (int i = 0; i < this->optiVariables.dcm.columns(); i++)
         {
-            const double currentTime = i * this->optiSettings.plannerSamplingTime;
-            if (!dcmRef.evaluatePoint(currentTime,
-                                     initialValueDCMEigenMap.col(i),
-                                     velocity,
-                                     acceleration))
+            if (!dcmRef.evaluatePoint(i * this->optiSettings.plannerSamplingTime,
+                                      initialValueDCMEigenMap.col(i),
+                                      velocity,
+                                      acceleration))
             {
                 log()->error("[TimeVaryingDCMPlanner::Impl::computeDCMRegularization] Unable to "
                              "evaluate the dcm reference trajectory.");
@@ -730,8 +734,8 @@ bool TimeVaryingDCMPlanner::computeTrajectory()
     // clear the solver and the solution computed
     m_pimpl->clear();
 
-    const double& initialTrajectoryTime = m_contactPhaseList.cbegin()->beginTime;
-    const double& endTrajectoryTime = m_contactPhaseList.lastPhase()->endTime;
+    const auto& initialTrajectoryTime = m_contactPhaseList.cbegin()->beginTime;
+    const auto& endTrajectoryTime = m_contactPhaseList.lastPhase()->endTime;
 
     m_pimpl->numberOfTrajectorySamples = std::ceil((endTrajectoryTime - initialTrajectoryTime)
                                                    / m_pimpl->optiSettings.plannerSamplingTime);

--- a/src/Planners/tests/SO3PlannerTest.cpp
+++ b/src/Planners/tests/SO3PlannerTest.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
 #include <Eigen/Geometry> // Required because of https://github.com/artivis/manif/issues/162
 
 // Catch2
@@ -18,11 +19,13 @@ using namespace BipedalLocomotion::Planners;
 
 TEST_CASE("SO3 planner")
 {
+    using namespace std::chrono_literals;
+
     manif::SO3d initialTranform = manif::SO3d::Random();
     manif::SO3d finalTranform = manif::SO3d::Random();
 
-    constexpr double T = 1;
-    constexpr double dT = 1e-4;
+    constexpr std::chrono::nanoseconds T = 1s;
+    constexpr std::chrono::nanoseconds dT = 100us;
     constexpr std::size_t samples = T / dT;
 
     constexpr double tolerance = 1e-3;
@@ -35,7 +38,7 @@ TEST_CASE("SO3 planner")
         manif::SO3d rotation, predictedRotation;
         manif::SO3d::Tangent velocity, predictedVelocity;
         manif::SO3d::Tangent acceleration;
-        REQUIRE(planner.evaluatePoint(0, rotation, velocity, acceleration));
+        REQUIRE(planner.evaluatePoint(0s, rotation, velocity, acceleration));
         predictedRotation = rotation;
         predictedVelocity = velocity;
 
@@ -46,8 +49,8 @@ TEST_CASE("SO3 planner")
         for (std::size_t i = 1; i < samples; i++)
         {
             // propagate the system
-            predictedRotation = rotation + (velocity * dT);
-            predictedVelocity = velocity + (acceleration * dT);
+            predictedRotation = rotation + (velocity * std::chrono::duration<double>(dT).count());
+            predictedVelocity = velocity + (acceleration * std::chrono::duration<double>(dT).count());
 
             planner.evaluatePoint(i * dT, rotation, velocity, acceleration);
 
@@ -69,7 +72,7 @@ TEST_CASE("SO3 planner")
         manif::SO3d rotation, predictedRotation;
         manif::SO3d::Tangent velocity, predictedVelocity;
         manif::SO3d::Tangent acceleration;
-        REQUIRE(planner.evaluatePoint(0, rotation, velocity, acceleration));
+        REQUIRE(planner.evaluatePoint(0s, rotation, velocity, acceleration));
         predictedRotation = rotation;
         predictedVelocity = velocity;
 
@@ -80,8 +83,8 @@ TEST_CASE("SO3 planner")
         for (std::size_t i = 1; i < samples; i++)
         {
             // propagate the system
-            predictedRotation = (velocity * dT) + rotation;
-            predictedVelocity = velocity + (acceleration * dT);
+            predictedRotation = (velocity * std::chrono::duration<double>(dT).count()) + rotation;
+            predictedVelocity = velocity + (acceleration * std::chrono::duration<double>(dT).count());
 
             planner.evaluatePoint(i * dT, rotation, velocity, acceleration);
 

--- a/src/Planners/tests/SplineTest.cpp
+++ b/src/Planners/tests/SplineTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <array>
+#include <chrono>
 #include <vector>
 
 // Catch2
@@ -19,11 +20,13 @@ using namespace BipedalLocomotion::Planners;
 
 TEST_CASE("Quintic spline")
 {
-    const std::size_t numberOfPoints = 100;
-    constexpr double initTime = 0.32;
-    constexpr double finalTime = 2.64;
+    using namespace std::chrono_literals;
 
-    constexpr double dT = (finalTime - initTime) / (static_cast<double>(numberOfPoints - 1));
+    constexpr std::size_t numberOfPoints = 100;
+    constexpr std::chrono::nanoseconds initTime = 320ms;
+    constexpr std::chrono::nanoseconds finalTime = 2s + 640s;
+
+    constexpr std::chrono::nanoseconds dT = (finalTime - initTime) / (numberOfPoints - 1);
     std::array<Eigen::Vector4d, 6> coefficients;
     for(auto& coeff: coefficients)
     {
@@ -31,34 +34,38 @@ TEST_CASE("Quintic spline")
     }
 
     std::vector<Eigen::VectorXd> knots;
-    std::vector<double> time;
+    std::vector<std::chrono::nanoseconds> time;
     for (std::size_t i = 0; i < numberOfPoints; i++)
     {
         time.push_back(dT * i + initTime);
-        knots.push_back(coefficients[0] + coefficients[1] * time.back()
-                        + coefficients[2] * std::pow(time.back(), 2)
-                        + coefficients[3] * std::pow(time.back(), 3)
-                        + coefficients[4] * std::pow(time.back(), 4)
-                        + coefficients[5] * std::pow(time.back(), 5));
+        const double t = std::chrono::duration<double>(time.back()).count();
+        knots.push_back(coefficients[0] + coefficients[1] * t
+                        + coefficients[2] * std::pow(t, 2)
+                        + coefficients[3] * std::pow(t, 3)
+                        + coefficients[4] * std::pow(t, 4)
+                        + coefficients[5] * std::pow(t, 5));
     }
 
-    Eigen::Vector4d initVelocity = coefficients[1] + 2 * coefficients[2] * initTime
-                                   + 3 * coefficients[3] * std::pow(initTime, 2)
-                                   + 4 * coefficients[4] * std::pow(initTime, 3)
-                                   + 5 * coefficients[5] * std::pow(initTime, 4);
+    const double initT = std::chrono::duration<double>(initTime).count();
+    const double finalT = std::chrono::duration<double>(finalTime).count();
+    Eigen::Vector4d initVelocity = coefficients[1] + 2 * coefficients[2] * initT
+                                   + 3 * coefficients[3] * std::pow(initT, 2)
+                                   + 4 * coefficients[4] * std::pow(initT, 3)
+                                   + 5 * coefficients[5] * std::pow(initT, 4);
 
-    Eigen::Vector4d initAcceleration = 2 * coefficients[2] + 3 * 2 * coefficients[3] * initTime
-                                       + 4 * 3 * coefficients[4] * std::pow(initTime, 2)
-                                       + 5 * 4 * coefficients[5] * std::pow(initTime, 3);
 
-    Eigen::Vector4d finalVelocity = coefficients[1] + 2 * coefficients[2] * finalTime
-                                    + 3 * coefficients[3] * std::pow(finalTime, 2)
-                                    + 4 * coefficients[4] * std::pow(finalTime, 3)
-                                    + 5 * coefficients[5] * std::pow(finalTime, 4);
+    Eigen::Vector4d initAcceleration = 2 * coefficients[2] + 3 * 2 * coefficients[3] * initT
+                                       + 4 * 3 * coefficients[4] * std::pow(initT, 2)
+                                       + 5 * 4 * coefficients[5] * std::pow(initT, 3);
 
-    Eigen::Vector4d finalAcceleration = 2 * coefficients[2] + 3 * 2 * coefficients[3] * finalTime
-                                        + 4 * 3 * coefficients[4] * std::pow(finalTime, 2)
-                                        + 5 * 4 * coefficients[5] * std::pow(finalTime, 3);
+    Eigen::Vector4d finalVelocity = coefficients[1] + 2 * coefficients[2] * finalT
+                                    + 3 * coefficients[3] * std::pow(finalT, 2)
+                                    + 4 * coefficients[4] * std::pow(finalT, 3)
+                                    + 5 * coefficients[5] * std::pow(finalT, 4);
+
+    Eigen::Vector4d finalAcceleration = 2 * coefficients[2] + 3 * 2 * coefficients[3] * finalT
+                                        + 4 * 3 * coefficients[4] * std::pow(finalT, 2)
+                                        + 5 * 4 * coefficients[5] * std::pow(finalT, 3);
 
     QuinticSpline spline;
     REQUIRE(spline.setKnots(knots, time));
@@ -68,33 +75,34 @@ TEST_CASE("Quintic spline")
 
     constexpr std::size_t pointsToCheckNumber = 1e4;
 
-    constexpr double dTCheckPoints
-        = (finalTime - initTime) / (static_cast<double>(pointsToCheckNumber));
+    constexpr std::chrono::nanoseconds dTCheckPoints
+        = (finalTime - initTime) / (pointsToCheckNumber);
 
     Eigen::Vector4d expected, position, velocity, acceleration;
 
     for (std::size_t i = 0; i < pointsToCheckNumber; i++)
     {
-        double t = dTCheckPoints * i + initTime;
+        std::chrono::nanoseconds t = dTCheckPoints * i + initTime;
+        double tDouble = std::chrono::duration<double>(t).count();
 
         REQUIRE(spline.evaluatePoint(t, position, velocity, acceleration));
 
         // check position
-        expected = coefficients[0] + coefficients[1] * t + coefficients[2] * std::pow(t, 2)
-                   + coefficients[3] * std::pow(t, 3) + coefficients[4] * std::pow(t, 4)
-                   + coefficients[5] * std::pow(t, 5);
+        expected = coefficients[0] + coefficients[1] * tDouble + coefficients[2] * std::pow(tDouble, 2)
+                   + coefficients[3] * std::pow(tDouble, 3) + coefficients[4] * std::pow(tDouble, 4)
+                   + coefficients[5] * std::pow(tDouble, 5);
 
         REQUIRE(expected.isApprox(position, 1e-5));
 
         // check velocity
-        expected = coefficients[1] + 2 * coefficients[2] * t + 3 * coefficients[3] * std::pow(t, 2)
-                   + 4 * coefficients[4] * std::pow(t, 3) + 5 * coefficients[5] * std::pow(t, 4);
+        expected = coefficients[1] + 2 * coefficients[2] * tDouble + 3 * coefficients[3] * std::pow(tDouble, 2)
+                   + 4 * coefficients[4] * std::pow(tDouble, 3) + 5 * coefficients[5] * std::pow(tDouble, 4);
         REQUIRE(expected.isApprox(velocity,  1e-5));
 
         // check acceleration
-        expected = 2 * coefficients[2] + 3 * 2 * coefficients[3] * t
-                   + 4 * 3 * coefficients[4] * std::pow(t, 2)
-                   + 5 * 4 * coefficients[5] * std::pow(t, 3);
+        expected = 2 * coefficients[2] + 3 * 2 * coefficients[3] * tDouble
+                   + 4 * 3 * coefficients[4] * std::pow(tDouble, 2)
+                   + 5 * 4 * coefficients[5] * std::pow(tDouble, 3);
         REQUIRE(expected.isApprox(acceleration,  1e-5));
     }
 
@@ -107,7 +115,7 @@ TEST_CASE("Quintic spline")
 
         for (std::size_t i = 0; i < pointsToCheckNumber; i++)
         {
-            double t = dTCheckPoints * i + initTime;
+            double t = std::chrono::duration<double>(dTCheckPoints * i + initTime).count();
             const auto& traj = spline.getOutput();
 
             // check position
@@ -138,11 +146,13 @@ TEST_CASE("Quintic spline")
 
 TEST_CASE("Cubic spline")
 {
-    const std::size_t numberOfPoints = 100;
-    constexpr double initTime = 0.32;
-    constexpr double finalTime = 2.64;
+    using namespace std::chrono_literals;
 
-    constexpr double dT = (finalTime - initTime) / (static_cast<double>(numberOfPoints - 1));
+    constexpr std::size_t numberOfPoints = 100;
+    constexpr std::chrono::nanoseconds initTime = 320ms;
+    constexpr std::chrono::nanoseconds finalTime = 2s + 640s;
+
+    constexpr std::chrono::nanoseconds dT = (finalTime - initTime) / (numberOfPoints - 1);
     std::array<Eigen::Vector4d, 6> coefficients;
     for(auto& coeff: coefficients)
     {
@@ -150,20 +160,24 @@ TEST_CASE("Cubic spline")
     }
 
     std::vector<Eigen::VectorXd> knots;
-    std::vector<double> time;
+    std::vector<std::chrono::nanoseconds> time;
     for (std::size_t i = 0; i < numberOfPoints; i++)
     {
         time.push_back(dT * i + initTime);
-        knots.push_back(coefficients[0] + coefficients[1] * time.back()
-                        + coefficients[2] * std::pow(time.back(), 2)
-                        + coefficients[3] * std::pow(time.back(), 3));
+        const double t = std::chrono::duration<double>(time.back()).count();
+        knots.push_back(coefficients[0] + coefficients[1] * t
+                        + coefficients[2] * std::pow(t, 2)
+                        + coefficients[3] * std::pow(t, 3));
     }
 
-    Eigen::Vector4d initVelocity = coefficients[1] + 2 * coefficients[2] * initTime
-                                   + 3 * coefficients[3] * std::pow(initTime, 2);
+    const double initT = std::chrono::duration<double>(initTime).count();
+    const double finalT = std::chrono::duration<double>(finalTime).count();
 
-    Eigen::Vector4d finalVelocity = coefficients[1] + 2 * coefficients[2] * finalTime
-                                    + 3 * coefficients[3] * std::pow(finalTime, 2);
+    Eigen::Vector4d initVelocity = coefficients[1] + 2 * coefficients[2] * initT
+                                   + 3 * coefficients[3] * std::pow(initT, 2);
+
+    Eigen::Vector4d finalVelocity = coefficients[1] + 2 * coefficients[2] * finalT
+                                    + 3 * coefficients[3] * std::pow(finalT, 2);
 
     CubicSpline spline;
     REQUIRE(spline.setKnots(knots, time));
@@ -173,25 +187,27 @@ TEST_CASE("Cubic spline")
 
     constexpr std::size_t pointsToCheckNumber = 1e4;
 
-    constexpr double dTCheckPoints
-        = (finalTime - initTime) / (static_cast<double>(pointsToCheckNumber));
+    constexpr std::chrono::nanoseconds dTCheckPoints = (finalTime - initTime) / pointsToCheckNumber;
 
     Eigen::Vector4d expected, position, velocity, acceleration;
 
     for (std::size_t i = 0; i < pointsToCheckNumber; i++)
     {
-        double t = dTCheckPoints * i + initTime;
+        std::chrono::nanoseconds t = dTCheckPoints * i + initTime;
+        double tSeconds = std::chrono::duration<double>(t).count();
 
         REQUIRE(spline.evaluatePoint(t, position, velocity, acceleration));
 
         // check position
-        expected = coefficients[0] + coefficients[1] * t + coefficients[2] * std::pow(t, 2)
-                   + coefficients[3] * std::pow(t, 3);
+        expected = coefficients[0] + coefficients[1] * tSeconds
+                   + coefficients[2] * std::pow(tSeconds, 2)
+                   + coefficients[3] * std::pow(tSeconds, 3);
 
         REQUIRE(expected.isApprox(position, 1e-5));
 
         // check velocity
-        expected = coefficients[1] + 2 * coefficients[2] * t + 3 * coefficients[3] * std::pow(t, 2);
+        expected = coefficients[1] + 2 * coefficients[2] * tSeconds
+                   + 3 * coefficients[3] * std::pow(tSeconds, 2);
         REQUIRE(expected.isApprox(velocity,  1e-5));
 
     }
@@ -205,7 +221,7 @@ TEST_CASE("Cubic spline")
 
         for (std::size_t i = 0; i < pointsToCheckNumber; i++)
         {
-            double t = dTCheckPoints * i + initTime;
+            double t = std::chrono::duration<double>(dTCheckPoints * i + initTime).count();
             const auto& traj = spline.getOutput();
 
             // check position

--- a/src/Planners/tests/SwingFootPlannerTest.cpp
+++ b/src/Planners/tests/SwingFootPlannerTest.cpp
@@ -5,6 +5,8 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
+
 // Catch2
 #include <catch2/catch.hpp>
 
@@ -20,35 +22,37 @@ using namespace BipedalLocomotion::ParametersHandler;
 
 TEST_CASE("Swing foot planner")
 {
+    using namespace std::chrono_literals;
+
     ContactList contactList;
 
     // first footstep
     manif::SE3d transform{{0.9, 0, 0}, Eigen::AngleAxisd(1.5708, Eigen::Vector3d::UnitZ())};
-    REQUIRE(contactList.addContact(transform, 0.0, 0.3));
+    REQUIRE(contactList.addContact(transform, 0s, 300ms));
 
     // second
     transform = manif::SE3d({0.8899, 0.1345, 0.0600},
                             Eigen::AngleAxisd(1.7208, Eigen::Vector3d::UnitZ()));
-    REQUIRE(contactList.addContact(transform, 0.6, 1.5));
+    REQUIRE(contactList.addContact(transform, 600ms, 1s + 500ms));
 
     // third
     transform = manif::SE3d({0.8104, 0.3915, 0.1800},
                             Eigen::AngleAxisd(2.0208, Eigen::Vector3d::UnitZ()));
-    REQUIRE(contactList.addContact(transform, 1.8, 2.7));
+    REQUIRE(contactList.addContact(transform, 1s + 800ms, 2s + 700ms));
 
     // forth
     transform = manif::SE3d({0.6585, 0.6135, 0.3000},
                             Eigen::AngleAxisd(2.3208, Eigen::Vector3d::UnitZ()));
-    REQUIRE(contactList.addContact(transform, 3.0, 3.9));
+    REQUIRE(contactList.addContact(transform, 3s, 3s + 900ms));
 
     // fifth
     transform = manif::SE3d({0.3261, 0.8388, 0.4800},
                             Eigen::AngleAxisd(2.7708, Eigen::Vector3d::UnitZ()));
-    REQUIRE(contactList.addContact(transform, 4.2, 6.0));
+    REQUIRE(contactList.addContact(transform, 4s, 6s));
 
     // Set the parameters
     std::shared_ptr<IParametersHandler> handler = std::make_shared<StdImplementation>();
-    constexpr double dT = 0.01;
+    constexpr std::chrono::nanoseconds dT = 10ms;
     handler->setParameter("sampling_time", dT);
     handler->setParameter("step_height", 0.1);
     handler->setParameter("foot_apex_time", 0.5);
@@ -57,15 +61,15 @@ TEST_CASE("Swing foot planner")
     handler->setParameter("foot_take_off_velocity", 0.0);
     handler->setParameter("foot_take_off_acceleration", 0.0);
 
-
     // initialize the planner
     SwingFootPlanner planner;
     REQUIRE(planner.initialize(handler));
     planner.setContactList(contactList);
 
     std::cout << "pos = [";
-    const std::size_t numberOfIterations = (contactList.lastContact()->deactivationTime + 1) / dT;
-    for (std::size_t i = 0; i < numberOfIterations; i++)
+    for (std::chrono::nanoseconds time = contactList.firstContact()->activationTime;
+         time < contactList.lastContact()->deactivationTime;
+         time += dT)
     {
         std::cout << planner.getOutput().transform.translation().transpose() << " "
                   << planner.getOutput().transform.quat().w() << " "

--- a/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
+++ b/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
@@ -5,6 +5,8 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
+
 // Catch2
 #include <catch2/catch.hpp>
 
@@ -20,6 +22,8 @@ using namespace BipedalLocomotion::Math;
 
 TEST_CASE("TimeVaryingDCMPlanner")
 {
+    using namespace std::chrono_literals;
+
     ContactPhaseList phaseList;
 
     ContactListMap contactListMap;
@@ -29,31 +33,31 @@ TEST_CASE("TimeVaryingDCMPlanner")
     Eigen::Vector3d leftPos;
     leftPos << 0, -0.8, 0;
     manif::SE3d leftTransform(leftPos, manif::SO3d::Identity());
-    REQUIRE(contactListMap["left"].addContact(leftTransform, 0.0, 1.0));
+    REQUIRE(contactListMap["left"].addContact(leftTransform, 0s, 1s));
 
     // second footstep
     leftPos(0) = 0.25;
     leftPos(2) = 0.2;
     leftTransform = manif::SE3d(leftPos, manif::SO3d::Identity());
-    REQUIRE(contactListMap["left"].addContact(leftTransform, 2.0, 7.0));
+    REQUIRE(contactListMap["left"].addContact(leftTransform, 2s, 7s));
 
     // right foot
     // first footstep
     Eigen::Vector3d rightPos;
     rightPos << 0, 0.8, 0;
     manif::SE3d rightTransform(rightPos, manif::SO3d::Identity());
-    REQUIRE(contactListMap["right"].addContact(rightTransform, 0.0, 3.0));
+    REQUIRE(contactListMap["right"].addContact(rightTransform, 0s, 3s));
 
     // second footstep
     rightPos(0) = 0.25;
     rightPos(2) = 0.2;
     rightTransform = manif::SE3d(rightPos, manif::SO3d::Identity());
-    REQUIRE(contactListMap["right"].addContact(rightTransform, 4.0, 7.0));
+    REQUIRE(contactListMap["right"].addContact(rightTransform, 4s, 7s));
     phaseList.setLists(contactListMap);
 
     // Set the parameters
     std::shared_ptr<IParametersHandler> handler = std::make_shared<StdImplementation>();
-    handler->setParameter("planner_sampling_time", 0.05);
+    handler->setParameter("planner_sampling_time", 50ms);
     handler->setParameter("number_of_foot_corners", 4);
 
     // set the foot-corners

--- a/src/TextLogging/include/BipedalLocomotion/TextLogging/Logger.h
+++ b/src/TextLogging/include/BipedalLocomotion/TextLogging/Logger.h
@@ -27,6 +27,22 @@ struct fmt::formatter<Eigen::Transpose<_Derived>> : ostream_formatter
 };
 #endif
 
+// spdlog/fmt/chrono.h has been introduced in spdlog v1.8.0
+#if (defined(SPDLOG_VERSION) && SPDLOG_VERSION >= 10800)
+#include <spdlog/fmt/chrono.h>
+#else // <--- The following lines copies the content of spdlog/fmt/chrono.h
+#if !defined(SPDLOG_FMT_EXTERNAL)
+#ifdef SPDLOG_HEADER_ONLY
+#ifndef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY
+#endif
+#endif
+#include <spdlog/fmt/bundled/chrono.h>
+#else
+#include <fmt/chrono.h>
+#endif
+#endif
+
 namespace BipedalLocomotion
 {
 namespace TextLogging

--- a/utilities/balancing-position-control/config/robots/ergoCubGazeboV1/blf-balancing-position-control-options.ini
+++ b/utilities/balancing-position-control/config/robots/ergoCubGazeboV1/blf-balancing-position-control-options.ini
@@ -1,12 +1,12 @@
-dt                       0.01   # in seconds
+dt                       "00:00:00.010000"   # Time expressed in RFC 3339 (0.01 seconds)
 contact_force_threshold  0.1    # in Newton
 
 
 com_knots_delta_x        (0.0, 0.0,  0.03,  0.03, -0.03, -0.03, 0.0,  0.0)    # in meter
 com_knots_delta_y        (0.0, 0.07, 0.07, -0.07, -0.07,  0.07, 0.07, 0.0)    # in meter
 com_knots_delta_z        (0.0, 0.0,  0.0,   0.0,   0.0,   0.0,  0.0,  0.0)    # in meter
-motion_duration          10.0   # in seconds
-motion_timeout           10.0   # in seconds
+motion_duration          "00:00:10.000000"   # Time expressed in RFC 3339 (10 seconds)
+motion_timeout           "00:00:10.000000"   # Time expressed in RFC 3339 (10 seconds)
 
 base_frame               l_sole
 left_contact_frame       l_sole

--- a/utilities/balancing-position-control/config/robots/ergoCubSN000/blf-balancing-position-control-options.ini
+++ b/utilities/balancing-position-control/config/robots/ergoCubSN000/blf-balancing-position-control-options.ini
@@ -1,12 +1,12 @@
-dt                       0.01   # in seconds
+dt                       "00:00:00.010000"   # Time expressed in RFC 3339 (0.01 seconds)
 contact_force_threshold  0.1    # in Newton
 
 
 com_knots_delta_x        (0.0, 0.0,  0.03,  0.03, -0.03, -0.03, 0.0,  0.0)    # in meter
 com_knots_delta_y        (0.0, 0.07, 0.07, -0.07, -0.07,  0.07, 0.07, 0.0)    # in meter
 com_knots_delta_z        (0.0, 0.0,  0.0,   0.0,   0.0,   0.0,  0.0,  0.0)    # in meter
-motion_duration          10.0   # in seconds
-motion_timeout           10.0   # in seconds
+motion_duration          "00:00:10.000000"   # Time expressed in RFC 3339 (10 seconds)
+motion_timeout           "00:00:10.000000"   # Time expressed in RFC 3339 (10 seconds)
 
 base_frame               l_sole
 left_contact_frame       l_sole

--- a/utilities/joint-position-tracking/config/robots/iCubGenova09/blf-joint-position-tracking-options.ini
+++ b/utilities/joint-position-tracking/config/robots/iCubGenova09/blf-joint-position-tracking-options.ini
@@ -1,5 +1,5 @@
 name                                             joint-position-tracking
-sampling_time                                    0.01
+sampling_time                                    "00:00:00.010000"
 max_angle_deg                                    70.0
 min_angle_deg                                    0.0
 trajectory_duration                              5.0

--- a/utilities/joint-position-tracking/include/BipedalLocomotion/JointPositionTracking/Module.h
+++ b/utilities/joint-position-tracking/include/BipedalLocomotion/JointPositionTracking/Module.h
@@ -9,6 +9,7 @@
 #define BIPEDAL_LOCOMOTION_UTILITIES_JOINT_POSITION_TRACKING_MODULE_H
 
 // std
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -29,7 +30,7 @@ namespace JointPositionTracking
 
 class Module : public yarp::os::RFModule
 {
-    double m_dT; /**< RFModule period. */
+    std::chrono::nanoseconds m_dT; /**< RFModule period. */
     std::string m_robot; /**< Robot name. */
 
     Eigen::VectorXd m_currentJointPos;
@@ -43,7 +44,7 @@ class Module : public yarp::os::RFModule
     std::vector<double>::const_iterator m_currentSetPoint;
 
     BipedalLocomotion::Planners::QuinticSpline m_spline;
-    std::vector<double> m_timeKnots;
+    std::vector<std::chrono::nanoseconds> m_timeKnots;
     std::vector<Eigen::VectorXd> m_trajectoryKnots;
 
     double m_initTrajectoryTime;

--- a/utilities/joint-position-tracking/src/Module.cpp
+++ b/utilities/joint-position-tracking/src/Module.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
 #include <fstream>
 #include <iomanip>
 
@@ -26,7 +27,7 @@ using namespace BipedalLocomotion::JointPositionTracking;
 
 double Module::getPeriod()
 {
-    return m_dT;
+    return std::chrono::duration<double>(m_dT).count();
 }
 
 bool Module::createPolydriver(std::shared_ptr<ParametersHandler::IParametersHandler> handler)
@@ -149,8 +150,9 @@ bool Module::configure(yarp::os::ResourceFinder& rf)
     m_spline.setFinalConditions(Vector1d::Zero(), Vector1d::Zero());
 
     m_timeKnots.clear();
-    m_timeKnots.push_back(0);
-    m_timeKnots.push_back(trajectoryDuration);
+    m_timeKnots.push_back(std::chrono::nanoseconds::zero());
+    m_timeKnots.push_back(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(trajectoryDuration)));
 
     if (!m_sensorBridge.advance())
     {
@@ -217,7 +219,7 @@ bool Module::updateModule()
     m_spline.advance();
 
     const double now = yarp::os::Time::now();
-    if (now - m_initTrajectoryTime > m_timeKnots.back() + 2)
+    if (now - m_initTrajectoryTime > std::chrono::duration<double>(m_timeKnots.back()).count() + 2)
     {
         std::cout << "[Module::updateModule] Generate a new trajectory." << std::endl;
 


### PR DESCRIPTION
Thanks to this PR we will change the page on how the time is considered in the framework.

Since now the time was considered as double, Now we move to `std::chrono::nanoseconds`. This will solve all the problems similar to what discussed in https://github.com/ami-iit/bipedal-locomotion-framework/pull/624#discussion_r1138761866

In detail this PR:
1. Add the support of `std::chrono` in The text logging
2. Add the possibility to retrieve and set duration from the `IParametersHandler`
   > With this feature it will be possible to specify the DateTime in an `ini` and a `toml` file. [`toml` officially support the local-time.](https://github.com/toml-lang/toml/blob/main/toml.md#local-time) Indeed, if you include only the time portion of an [RFC 3339](https://tools.ietf.org/html/rfc3339) formatted date-time, it will represent that time of day
   >  ```toml
   >  dt = 00:00:00.010000
   >  ```
   > means that `dt` is equal to `0.01 seconds` Following the same language specification ([RFC 3339](https://tools.ietf.org/html/rfc3339)) I also added the local time support to the yarp `ini` file specification (@traversaro, do you think this may be ported directly inside yarp?).
3. Restructure the Contacts component to handle time with `std::chrono::nanoseconds`
4. Restructure the Planners component to handle time with `std::chrono::nanoseconds`
5. Restructure the FloatingBaseEstimator component to handle time with `std::chrono::nanoseconds`
6. Update the `blf-position-tracking` to handle time with `std::chrono::nanoseconds`
7. Remove all the thresholds added in #624 in the `ContactDetectors` required by https://github.com/ami-iit/bipedal-locomotion-framework/pull/624#discussion_r1138761866
8. Restructure the python bindings


⚠️ Once this PR got merged I can help @paolo-viceconte, @LoreMoretti, @CarlottaSartore  to update the python code that uses the planner component