### PR TITLE
Add dynamic models composing the UKF measurement model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - Add the possibility to retrieve and set duration from the `IParametersHandler` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 - Add the possibility to update the contact list in the swing foot trajectory planner (https://github.com/ami-iit/bipedal-locomotion-framework/pull/637)
 - Implement state dynamic models needed to define an UKF process model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/615)
+- Implement measurement dynamic models needed to define an UKF measurement model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/640)
 
 ### Changed
 - Update the `IK tutorial` to use `QPInverseKinematics::build` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/621)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Add the support of `std::chrono` in The text logging (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 - Add the possibility to retrieve and set duration from the `IParametersHandler` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 - Add the possibility to update the contact list in the swing foot trajectory planner (https://github.com/ami-iit/bipedal-locomotion-framework/pull/637)
+- Implement state dynamic models needed to define an UKF process model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/615)
 
 ### Changed
 - Update the `IK tutorial` to use `QPInverseKinematics::build` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/621)
@@ -26,7 +27,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 - Return an error if an invalid `KinDynComputations` object is passed to `QPInverseKinematics::build()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/622)
-- Fix `QPTSIF` documentation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/634)
+- Fix `QPTSID` documentation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/634)
 - Fix error messages in `QPTSID` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/639)
 
 ## [0.12.0] - 2023-03-07

--- a/CHANGELOG.md.orig
+++ b/CHANGELOG.md.orig
@@ -1,0 +1,388 @@
+# Changelog
+All notable changes to this project are documented in this file.
+
+## [unreleased]
+### Added
+- Implement the `DiscreteGeometryContact` in Contacts component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/626)
+- Implement the `SchmittTrigger` in component `Math` and the associated python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/624)
+- Add the support of `std::chrono` in The text logging (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Add the possibility to retrieve and set duration from the `IParametersHandler` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Add the possibility to update the contact list in the swing foot trajectory planner (https://github.com/ami-iit/bipedal-locomotion-framework/pull/637)
+- Implement state dynamic models needed to define an UKF process model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/615)
+
+### Changed
+- Update the `IK tutorial` to use `QPInverseKinematics::build` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/621)
+- Handle case where no FT sensors are specified to split the model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/625)
+- General restructure of the `ContactDetector`and the derived classes (`SchmittTriggerDetector` and `FixedFootDetector`) (https://github.com/ami-iit/bipedal-locomotion-framework/pull/624)
+  Thanks to this refactory the `FixedFootDetector` usage becomes similar to the others `advanceable`.
+  Indeed now `FixedFootDetector::advace()` considers the input set by the user and provides the corresponding output.
+  ⚠️  Even if this modification do not break the API the user may notice some strange behavior if `advance` was called after getting the output of the detector.
+- Restructure the `Contacts` component to handle time with `std::chrono::nanoseconds` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Restructure the `Planners` component to handle time with `std::chrono::nanoseconds` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Restructure the `FloatingBaseEstimator` component to handle time with `std::chrono::nanoseconds`(https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Update the `blf-position-tracking` to handle time with `std::chrono::nanoseconds` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Update the python bindings to consider the time with `std::chrono::nanoseconds` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
+- Robustify SubModelCreator and SubModelKinDynWrapper tests (https://github.com/ami-iit/bipedal-locomotion-framework/pull/631)
+- `SwingFootTrajectoryPlanner::advance()` must be called before getting the output (https://github.com/ami-iit/bipedal-locomotion-framework/pull/637)
+
+### Fixed
+- Return an error if an invalid `KinDynComputations` object is passed to `QPInverseKinematics::build()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/622)
+- Fix `QPTSID` documentation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/634)
+<<<<<<< HEAD
+- Fix error messages in `QPTSID` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/639)
+=======
+>>>>>>> Update CHANGELOG
+
+## [0.12.0] - 2023-03-07
+### Added
+- Add the possibility to attach all the multiple analog sensor clients  (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
+- Add a tutorial for the inverse kinematics  (https://github.com/ami-iit/bipedal-locomotion-framework/pull/596)
+- Implement the ROS2 sink for the `TextLogging` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/587)
+- Implement the `QPFixedBaseInverseKinematics` in the `IK` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/599)
+- 🤖 [ergoCubSN000] Add configuration files for the YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/600)
+- Add functions to split a model in a set of submodels in the Estimator component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/604)
+- Add the possibity to call the advanceable capabilities of the `QuinticSpline` from the python (https://github.com/ami-iit/bipedal-locomotion-framework/pull/609)
+- Implement the `CubicSpline` python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/609)
+- Implement the python bindings for the iDynTree to manif conversions (https://github.com/ami-iit/bipedal-locomotion-framework/pull/610)
+- Implement `blf-balancing-position-control` application (https://github.com/ami-iit/bipedal-locomotion-framework/pull/611)
+- Implement the python bindings for `YarpTextLogging` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/611)
+- Add SubModelKinDynWrapper class to handle the `KinDynComputation` object of a sub-model (https://github.com/ami-iit/bipedal-locomotion-framework/pull/605)
+- Implement the `JointLimitsTask` for the IK (https://github.com/ami-iit/bipedal-locomotion-framework/pull/603)
+- Add the possibility to programmatically build an IK problem from a configuration file (https://github.com/ami-iit/bipedal-locomotion-framework/pull/614, https://github.com/ami-iit/bipedal-locomotion-framework/pull/619)
+
+### Changed
+- Ask for `toml++ v3.0.1` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/581)
+- The YarpRobotLogger will now automatically connect to the exogenous signal port if available (https://github.com/ami-iit/bipedal-locomotion-framework/pull/570/)
+- 🤖 [iCubGenova09] Add the left and right hands skin (raw and filtered) data acquisition (https://github.com/ami-iit/bipedal-locomotion-framework/pull/570/)
+- Add informative prints `YarpSensorBridge::Impl` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
+- The minimum version of iDynTree now supported is iDynTree 4.3.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/588).
+- Allow using the `iDynTree swig` bindings in `QPFixedBaseTSID` for the kindyncomputation object (https://github.com/ami-iit/bipedal-locomotion-framework/pull/599)
+- Add the possibility to customize the video codec in the `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/607)
+
+### Fix
+- Return an invalid `PolyDriverDescriptor` if `description` is not found in `constructMultipleAnalogSensorsRemapper()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/569)
+- Fix compatibility with OpenCV 4.7.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/589)
+- Fix `attachRemappedRemoteControlBoard` in `YarpSensorBridge` when the `RemoteControlBoard` is not the first polydriver in the polydriverlist (https://github.com/ami-iit/bipedal-locomotion-framework/pull/608)
+- Fix race condition in System::ClockBuilder (https://github.com/ami-iit/bipedal-locomotion-framework/pull/618)
+
+## [0.11.1] - 2022-12-19
+### Fix
+- Fix the compilation of the `YarpRobotLoggerDevice` in `Windows` and `macOS` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/580)
+
+## [0.11.0] - 2022-12-17
+### Added
+- Log the status of the system in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/571)
+- Add the `ROS2` implementation for Clock class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/575)
+
+### Changed
+- YARP devices are now enabled by default if YARP is found (https://github.com/ami-iit/bipedal-locomotion-framework/pull/576).
+- Restructure the python bindings to support _official_ `iDynTree` bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/578)
+- Remove _unofficial_ `iDynTree` bindings based on pybind11  (https://github.com/ami-iit/bipedal-locomotion-framework/pull/578)
+
+### Fix
+- Fix compatibility with YARP 3.8 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/577).
+
+## [0.10.0] - 2022-09-23
+### Added
+- Add the possibility to set the exogenous feedback for the `IK::SE3Task` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/567)
+- Implement `RobotInterface::constructMultipleAnalogSensorsClient()` and `RobotInterface::constructMultipleAnalogsensorsRemapper()` methods (https://github.com/ami-iit/bipedal-locomotion-framework/pull/568)
+
+### Changed
+- Add the possibility to log only a subset of text logging ports in `YarpRobotLogger` device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/561)
+- Accept boolean as integer while getting an element from searchable in `YarpUtilities` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/566)
+
+### Fix
+- Fix typo in the `RobotInterface::constructGenericSensorClient()` documentation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/568)
+- Fix compatibility with qhull installed by vcpkg `2022.07.25` and robotology-superbuild-dependencies-vcpkg `0.10.1` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/565).
+
+## [0.9.0] - 2022-09-09
+### Added
+- Implement the `MultiStateWeightProvider` in `ContinuousDynamicalSystem` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/555)
+- Implement `PortInput` and `PortOutput`in `System` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/555)
+- Implement `toManifTwist` in `Conversions` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/557)
+- Add the default value for the desired spatial and angular velocity to the `IK::SO3Task` and `IK::SE3Task` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/557)
+- Implement the `IK::R3Task` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/559)
+
+### Changed
+- Now `Advanceable` inherits from `PortInput` and `PortOutput` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/555)
+
+### Fix
+- Fix the dependency required to compile the YarpRobotLogger device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/554)
+- Fix the compatibility with fmt v9.0.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/556)
+
+## [0.8.0] - 2022-07-29
+### Added
+- Add the possibility to log the YarpTextLogging in the YarpRobotLogger (https://github.com/ami-iit/bipedal-locomotion-framework/pull/541)
+- Enable the logging FTs and IMU logging of iCubGenova09 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/546/)
+### Changed
+- Ported `YarpLoggerDevice` to `robometry`(https://github.com/ami-iit/bipedal-locomotion-framework/pull/533)
+- bipedal locomotion framework now depends on YARP 3.7.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/541)
+### Fix
+- Avoid to use deprecated function cv::aruco::drawAxis in ArucoDetector to fix compilation with OpenCV 4.6.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/552)
+
+## [0.7.0] - 2022-06-21
+### Added
+- Implement the python bindings for the clock machinery and for the yarp clock (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)
+- Implement the `IWeightProvider` interface and the `ConstantWeightProvider` class in the System component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/506)
+- Add installation of pip metadata files for when blf python bindings are installed only via CMake (https://github.com/ami-iit/bipedal-locomotion-framework/pull/508)
+- Implement the python bindings for the VectorsCollection message and the associated buffered port (https://github.com/ami-iit/bipedal-locomotion-framework/pull/511)
+- Implement the `VectorsCollectionWrapper` device for collection of arbitrary vector ports (https://github.com/ami-iit/bipedal-locomotion-framework/pull/512)
+- Add reading of right upper leg FT for `iCubGenova09` and associated cartesian wrench in `YarpRobotLoggerDevice` configuration files (https://github.com/ami-iit/bipedal-locomotion-framework/pull/513)
+- Add reading of right and left arms FT for `iCubGenova09` in `YarpRobotLoggerDevice` configuration files (https://github.com/ami-iit/bipedal-locomotion-framework/pull/515)
+- Add reading of right and left arms and right upper leg FTs and cartesian wrenches for `iCubGazeboV3` in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/525)
+- Add the possibility to retrieve the temperature sensor from `SensorBridge` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/519)
+- Add the possibility to set only the velocity in `CubicSpline::setInitialConditions` and `CubicSpline::setFinalConditions` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/528)
+- Implement the python bindings for the `ContinuousDynamicalSystem` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/532)
+- Add the possibility to log the video in the `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/516)
+
+### Changed
+- An error it will be returned if the user tries to change the clock type once the `clock()` has been already called once (https://github.com/ami-iit/bipedal-locomotion-framework/pull/500)
+- Log the arms external wrenches on the YarpRobotLogger for iCubGenova09 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/502)
+- IK and TSID now uses the weight provider to specify the weight associated to a task (https://github.com/ami-iit/bipedal-locomotion-framework/pull/506)
+- The `Planners`, `System`, `RobotInterface` and `YarpImplementation` components are no more mandatory to compile the python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/511)
+- Reorganize the multiple FT sensor and external wrench files into a single file in the YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/525)
+- Save the robot name and the names of the channel's elements in the YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/522)
+- Use icub-models to get the urdf models for the tests (https://github.com/ami-iit/bipedal-locomotion-framework/pull/526)
+- The FT sensor are now considered as `multianalogsensor` in `YarpSensorBridge` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/519)
+- Make `YarpRobotLogger` compatible with `yarp-telemetry` v0.5.1 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/535)
+- Set for `yarp-telemetry` minimum version to v0.5.1 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/535)
+- Make `YarpCameraBridge::getColorImage()` and `YarpCameraBridge::getDepthImage()` thread safe (https://github.com/ami-iit/bipedal-locomotion-framework/pull/516)
+- Deprecate `YarpCameraBridge::get()` in favor of `YarpCameraBridge::getMetaData()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/516)
+- Move from LGPL to BSD3 license (https://github.com/ami-iit/bipedal-locomotion-framework/pull/550)
+
+### Fix
+- Remove outdated includes in YarpRobotLoggerDevice.cpp (https://github.com/ami-iit/bipedal-locomotion-framework/pull/502)
+
+## [0.6.0] - 2022-01-10
+### Added
+- Add the reading of the orientation of the head IMU in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/471)
+- Add the possibility to change the weight in TSID/IK (https://github.com/ami-iit/bipedal-locomotion-framework/pull/475)
+- Implement a `FirstOrderSmoother` class in `ContinuousDynamicalSystem` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/476)
+- Implement `getIntegrationStep` in `FixedIntegration` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/476)
+- Add the possibility to create custom `LinearTasks` in python (https://github.com/ami-iit/bipedal-locomotion-framework/pull/480)
+- Implement the possibility to compute the residual terms in the `LinearTask` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/483)
+- Define `VectorsCollection` message in `YarpUtilities` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/483)
+- Add the reading of the joint and motor acceleration in `YarpSensorBridge` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/492)
+
+### Changed
+- Use yarp clock instead of system clock in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/473)
+- Reduce code duplication in python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/484)
+- Use `TextLogger` in `YarpRobotLoggerDevice` instead of `yarp` commands (https://github.com/ami-iit/bipedal-locomotion-framework/pull/486)
+- Ask for `osqp-eigen 0.6.4.100`(https://github.com/ami-iit/bipedal-locomotion-framework/pull/490)
+- Use enum underlying type to convert `TextLogging` verbosity level to `spdlog` verbosity level (https://github.com/ami-iit/bipedal-locomotion-framework/pull/495)
+- `yarp-telemetry` is now a dependency of the `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/487)
+- Fix deprecated `YARP` functions in `YarpUtilities` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/491)
+
+### Fix
+- Fix the population of the jointAccelerations and baseAcceleration variables in QPTSID (https://github.com/ami-iit/bipedal-locomotion-framework/pull/478)
+- Fix the documentation in the `Advanceable` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/476)
+- Add virtual destrutors in `System::Sink`, `System::Source`, `System::LinearTask`,
+`System::ITaskControlMode`, `TSID::TSIDLinearTask` and `IK::IKLinearTask` classes (https://github.com/ami-iit/bipedal-locomotion-framework/pull/480)
+- The joint torques is now correctly retrieved in QPTSID class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/482)
+- The motor velocity and positions are now returned in rad/s and rad (https://github.com/ami-iit/bipedal-locomotion-framework/pull/489)
+- Fix `YarpRobotLoggerDevice` documentation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/472)
+
+## [0.5.0] - 2021-11-30
+### Added
+- Implement Python bindings for the TSID component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/428)
+- Add the possibility to set the name of each element of a variable stored in the variables handler (https://github.com/ami-iit/bipedal-locomotion-framework/pull/429)
+- Develop the python bindings for toml implementation of the parameters handler (https://github.com/ami-iit/bipedal-locomotion-framework/pull/432)
+- Implement the VariableRegularizationTask in TSID (https://github.com/ami-iit/bipedal-locomotion-framework/pull/431)
+- Implement `create_tsid` utility function for the python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/433)
+- Implement the `AngularMomentumTask` in the `TSID` component and the associated python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/436)
+- Implement `QPTSID::toString` method and the associated python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/440)
+- Implement `ContactWrench` python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/441)
+- Implement AngularMomentum task in the IK component and the associated bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/443)
+- Implement `create_ik` utility function for the python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/444)
+- Add the possibility to set the task controller mode for the SE3Task in the TSID component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/445)
+- Expose the `ITaskControlMode` class in the python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/445)
+- Add the possibility to enable/disable the joints and motors state logging in the `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/453)
+- Implement `QPInverseKinematics::toString` method and the associated python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/461)
+- Add the cartesian wrenches logging in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/447)
+- Implement the python bindings for the manif conversions methods (https://github.com/ami-iit/bipedal-locomotion-framework/pull/465)
+
+### Changed
+- Inherits all the `Eigen::Matrix` constructors in the `Wrenchd` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/441)
+- Bump the minimum `cmake` version to `3.16.0` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/468)
+
+### Fix
+- Fix Analog FT Sensor reading in `YarpSensorBridgeImpl` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/459)
+- Fix config files in `YarpRobotLoggerDevice` for iCub3 head IMU reading (https://github.com/ami-iit/bipedal-locomotion-framework/pull/467)
+
+## [0.4.0] - 2021-10-15
+### Added
+- Implement `AdvanceableRunner::isRunning()` method (https://github.com/ami-iit/bipedal-locomotion-framework/pull/395)
+- Implement `ContactPhaseList::getPresentPhase()` method (https://github.com/ami-iit/bipedal-locomotion-framework/pull/396)
+- Add a synchronization mechanism for the `AdvanceableRunner` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/403)
+- Add the possibility to use spdlog with YARP (https://github.com/ami-iit/bipedal-locomotion-framework/pull/408)
+- Add new Advanceable exposing `UnicyclePlanner` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/320)
+
+### Changed
+- Add `name` parameter to the `AdvanceableRunner` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/406)
+- Set the required `spdlog` version in the cmake file (https://github.com/ami-iit/bipedal-locomotion-framework/pull/415)
+- Add features to FTIMULoggerDevice and rename it in YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/405)
+
+### Fix
+- Fix missing components dependencies in the `CMake` machinery (https://github.com/ami-iit/bipedal-locomotion-framework/pull/414)
+- Fixed missing include in `FloatingBaseEstimatorIO.h` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/417)
+
+## [0.3.0] - 2021-08-12
+### Added
+- Implement `CubicSpline` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/344)
+- Implement `PWM` control in RobotControl class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/346)
+- Implement `ContactWrenchCone` class in Math component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/352)
+- Implement `skew` function in Math component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/352)
+- Implement `QPTSID` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/366)
+- Implement motor pwm, motor encoders, wbd joint torque estimates, pid reading in `YarpSensorBridge`(https://github.com/ami-iit/bipedal-locomotion-framework/pull/359).
+- Implement FeasibleContactWrenchTask for TSID component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/369).
+- Implement python bindings for QPInverseKinematics class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/303)
+- Implement `ControlTask` in for System component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/373).
+- Allow changing the log verbosity (https://github.com/ami-iit/bipedal-locomotion-framework/pull/385)
+- Implement the CoMZMP controller (https://github.com/ami-iit/bipedal-locomotion-framework/pull/387)
+
+### Changed
+- Add common Python files to gitignore (https://github.com/ami-iit/bipedal-locomotion-framework/pull/338)
+- General improvements of `blf-calibration-delta-updater` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/361)
+- Add the possibility to control a subset of coordinates in `IK::SE3Task` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/356)
+- Add the possibility to control a subset of coordinates in `IK::CoMTask` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/357)
+- Reduce the duplicate code in IK and TSID (https://github.com/ami-iit/bipedal-locomotion-framework/pull/364)
+- `QPFixedBaseTSID` now inherits from `QPTSID` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/366)
+- Enable the Current control in `RobotInterface` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/375)
+- Add the possibility to disable and enable the PD controllers in `IK::SE3Task` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/373).
+- Add the possibility to use manif objects in the ForwardEuler integrator (https://github.com/ami-iit/bipedal-locomotion-framework/pull/379).
+
+### Fix
+- Fixed the crashing of `YarpSensorBridge` while trying to access unconfigured control board sensors data by adding some checks (https://github.com/ami-iit/bipedal-locomotion-framework/pull/378)
+- Fixed the compilation of Python bindings (enabled by the `FRAMEWORK_COMPILE_PYTHON_BINDINGS` CMake option) when compiling with Visual Studio (https://github.com/ami-iit/bipedal-locomotion-framework/pull/380).
+- Fixed the `TOML` and `YARP` implementation of the parameters handler when a `std::vector<bool>` is passed to the `setParameter()` method (https://github.com/ami-iit/bipedal-locomotion-framework/pull/390).
+
+## [0.2.0] - 2021-06-15
+### Added
+- Implement IRobotControl python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/200)
+- Implement ISensorBridge python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/203)
+- Implement `LeggedOdometry` class as a part of `FloatingBaseEstimators` library and handle arbitrary contacts in `FloatingBaseEstimator`. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/151)
+- Implement the possibility to set a desired reference trajectory in the TimeVaryingDCMPlanner. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/208)
+- Implement SchmittTriggerDetector python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/213)
+- Implement ModelComputationsHelper for quick construction of KinDynComputations object using parameters handler (https://github.com/ami-iit/bipedal-locomotion-framework/pull/216)
+- Implement FloatingBaseEstimator and LeggedOdometry python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/218)
+- Add spdlog as mandatory dependency of the project (https://github.com/ami-iit/bipedal-locomotion-framework/pull/225)
+- Implement `ICameraBridge` and `IPointCloudBridge` interface classes as a part of `PerceptionInterface` library. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/165)
+- Implement `RealSense` driver class as a part of `PerceptionCapture` library. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/165)
+- Implement `realsense-test` utility application. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/165)
+- Implement the inverse kinematics component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/229)
+- Implement LinearizedFrictionCone class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/244)
+- Added a check on whether the installed public headers have the correct folder structure (https://github.com/ami-iit/bipedal-locomotion-framework/pull/247)
+- Implement python bindings for VariablesHandler class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/234)
+- Implement `PerceptionFeatures` library and implement `ArucoDetector`. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/159)
+- Implement FixedBaseDynamics class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/242)
+- Implemented Sink and Source classes (https://github.com/ami-iit/bipedal-locomotion-framework/pull/267)
+- Implement the IClock, StdClock and YarpClock classes (https://github.com/ami-iit/bipedal-locomotion-framework/pull/269)
+- Implement `YarpCameraBridge` class for Yarp implementation of ICameraBridge (https://github.com/ami-iit/bipedal-locomotion-framework/pull/237)
+- Implement `PointCloudProcessor` class and modify `realsense-test` to test point clouds handling with Realsense. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/236)
+- Implement `AdvanceableRunner` and `SharedResource` classes in System component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/272)
+- Implement `handleQuitSignals()` function in System component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/277)
+- Implement TaskSpaceInverseDynamics interface (https://github.com/ami-iit/bipedal-locomotion-framework/pull/279)
+- Implement `Wrench` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/279)
+- Implement `SO3Task` in `TSID` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/281)
+- Implement clone method in ParametersHandler classes (https://github.com/ami-iit/bipedal-locomotion-framework/pull/288)
+- Implement `VariablesHandler::clear()` and `VariablesHandler::initialize()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/291)
+- Implement the possibility to set the default contact in the `ContactList` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/297)
+- Implement `FixedFootDetector` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/284)
+- Implement QPFixedBaseTSID class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/251)
+- Implement `YarpImplementation::setFromFile()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/307)
+- Implement `CoMTask` in TSID (https://github.com/ami-iit/bipedal-locomotion-framework/pull/304)
+- Implement `YarpParametersHandler` bindings (https://github.com/ami-iit/bipedal-locomotion-framework/pull/309)
+- Implement `contactListMapFromJson()` and `contactListMapToJson()` methods and python bindings (https://github.com/ami-iit/bipedal-locomotion-framework/issues/316)
+- Implement a matioCpp-based strain2 sensors' FT-IMU logger example device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/326)
+- Implement `TomlImplementation` in `ParametersHandler` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/328)
+- Implement blf_calibration_delta_updater.py application (https://github.com/ami-iit/bipedal-locomotion-framework/pull/332)
+
+### Changed
+- Move all the Contacts related classes in Contacts component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/204)
+- Move all the ContactDetectors related classes in Contacts component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/209)
+- The DCMPlanner and TimeVaryingDCMPlanner initialize functions take as input an std::weak_ptr. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/208)
+- Use `Math::StandardAccelerationOfGravitation` instead of hardcoding 9.81. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/211)
+- Convert iDynTree types in FloatingBaseEstimators component to Eigen/manif types (https://github.com/ami-iit/bipedal-locomotion-framework/pull/215)
+- Use std::optional instead of raw pointer in ISensorBridge. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/226)
+- Use `System::LinearTask` in TSID component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/240)
+- Restructure python bindings in submodules (https://github.com/ami-iit/bipedal-locomotion-framework/pull/238)
+- Integrators and DynamicalSystems are now in the `ContinuousDynamicalSystem` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/242)
+- Add Input template class to `System::Advanceable` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/267)
+- Add support for landmarks and kinematics-free estimation in `FloatingBaseEstimators`. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/254)
+- If FRAMEWORK_DETECT_ACTIVE_PYTHON_SITEPACKAGES is OFF, for Python bindings use installation directory provided by sysconfig Python module. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/274)
+- Reduce memory allocation in `YarpSensorBridge` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/278)
+- Use `TextLogging` in `VariablesHandler` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/291)
+- Fix `YarpImplementation::setParameterPrivate()` when a boolean or a vector of boolean is passed (https://github.com/ami-iit/bipedal-locomotion-framework/pull/311)
+- Add `foot_take_off_acceleration` and `foot_take_off_velocity` parameters in the `SwingFootPlanner` class (https://github.com/ami-iit/bipedal-locomotion-framework/issues/323)
+- Change the parameters handler verbosity (https://github.com/ami-iit/bipedal-locomotion-framework/pull/330)
+- Restore backward compatibility of SwingFootPlanner parameters (https://github.com/ami-iit/bipedal-locomotion-framework/pull/334)
+- Bump manif version to 0.0.4  (https://github.com/ami-iit/bipedal-locomotion-framework/pull/339)
+
+### Fixed
+- Fix missing implementation of `YarpSensorBridge::getFailedSensorReads()`. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/202)
+- Fixed `mas-imu-test` configuration files after FW fix.
+- Fixed the implementation ``YarpSensorBridge::attachAllSixAxisForceTorqueSensors()`. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/231)
+- Avoid the "Generating the Urdf Model from" message to appear when doing ccmake. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/243)
+- Fixed the installation path of public headers related to perception libraries. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/245)
+- Fixed InstallBasicPackageFiles to avoid the same problem of https://github.com/ami-iit/matio-cpp/pull/41 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/253)
+- Call `positionInterface->setRefSpeeds()` only once when a position reference is set in `YarpRobotControl` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/271)
+- Fix initialization of reference frame for world in `LeggedOdometry` class. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/289)
+- `LeggedOdometry::Impl::updateInternalContactStates()` is now called even if the legged odometry is not initialize. This was required to have a meaningful base estimation the first time `LeggedOdometry::changeFixedFrame()` is called. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/292)
+- Avoid to use the default copy-constructor and copy-assignment operator in `ContactPhaseList` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/295)
+- Fix `toString()` method of `VariablesHandler` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/302)
+- Fix in `YarpUtilities::getVectorFromSearchable` when a vector of boolean is passed as input (https://github.com/ami-iit/bipedal-locomotion-framework/pull/313)
+- Various fixes for the yarp devices (https://github.com/ami-iit/bipedal-locomotion-framework/pull/337)
+
+## [0.1.1] - 2021-05-08
+### Fix
+- Fix the documentation in `TemplateHelpers.h`
+
+## [0.1.0] - 2021-02-22
+### Added
+- The `CHANGELOG.md` file
+- The `cmake/BipedalLocomotionControllersFindDepencies.cmake` file
+- The `cmake/AddInstallRPATHSupport.cmake` file
+- The `cmake/AddUninstallTarget.cmake` file
+- The `cmake/FindEigen3.cmake` file
+- The `cmake/InstallBasicPackageFiles.cmake` file
+- Implement the first version of the `BipedalLocomotionControllers` interface
+- Implement the  first version of the `YarpUtilities` library
+- Implement `ParametersHandler` library (https://github.com/ami-iit/bipedal-locomotion-controllers/pull/13)
+- Implement `GenericContainer::Vector` (https://github.com/ami-iit/bipedal-locomotion-controllers/pull/29)
+- Implement `Estimators` library (https://github.com/ami-iit/bipedal-locomotion-controllers/pull/23)
+- Implement `Contact` library. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/43 and https://github.com/ami-iit/bipedal-locomotion-framework/pull/45)
+- Implement the first version of the `TimeVaryingDCMPlanner` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/61)
+- Implement the Quintic Spline class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/83)
+- Implement the `ConvexHullHelper` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/51)
+- Implement the `DynamicalSystem` and `Integrator` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/46)
+- Implement the `IRobotControl` interface and the YARP specialization (https://github.com/ami-iit/bipedal-locomotion-framework/pull/97, https://github.com/ami-iit/bipedal-locomotion-framework/pull/192)
+- Add `SensorBridge` interface (https://github.com/ami-iit/bipedal-locomotion-framework/pull/87)
+- Add the `YarpSensorBridge` Implementation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/106)
+- Added `CommonConversions`, `ManifConversions`, and `matioCppConversions` libraries to handle type conversions. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/138 and https://github.com/ami-iit/bipedal-locomotion-framework/pull/143)
+- Implement the `JointPositionTracking` application. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/136)
+- Initial implementation of Python bindings using pybind11 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/134)
+- Implement `FloatingBaseEstimatorDevice` YARP device for wrapping floating base estimation algorithms. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/130)
+- Implement Continuous algebraic Riccati equation function (https://github.com/ami-iit/bipedal-locomotion-framework/pull/157)
+- Implement YARP based `ROSPublisher` in the `YarpUtilities` library. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/156)
+- Implement example YARP device `ROSPublisherTestDevice` for understanding the usage of `ROSPublisher`. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/160)
+- Implement `TSID` library. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/167, https://github.com/ami-iit/bipedal-locomotion-framework/pull/170, https://github.com/ami-iit/bipedal-locomotion-framework/pull/178)
+- Implement the `JointTrajectoryPlayer` application. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/169)29ed234a1c
+- Implement `ContactDetectors` library. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/142)
+- Added `mas-imu-test` application to check the output of MAS IMUs (https://github.com/ami-iit/bipedal-locomotion-framework/pull/62)
+- Implement motor currents reading in `YarpSensorBridge`. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/187)
+
+[unreleased]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.12.0...master
+[0.12.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/ami-iit/bipedal-locomotion-framework/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/ami-iit/bipedal-locomotion-framework/releases/tag/v0.1.0

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -86,6 +86,10 @@ find_package(robometry 1.1.0 QUIET)
 checkandset_dependency(robometry MINIMUM_VERSION 1.1.0)
 dependency_classifier(robometry MINIMUM_VERSION 1.1.0 IS_USED ${FRAMEWORK_USE_robometry})
 
+find_package(BayesFilters QUIET)
+checkandset_dependency(BayesFilters)
+dependency_classifier(BayesFilters IS_USED ${FRAMEWORK_USE_BayesFilters})
+
 # required only for some tests
 find_package(icub-models 1.23.3 QUIET)
 checkandset_dependency(icub-models)
@@ -170,7 +174,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_FloatingBaseEstimators
 
 framework_dependent_option(FRAMEWORK_COMPILE_RobotDynamicsEstimator
   "Compile RobotDynamicsEstimator libraries?" ON
-  "FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_System;FRAMEWORK_COMPILE_ManifConversions;FRAMEWORK_USE_manif" OFF)
+  "FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_System;FRAMEWORK_COMPILE_ManifConversions;FRAMEWORK_USE_manif;FRAMEWORK_USE_BayesFilters" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_ManifConversions
   "Compile manif Conversions libraries?" ON

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -28,11 +28,13 @@ if(FRAMEWORK_COMPILE_RobotDynamicsEstimator)
   add_bipedal_locomotion_library(
     NAME                    RobotDynamicsEstimator
     SOURCES                 src/SubModel.cpp src/SubModelKinDynWrapper.cpp src/Dynamics.cpp src/ZeroVelocityDynamics.cpp src/FrictionTorqueStateDynamics.cpp
-                            src/JointVelocityStateDynamics.cpp src/UkfState.cpp src/SubModelDynamics.cpp
+                            src/JointVelocityStateDynamics.cpp src/UkfState.cpp src/SubModelDynamics.cpp src/MotorCurrentMeasurementDynamics.cpp
+                            src/UkfMeasurement.cpp src/AccelerometerMeasurementDynamics.cpp src/GyroscopeMeasurementDynamics.cpp
     SUBDIRECTORIES          tests/RobotDynamicsEstimator
     PUBLIC_HEADERS          ${H_PREFIX}/SubModel.h ${H_PREFIX}/SubModelKinDynWrapper.h ${H_PREFIX}/Dynamics.h ${H_PREFIX}/ZeroVelocityDynamics.h
-                            ${H_PREFIX}/FrictionTorqueStateDynamics.h ${H_PREFIX}/JointVelocityStateDynamics.h
-                            ${H_PREFIX}/UkfState.h ${H_PREFIX}/SubModelDynamics.h
+                            ${H_PREFIX}/FrictionTorqueStateDynamics.h ${H_PREFIX}/JointVelocityStateDynamics.h ${H_PREFIX}/AccelerometerMeasurementDynamics.h
+                            ${H_PREFIX}/UkfState.h ${H_PREFIX}/SubModelDynamics.h ${H_PREFIX}/MotorCurrentMeasurementDynamics.h ${H_PREFIX}/UkfMeasurement.h
+                            ${H_PREFIX}/GyroscopeMeasurementDynamics.h
     PUBLIC_LINK_LIBRARIES   BipedalLocomotion::ParametersHandler MANIF::manif BipedalLocomotion::System BipedalLocomotion::Math iDynTree::idyntree-high-level
                             iDynTree::idyntree-core iDynTree::idyntree-model iDynTree::idyntree-modelio Eigen3::Eigen MANIF::manif BayesFilters::BayesFilters
     PRIVATE_LINK_LIBRARIES  BipedalLocomotion::TextLogging BipedalLocomotion::ManifConversions

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -27,19 +27,14 @@ if(FRAMEWORK_COMPILE_RobotDynamicsEstimator)
   set(H_PREFIX include/BipedalLocomotion/RobotDynamicsEstimator)
   add_bipedal_locomotion_library(
     NAME                    RobotDynamicsEstimator
-    SOURCES                 src/SubModel.cpp
-                            src/SubModelKinDynWrapper.cpp
+    SOURCES                 src/SubModel.cpp src/SubModelKinDynWrapper.cpp src/Dynamics.cpp src/ZeroVelocityDynamics.cpp src/FrictionTorqueStateDynamics.cpp
+                            src/JointVelocityStateDynamics.cpp src/UkfState.cpp src/SubModelDynamics.cpp
     SUBDIRECTORIES          tests/RobotDynamicsEstimator
-    PUBLIC_HEADERS          ${H_PREFIX}/SubModel.h
-                            ${H_PREFIX}/SubModelKinDynWrapper.h
-    PUBLIC_LINK_LIBRARIES   BipedalLocomotion::ParametersHandler
-                            BipedalLocomotion::TextLogging
-                            BipedalLocomotion::ManifConversions
-                            iDynTree::idyntree-high-level
-                            iDynTree::idyntree-core
-                            iDynTree::idyntree-model
-                            iDynTree::idyntree-modelio
-                            Eigen3::Eigen
-                            MANIF::manif
-)
+    PUBLIC_HEADERS          ${H_PREFIX}/SubModel.h ${H_PREFIX}/SubModelKinDynWrapper.h ${H_PREFIX}/Dynamics.h ${H_PREFIX}/ZeroVelocityDynamics.h
+                            ${H_PREFIX}/FrictionTorqueStateDynamics.h ${H_PREFIX}/JointVelocityStateDynamics.h
+                            ${H_PREFIX}/UkfState.h ${H_PREFIX}/SubModelDynamics.h
+    PUBLIC_LINK_LIBRARIES   BipedalLocomotion::ParametersHandler MANIF::manif BipedalLocomotion::System BipedalLocomotion::Math iDynTree::idyntree-high-level
+                            iDynTree::idyntree-core iDynTree::idyntree-model iDynTree::idyntree-modelio Eigen3::Eigen MANIF::manif BayesFilters::BayesFilters
+    PRIVATE_LINK_LIBRARIES  BipedalLocomotion::TextLogging BipedalLocomotion::ManifConversions
+                            )
 endif()

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h
@@ -1,0 +1,198 @@
+/**
+ * @file Dynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_DYNAMICS_H
+
+#include <memory>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/System/Factory.h>
+#include <BipedalLocomotion/System/Advanceable.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+
+/**
+ * BLF_REGISTER_DYNAMICS is a macro that can be used to register a Dynamics. The key of
+ * the dynamics will be the stringified version of the Dynamics C++ Type
+ * @param _model the model of the dynamics
+ * @param _baseModel the base model from which the _model inherits.
+ */
+#define BLF_REGISTER_DYNAMICS(_model, _baseModel)               \
+    static std::shared_ptr<_baseModel> _model##FactoryBuilder() \
+{                                                               \
+    return std::make_shared<_model>();                          \
+    };                                                          \
+    static std::string _model##BuilderAutoRegHook               \
+    = ::BipedalLocomotion::Estimators::                         \
+    RobotDynamicsEstimator::DynamicsFactory::registerBuilder    \
+    (#_model, _model##FactoryBuilder);
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * @brief The UKFInput struct represents the input of the ukf needed to update the dynamics.
+ */
+struct UKFInput
+{
+    Eigen::VectorXd robotJointPositions; /**< Vector of joint positions. */
+    manif::SE3d robotBasePose; /**< Robot base position and orientation. */
+    manif::SE3d::Tangent robotBaseVelocity; /**< Robot base velocity. */
+    manif::SE3d::Tangent robotBaseAcceleration; /**< Robot base acceleration. */
+};
+
+/**
+ * UkfInputProvider describes the provider for the inputs of the ukf
+ */
+class UkfInputProvider : public System::Advanceable<UKFInput, UKFInput>
+{
+private:
+    UKFInput m_ukfInput;
+
+public:
+    /**
+     * Get the inputes
+     * @return A struct containing the inputs for the ukf
+     */
+    const UKFInput& getOutput() const override;
+
+    /**
+     * Set the state which represents the state of the provider.
+     * @param input is a struct containing the input of the ukf.
+     */
+    bool setInput(const UKFInput& input) override;
+
+    /**
+     * @brief Advance the internal state. This may change the value retrievable from getOutput().
+     * @return True if the advance is successfull.
+     */
+    bool advance() override;
+
+    /**
+     * @brief Determines the validity of the object retrieved with getOutput()
+     * @return True if the object is valid, false otherwise.
+     */
+    bool isOutputValid() const override;
+
+}; // class UkfProcessInputProvider
+
+/**
+ * Dynamics describes a generic dynamic model for a UKF state or measurement.
+ */
+class Dynamics
+{
+protected:
+    int m_size; /**< Size of the variable associate to the Dynamics object. */
+    Eigen::VectorXd m_updatedVariable; /**< Updated variable computed using the dynamic model. */
+    std::string m_description{"Generic Dynamics Element"}; /**< String describing the type of the dynamics */
+    std::string m_name; /**< Name of dynamics. */
+    Eigen::VectorXd m_covariances; /**< Vector of covariances. */
+    std::vector<std::string> m_elements = {}; /**< Elements composing the variable vector. */
+    std::string m_dynamicModel;
+    bool m_isInitialized{false}; /**< True if the dynamics has been initialized. */
+    System::VariablesHandler m_stateVariableHandler; /**< Variable handler describing the variables and the sizes in the ukf state/measurement vector. */
+    bool m_isStateVariableHandlerSet{false}; /**< True if setVariableHandler is called. */
+    UKFInput m_ukfInput;
+
+    /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    virtual bool checkStateVariableHandler();
+
+
+public:
+    /**
+     * Initialize the task.
+     * @param paramHandler pointer to the parameters handler.
+     * @return True in case of success, false otherwise.
+     */
+    virtual bool
+    initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler);
+
+    /**
+     * Finalize the Dynamics.
+     * @param handler object describing the variables in the vector for which all the dynamics are defined.
+     * @note You should call this method after you add ALL the dynamics to the variable handler.
+     * @return true in case of success, false otherwise.
+     */
+    virtual bool finalize(const System::VariablesHandler& handler);
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param kinDynWrapper pointer to a SubModelKinDynWrapper object.
+     * @return True in case of success, false otherwise.
+     */
+    virtual bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList);
+
+    /**
+     * Update the dynamics of the variable.
+     * @return True in case of success, false otherwise.
+     */
+    virtual bool update();
+
+    /**
+     * Get the next value m_updatedVariable.
+     * @return a const reference to the next variable value.
+     */
+    Eigen::Ref<const Eigen::VectorXd> getUpdatedVariable() const;
+
+    /**
+     * Get the size of the state.
+     * @return the size of the state.
+     */
+    int size() const;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics.
+     * @param ukfState reference to the ukf state.
+     */
+    virtual void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) = 0;
+
+    /**
+     * Set a `UKFInput` object.
+     * @param ukfInput reference to the UKFInput struct.
+     */
+    virtual void setInput(const UKFInput & ukfInput) = 0;
+
+    /**
+     * @brief getCovariance access the covariance `Eigen::VectorXd` associated to the variables described by this dynamics.
+     * @return the vector of covariances.
+     */
+    Eigen::Ref<const Eigen::VectorXd> getCovariance();
+
+    /**
+     * Destructor.
+     */
+    virtual ~Dynamics() = default;
+};
+
+/**
+ * DynamicsFactory implements the factory design patter for constructing a Dynamics given
+ * its model.
+ */
+class DynamicsFactory : public System::Factory<Dynamics>
+{
+
+public:
+    virtual ~DynamicsFactory() = default;
+};
+
+} // RobotDynamicsEstimator
+} // Estimators
+} // BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_DYNAMICS_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h
@@ -103,7 +103,7 @@ protected:
     std::vector<std::string> m_elements = {}; /**< Elements composing the variable vector. */
     std::string m_dynamicModel;
     bool m_isInitialized{false}; /**< True if the dynamics has been initialized. */
-    System::VariablesHandler m_stateVariableHandler; /**< Variable handler describing the variables and the sizes in the ukf state/measurement vector. */
+    System::VariablesHandler m_stateVariableHandler; /**< Variable handler describing the variables and the sizes in the ukf state vector. */
     bool m_isStateVariableHandlerSet{false}; /**< True if setVariableHandler is called. */
     UKFInput m_ukfInput;
 

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/FrictionTorqueStateDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/FrictionTorqueStateDynamics.h
@@ -1,0 +1,135 @@
+/**
+ * @file FrictionTorqueStateDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_FRICTION_TORQUE_STATE_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_FRICTION_TORQUE_STATE_DYNAMICS_H
+
+#include <memory>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelDynamics.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The FrictionTorqueDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element if you want to use a specific friction torque model dynamics.
+ * The FrictionTorqueDynamics represents the following equation in the continuous time:
+ * \f[
+ * \dot{\tau_{F}} = \ddot{s} ( k_{2} + k_{0} k_{1} (1 - tanh^{2} (k_{1} \dot{s})) )
+ * \f]
+ * since the friction model implemented by this class is defined as:
+ * \f[
+ * \tau_{F} = k_{0} tanh(k_{1} \dot{s}) + k_{2} \dot{s}
+ * \f]
+ * In the discrete time the dynamics is defined as:
+ * \f[
+ * \tau_{F,k+1} = \tau_{F,k} + \Delta T ( k_{2} + k_{0} k_{1} (1 - tanh^{2} (k_{1} \dot{s,k})) ) \ddot{s}
+ * \f]
+ */
+
+class FrictionTorqueStateDynamics : public Dynamics
+{
+    Eigen::VectorXd m_jointVelocityFullModel; /**< Vector of joint velocities. */
+    Eigen::VectorXd m_currentFrictionTorque; /**< Vector of friction torques. */
+    Eigen::VectorXd m_k0, m_k1, m_k2; /**< Friction parameters (see class description). */
+    double m_dT; /**< Sampling time. */
+    int m_nrOfSubDynamics; /**< Number of sub-dynamics which corresponds to the number of sub-models. */
+    std::vector<std::unique_ptr<SubModelDynamics>> m_subDynamics; /**< Vector of SubModelInversDynamics objects. */
+    Eigen::VectorXd m_motorTorqueFullModel; /**< Motor torque vector of full-model. */
+    Eigen::VectorXd m_frictionTorqueFullModel; /**< Friction torque vector of full-model. */
+    std::vector<Eigen::VectorXd> m_subModelUpdatedJointAcceleration; /**< Updated joint acceleration of each sub-model. */
+    Eigen::VectorXd m_jointAccelerationFullModel; /**< Vector of joint accelerations. */
+    bool m_isSubModelListSet{false}; /**< Boolean flag saying if the sub-model list has been set. */
+
+protected:
+    Eigen::VectorXd m_tanhArgument;
+    Eigen::VectorXd m_tanh;
+    Eigen::VectorXd m_k0k1;
+    Eigen::VectorXd m_argParenthesis;
+    Eigen::VectorXd m_dotTauF;
+
+public:
+    /*
+     * Constructor
+     */
+    FrictionTorqueStateDynamics();
+
+    /*
+     * Destructor
+     */
+    virtual ~FrictionTorqueStateDynamics();
+
+    /**
+     * Initialize the state dynamics.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               | `string` |   Name of the state contained in the `VariablesHandler` describing the state associated to this dynamics|    Yes    |
+     * |            `covariance`            | `vector` |                                Process covariances                                                      |    Yes    |
+     * |           `dynamic_model`          | `string` |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
+     * |             `elements`             | `vector` |  Vector of strings describing the list of sub variables composing the state associated to this dynamics.|    No     |
+     * |            `friction_k0`           | `vector` |  Vector of coefficients k0. For more info check the class description.                                  |    Yes    |
+     * |            `friction_k1`           | `vector` |  Vector of coefficients k1. For more info check the class description.                                  |    Yes    |
+     * |            `friction_k2`           | `vector` |  Vector of coefficients k2. For more info check the class description.                                  |    Yes    |
+     * |                `dT`                | `double` |                                Sampling time.                                                           |    Yes    |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param stateVariableHandler object describing the variables in the state vector.
+     * @note You should call this method after you add ALL the state dynamics to the state variable handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& stateVariableHandler) override;
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param kinDynWrapper pointer to a SubModelKinDynWrapper object.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    bool checkStateVariableHandler() override;
+
+    /**
+     * Update the content of the element.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics.
+     * @param ukfState reference to the ukf state.
+     */
+     void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+     /**
+      * Set a `UKFInput` object.
+      * @param ukfInput reference to the UKFInput struct.
+      */
+      void setInput(const UKFInput & ukfInput) override;
+};
+
+BLF_REGISTER_DYNAMICS(FrictionTorqueStateDynamics, ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_FRICTION_TORQUE_STATE_DYNAMICS_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/GyroscopeMeasurementDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/GyroscopeMeasurementDynamics.h
@@ -1,15 +1,16 @@
 /**
- * @file ZeroVelocityDynamics.h
+ * @file GyroscopeMeasurementDynamics.h
  * @authors Ines Sorrentino
  * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the BSD-3-Clause license.
  */
 
-#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_ZERO_VELOCITY_DYNAMICS_H
-#define BIPEDAL_LOCOMOTION_ESTIMATORS_ZERO_VELOCITY_DYNAMICS_H
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_ACCELEROMETER_MEASUREMENT_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_ACCELEROMETER_MEASUREMENT_DYNAMICS_H
 
 #include <memory>
 #include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelDynamics.h>
 
 namespace BipedalLocomotion
 {
@@ -19,33 +20,46 @@ namespace RobotDynamicsEstimator
 {
 
 /**
- * The ZeroVelocityDynamics class is a concrete implementation of the Dynamics.
- * Please use this element if you do not know the specific dynamics of a state variable.
- * The ZeroVelocityDynamics represents the following equation in the continuous time:
+ * The GyroscopeMeasurementDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element if you want to use the model dynamics of a gyroscope.
+ * The GyroscopeMeasurementDynamics represents the following equation in the continuous time:
  * \f[
- * \dot{x} = 0
+ * \omega^{gyroscope} = J \nu = J^{base} v^{base} + J^{joints} \dot{s}
  * \f]
- * In the discrete time the following dynamics assigns the current state to the next state:
- * \f[
- * x_{k+1} = x_{k}
- * \f]
+ * where the joint velocity is estimated by the ukf.
  */
 
-class ZeroVelocityDynamics : public Dynamics
+class GyroscopeMeasurementDynamics : public Dynamics
 {
-protected:
-    Eigen::VectorXd m_currentState; /**< Current state. */
     bool m_useBias{false}; /**< If true the dynamics depends on a bias additively. */
     Eigen::VectorXd m_bias; /**< The bias is initialized and used only if m_useBias is true. False if not specified. */
     std::string m_biasVariableName; /**< Name of the variable containing the bias in the variable handler. */
+    bool m_isSubModelListSet{false}; /**< Boolean flag saying if the sub-model list has been set. */
+    double m_dT; /**< Sampling time. */
+    int m_nrOfSubDynamics; /**< Number of sub-dynamics which corresponds to the number of sub-models. */
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> m_subModelKinDynList; /**< Vector of SubModelKinDynWrapper objects. */
+    std::vector<SubModel> m_subModelList; /**< Vector of SubModel objects. */
+    std::vector<Eigen::VectorXd> m_subModelJointVel; /**< Updated joint velocities of each sub-model. */
+    std::vector<std::size_t> m_subModelWithGyro; /**< List of indeces saying which sub-model in the m_subDynamics list containa the gyroscope. */
+    Eigen::VectorXd m_jointVelocityFullModel; /**< Vector of joint velocities. */
 
-    /**
-      * Controls whether the variable handler contains the variables on which the dynamics depend.
-      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
-      */
-    bool checkStateVariableHandler() override;
+protected:
+    Eigen::VectorXd m_covSingleVar;
+    manif::SE3d::Tangent m_subModelBaseVel;
+    Eigen::VectorXd m_JvBase;
+    Eigen::VectorXd m_Jsdot;
 
 public:
+    /*
+     * Constructor
+     */
+    GyroscopeMeasurementDynamics();
+
+    /*
+     * Destructor
+     */
+    virtual ~GyroscopeMeasurementDynamics();
+
     /**
      * Initialize the state dynamics.
      * @param paramHandler pointer to the parameters handler.
@@ -57,6 +71,7 @@ public:
      * |           `dynamic_model`          | `string` |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
      * |             `elements`             | `vector` |  Vector of strings describing the list of sub variables composing the state associated to this dynamics.|    No     |
      * |             `use_bias`             |`boolean` |     Boolean saying if the dynamics depends on a bias. False if not specified.                           |    No     |
+     * |                `dT`                | `double` |                                Sampling time.                                                           |    Yes    |
      * @return True in case of success, false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
@@ -77,6 +92,12 @@ public:
     bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
 
     /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    bool checkStateVariableHandler() override;
+
+    /**
      * Update the content of the element.
      * @return True in case of success, false otherwise.
      */
@@ -86,20 +107,20 @@ public:
      * Set the state of the ukf needed to update the dynamics.
      * @param ukfState reference to the ukf state.
      */
-     void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+    void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
 
-     /**
+    /**
       * Set a `UKFInput` object.
       * @param ukfInput reference to the UKFInput struct.
       */
-      void setInput(const UKFInput & ukfInput) override;
+    void setInput(const UKFInput & ukfInput) override;
 
-}; // class ZeroVelocityDynamics
+}; // class GyroscopeMeasurementDynamics
 
-BLF_REGISTER_DYNAMICS(ZeroVelocityDynamics, ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+BLF_REGISTER_DYNAMICS(GyroscopeMeasurementDynamics, ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
 
 } // namespace RobotDynamicsEstimator
 } // namespace Estimators
 } // namespace BipedalLocomotion
 
-#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_ZERO_VELOCITY_DYNAMICS_H
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_ACCELEROMETER_MEASUREMENT_DYNAMICS_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/JointVelocityStateDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/JointVelocityStateDynamics.h
@@ -1,0 +1,123 @@
+/**
+ * @file JointVelocityStateDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_JOINT_VELOCITY_STATE_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_JOINT_VELOCITY_STATE_DYNAMICS_H
+
+#include <memory>
+#include <map>
+
+#include <BipedalLocomotion/Math/Wrench.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelDynamics.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The JointVelocityDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element if you want to use the robot dynaic model to update the joint dynamics.
+ * The JointVelocityDynamics represents the following equation in the continuous time:
+ * \f[
+ * \ddot{s} = H^{-1} [\tau_{m} - \tau_{F} + (\sum J^T_{FT} f_{FT}) +
+ * + (\sum J^T_{ext} f_{ext})   - F^T {}^B \dot v  - h ]
+ * \f]
+ */
+
+class JointVelocityStateDynamics : public Dynamics
+{
+    int m_nrOfSubDynamics; /**< Number of sub-dynamics which corresponds to the number of sub-models. */
+    std::vector<std::unique_ptr<SubModelDynamics>> m_subDynamics; /**< Vector of SubModelInversDynamics objects. */
+    double m_dT; /**< Sampling time. */
+    bool m_isSubModelListSet{false}; /**< Boolean flag saying if the sub-model list has been set. */
+    Eigen::VectorXd m_jointVelocityFullModel; /**< Joint velocities of full-model. */
+    Eigen::VectorXd m_motorTorqueFullModel; /**< Motor torque vector of full-model. */
+    Eigen::VectorXd m_frictionTorqueFullModel; /**< Friction torque vector of full-model. */
+    std::vector<Eigen::VectorXd> m_subModelUpdatedJointVelocity; /**< Updated joint velocity of each sub-model. */
+    Eigen::VectorXd m_jointAccelerationFullModel; /**< Vector of joint accelerations. */
+    std::vector<Eigen::VectorXd> m_subModelUpdatedJointAcceleration; /**< Updated joint acceleration of each sub-model. */
+
+public:
+    /*
+     * Constructor
+     */
+    JointVelocityStateDynamics();
+
+    /*
+     * Destructor
+     */
+    virtual ~JointVelocityStateDynamics();
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param kinDynWrapper pointer to a SubModelKinDynWrapper object.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+     * Initialize the state dynamics.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               | `string` |   Name of the state contained in the `VariablesHandler` describing the state associated to this dynamics|    Yes    |
+     * |            `covariance`            | `vector` |                                Process covariances                                                      |    Yes    |
+     * |           `dynamic_model`          | `string` |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
+     * |             `elements`             | `vector` |  Vector of strings describing the list of sub variables composing the state associated to this dynamics.|    No     |
+     * |                `dT`                | `double` |                                Sampling time.                                                           |    Yes    |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param stateVariableHandler object describing the variables in the state vector.
+     * @note You should call this method after you add ALL the state dynamics to the state variable handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& stateVariableHandler) override;
+
+    /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    bool checkStateVariableHandler() override;
+
+    /**
+     * Update the state.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics.
+     * @param ukfState reference to the ukf state.
+     */
+     void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+     /**
+      * Set a `UKFInput` object.
+      * @param ukfInput reference to the UKFInput struct.
+      */
+      void setInput(const UKFInput & ukfInput) override;
+
+};
+
+BLF_REGISTER_DYNAMICS(JointVelocityStateDynamics, ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_JOINT_VELOCITY_STATE_DYNAMICS_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/MotorCurrentMeasurementDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/MotorCurrentMeasurementDynamics.h
@@ -1,0 +1,117 @@
+/**
+ * @file MotorCurrentMeasurementDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_MOTOR_CURRENT_MEASUREMENT_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_MOTOR_CURRENT_MEASUREMENT_DYNAMICS_H
+
+#include <memory>
+
+// Eigen
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The MotorCurrentMeasurementDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element to define the measurement of the motor current.
+ * The MotorCurrentMeasurementDynamics represents the following equation in the continuous time:
+ * \f[
+ * \dot{i_{m}} = \tau_{m} / (k_{\tau} r)
+ * \f]
+ */
+
+class MotorCurrentMeasurementDynamics : public Dynamics
+{
+protected:
+    Eigen::VectorXd m_motorTorque; /**< Vector of joint velocities. */
+    Eigen::VectorXd m_currentFrictionTorque; /**< Vector of friction torques. */
+    Eigen::VectorXd m_kTau; /**< Torque constant. */
+    Eigen::VectorXd m_gearRatio; /**< Gearbox reduction ratio. */
+
+public:
+    /*
+     * Constructor
+     */
+    MotorCurrentMeasurementDynamics();
+
+    /*
+     * Destructor
+     */
+    virtual ~MotorCurrentMeasurementDynamics();
+
+    /**
+     * Initialize the measurement object.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               | `string` |Name of the measurement variable contained in the `VariablesHandler` describing this dynamics            |    Yes    |
+     * |            `covariance`            | `vector` |                                Process covariances                                                      |    Yes    |
+     * |           `dynamic_model`          | `string` |               Type of dynamic model describing the measurement dynamics.                                |    Yes    |
+     * |             `elements`             | `vector` |Vector of strings describing the list of variables composing the measurement dynamics.                   |    No     |
+     * |          `torque_constant`         | `vector` |  Vector of coefficients k0. For more info check the class description.                                  |    Yes    |
+     * |            `gear_ratio`            | `vector` |  Vector of coefficients k1. For more info check the class description.                                  |    Yes    |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param measurementVariableHandler object describing the variables in the measurement vector.
+     * @note You should call this method after you add ALL the measurement dynamics to the measurement variable handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& measurementVariableHandler) override;
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param kinDynWrapper pointer to a SubModelKinDynWrapper object.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    bool checkStateVariableHandler() override;
+
+    /**
+     * Update the content of the element.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics.
+     * @param ukfState reference to the ukf state.
+     * @return true if the current state has been updated correctly.
+     */
+    void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+    /**
+     * Set a `UKFInput` object.
+     * @param ukfInput reference to the UKFInput struct.
+     */
+     void setInput(const UKFInput & ukfInput) override;
+
+};
+
+BLF_REGISTER_DYNAMICS(MotorCurrentMeasurementDynamics, ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_MOTOR_CURRENT_MEASUREMENT_DYNAMICS_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/SubModel.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/SubModel.h
@@ -147,24 +147,70 @@ public:
 
     /**
      * @brief Access an element of the force/torque sensor list.
+     * @param index is the index of the force/torque sensor in the submodel
      * @return FT object associated with the specified index.
      */
     const FT& getFTSensor(const int index) const;
 
     /**
+     * @brief Access an element of the force/torque sensor list.
+     * @param is the name of the force/torque sensor.
+     * @return FT object associated with the specified name.
+     */
+    const FT& getFTSensor(const std::string name) const;
+
+    /**
+     * @brief hasFTSensor check if the force/torque sensor is part of the sub-model
+     * @param name is the name of the ft sensor
+     * @return true if the sensor is found, false otherwise
+     */
+    bool hasFTSensor(const std::string name) const;
+
+    /**
      * @brief Access an element of the accelerometer list.
+     * @param index is the index of the accelerometer in the submodel
      * @return a Sensor object corresponding to the accelerometer associated with the specified index.
      */
     const Sensor& getAccelerometer(const int index) const;
 
     /**
+     * @brief Access an element of the accelerometer list.
+     * @param is the name of the accelerometer.
+     * @return a Sensor object corresponding to the accelerometer associated with the specified name.
+     */
+    const Sensor& getAccelerometer(const std::string name) const;
+
+    /**
+     * @brief hasAccelerometer check if the accelerometer is part of the sub-model
+     * @param name is the name of the accelerometer
+     * @return true if the sensor is found, false otherwise
+     */
+    bool hasAccelerometer(const std::string name) const;
+
+    /**
      * @brief Access an element of the gyroscope list.
+     * @param index is the index of the gyroscope in the submodel
      * @return a Sensor object corresponding to the gyroscope associated with the specified index.
      */
     const Sensor& getGyroscope(const int index) const;
 
     /**
+     * @brief Access an element of the gyroscope list.
+     * @param is the name of the gyroscoper.
+     * @return a Sensor object corresponding to the gyroscope associated with the specified name.
+     */
+    const Sensor& getGyroscope(const std::string name) const;
+
+    /**
+     * @brief hasAccelerometer check if the gyroscope is part of the sub-model
+     * @param name is the name of the gyroscope
+     * @return true if the sensor is found, false otherwise
+     */
+    bool hasGyroscope(const std::string name) const;
+
+    /**
      * @brief access an element of the contact frame list.
+     * @param index is the index of the external contact in the submodel.
      * @return a string corresponding to the external contact frame associated with the specified index.
      */
     const std::string& getExternalContact(const int index) const;

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/SubModelDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/SubModelDynamics.h
@@ -1,0 +1,114 @@
+/**
+ * @file SubModelDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SUB_MODEL_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_SUB_MODEL_DYNAMICS_H
+
+#include <memory>
+#include <string>
+#include <map>
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/Math/Wrench.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+struct SubModelDynamics
+{
+    std::shared_ptr<SubModelKinDynWrapper> kinDynWrapper; /**< object containing the kinematics and dynamics properties of a sub-model. */
+    SubModel subModel; /**< Sub-model object storing information about the model (joints, sensors, applied wrenches) */
+    std::map<std::string, Math::Wrenchd> FTMap; /**< The map contains names of the ft sensors and values of the wrench */
+    std::map<std::string, Math::Wrenchd> extContactMap; /**< The map contains names of the ft sensors and values of the wrench */
+    manif::SE3d::Tangent baseAcceleration; /**< Velocity of the base of the sub-model. */
+    Eigen::VectorXd motorTorque; /**< Motor torque vector of sub-model. */
+    Eigen::VectorXd frictionTorque; /**< Friction torque vector of sub-model. */
+    Eigen::VectorXd jointVelocity; /**< Joint velocities of sub-model. */
+    Eigen::VectorXd totalTorqueFromContacts; /**< Joint torques due to known and unknown contacts on the sub-model. */
+    Math::Wrenchd wrench; /**< Joint torques due to a specific contact. */
+    Eigen::VectorXd torqueFromContact; /**< Joint torques due to a specific contact. */
+
+    /*
+     * Constructor
+     */
+    SubModelDynamics();
+
+    /*
+     * Destructor
+     */
+    virtual ~SubModelDynamics();
+
+    /**
+     * @brief Set the SubModelKinDynWrapper object.
+     * @param kinDynWrapper pointer to a SubModelKinDynWrapper object.
+     * @return true in case of success, false otherwise.
+     */
+    bool setKinDynWrapper(std::shared_ptr<SubModelKinDynWrapper> kinDynWrapper);
+
+    /**
+     * @brief Set the SubModel object.
+     * @param subModel pointer to a SubModel object.
+     * @return true in case of success, false otherwise.
+     */
+    bool setSubModel(const SubModel& subModel);
+
+    /**
+     * @brief Initialize the SubDynamics.
+     * @return true in case of success, false otherwise.
+     */
+    bool initialize();
+
+    /**
+     * @brief setState set the state of the variables used to compute the inverse dynamics.
+     * @param ukfState an Eigen::Vector representing the state computed by the ukf estimator.
+     * @param jointVelocityFullModel `Eigen::Vector` representing the velocity of the robot joints.
+     * @param motorTorqueFullModel `Eigen::Vector` representing the torque of the robot motors.
+     * @param frictionTorqueFullModel `Eigen::Vector` representing the friction torque at the robot motors.
+     * @param variableHandler handler of the state of the ukf.
+     */
+    void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState,
+                  const Eigen::Ref<const Eigen::VectorXd> jointVelocityFullModel,
+                  const Eigen::Ref<const Eigen::VectorXd> motorTorqueFullModel,
+                  const Eigen::Ref<const Eigen::VectorXd> frictionTorqueFullModel,
+                  const System::VariablesHandler& variableHandler);
+
+    /**
+     * @brief update computes the joint accelerations given by the forward dynamics and the joint velocities given
+     * by the numerical integration of the joint accelerations.
+     * @param fullModelBaseAcceleration is a `manif::SE3d::Tangent` representing the acceleration of the base of the full model.
+     * @param fullModelJointAcceleration is a `Eigen::VectorXd` representing the acceleration of the joints of the full model.
+     * @param updatedJointAcceleration is a `Eigen::VectorXd` representing the joint accelerations of the sub-model.
+     * @return true in case of success, false otherwise.
+     * @note this method computes the joint acceleration of the sub-model, but it requires the joint acceleration of the full model.
+     * Actually the only joint accelerations needed to compute the ones of this sub-model are the joint accelerations
+     * of the previous sub-models as they are used to compute the acceleration of the base of this sub-model. The rest of the joint
+     * accelerations, which are computed here, can be set to zero as those values are not used.
+     */
+    bool update(manif::SE3d::Tangent& fullModelBaseAcceleration,
+                Eigen::Ref<const Eigen::VectorXd> fullModelJointAcceleration,
+                Eigen::Ref<Eigen::VectorXd> updatedJointAcceleration);
+
+    /**
+     * @brief Compute the contribution of external contacts on the joint torques.
+     */
+    void computeTotalTorqueFromContacts();
+};
+
+} // RobotDynamicsEstimator
+} // Estimators
+} // BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SUB_MODEL_DYNAMICS_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/UkfMeasurement.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/UkfMeasurement.h
@@ -1,0 +1,240 @@
+/**
+ * @file UkfMeasurement.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_UKF_MEASUREMENT_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_UKF_MEASUREMENT_H
+
+#include <memory>
+#include <string>
+#include <Eigen/Dense>
+
+// BayesFilters
+#include <BayesFilters/AdditiveMeasurementModel.h>
+
+// BLF
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/System/Source.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * UkfMeasurement is a concrete class that represents the Measurement of the estimator.
+ * The user should build the dynamic model of the measurement, setting a variable handler
+ * describing the variables composing the measurement vector, the list of the dynamic models
+ * associated to each variable, and the matrix of covariances associated to the variable in the
+ * measurement vector. The user should set also a ukf input provider
+ * which provides the inputs needed to update the dynamics.
+ */
+
+class UkfMeasurement : public bfl::AdditiveMeasurementModel
+{
+    /**
+     * Private implementation
+     */
+    struct Impl;
+    std::unique_ptr<Impl> m_pimpl;
+
+public:
+    /**
+     * Constructor.
+     */
+    UkfMeasurement();
+
+    /**
+     * Destructor.
+     */
+    virtual ~UkfMeasurement();
+
+    /**
+     * Build the ukf measurement model
+     * @param kinDyn a pointer to an iDynTree::KinDynComputations object that will be shared among
+     * all the dynamics.
+     * @param subModelList a vector of SubModel objects.
+     * @param kinDynWrapperList a vector of pointers to SubModelKinDynWrapper objects
+     * @param handler pointer to the IParametersHandler interface.
+     * @param stateVariableHandler a variable handler describing the variables in the state vector of the ukf.
+     * @note the following parameters are required by the class
+     * |         Parameter Name         |       Type      |                                           Description                                          | Mandatory |
+     * |:------------------------------:|:---------------:|:----------------------------------------------------------------------------------------------:|:---------:|
+     * |         `sampling_time`        |     `double`    |                                      Sampling time.                                            |    Yes    |
+     * |         `dynamics_list`        |`vector<string>` |                          List of dynamics composing the measurement model.                           |    Yes    |
+     * For **each** dynamics listed in the parameter `dynamics_list` the user must specified all the parameters
+     * required by the dynamics itself but `dT` since is already specified in the parent group.
+     * Moreover the following parameters are required for each dynamics.
+     * |     Group     |         Parameter Name         |         Type         |                                           Description                                          | Mandatory |
+     * |:-------------:|:------------------------------:|:--------------------:|:----------------------------------------------------------------------------------------------:|:---------:|
+     * |`DYNAMICS_NAME`|             `name`             |        `string`      |                               String representing the name of the dynamics.                    |    Yes    |
+     * |`DYNAMICS_NAME`|           `elements`           |`std::vector<string>` |  Vector of strings representing the elements composing the specific dynamics.                  |    No     |
+     * |`DYNAMICS_NAME`|          `covariance`          |`std::vector<double>` |             Vector of double containing the covariance associated to each element.             |    Yes    |
+     * |`DYNAMICS_NAME`|         `dynamic_model`        |        `string`      |  String representing the type of dynamics. The string should match the name of the C++ class.  |    Yes    |
+     * |`DYNAMICS_NAME`|            `use_bias`          |       `boolean`      |               Boolean saying if an additive bias must be used in the dynamic model.            |    No     |
+     * |`DYNAMICS_NAME`|            `use_bias`          |       `boolean`      |               Boolean saying if an additive bias must be used in the dynamic model.            |    No     |
+     * `DYNAMICS_NAME` is a placeholder for the name of the dynamics contained in the `dynamics_list` list.
+     * `name` can contain only the following values ("ds", "i_m", "*_ft_sensor", "*_ft_acc", "*_ft_gyro").
+     * @note The following `ini` file presents an example of the configuration that can be used to
+     * build the UkfMeasurement.
+     *
+     * UkfMeasurement.ini
+     *
+     * dynamics_list                   ("JOINT_VELOCITY", "MOTOR_CURRENT", "RIGHT_LEG_FT", "RIGHT_FOOT_REAR_GYRO")
+     *
+     * [JOINT_VELOCITY]
+     * name                            "ds"
+     * elements                        ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
+     * covariance                      (1e-3, 1e-3, 1e-3, 1e-3, 1e-3, 1e-3)
+     * dynamic_model                   "JointVelocityDynamics"
+     *
+     * [FRICTION_TORQUE]
+     * name                            "tau_F"
+     * elements                        ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
+     * covariance                      (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-1)
+     * dynamic_model                   "FrictionTorqueDynamics"
+     * friction_k0                     (9.106, 5.03, 4.93, 12.88, 14.34, 1.12)
+     * friction_k1                     (200.0, 6.9, 200.0, 59.87, 200.0, 200.0)
+     * friction_k2                     (1.767, 5.64, 0.27, 2.0, 3.0, 0.0)
+     *
+     * [RIGHT_LEG_FT]
+     * name                            "r_leg_ft_sensor"
+     * elements                        ("fx", "fy", "fz", "mx", "my", "mz")
+     * covariance                      (1e-3, 1e-3, 1e-3, 1e-4, 1e-4, 1e-4)
+     * dynamic_model                   "ZeroVelocityDynamics"
+     *
+     * [RIGHT_FOOT_REAR_GYRO_BIAS]
+     * name                            "r_foot_rear_ft_gyro_bias"
+     * elements                        ("x", "y", "z")
+     * covariance                      (8.2e-8, 1e-2, 9.3e-3)
+     * dynamic_model                   "ZeroVelocityDynamics"
+     *
+     * ~~~~~
+     * @return a std::unique_ptr to the UkfMeasurement.
+     * In case of issues, an empty BipedalLocomotion::System::VariablesHandler
+     * and an invalid pointer will be returned.
+     */
+    static std::unique_ptr<UkfMeasurement> build(std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
+                                                 System::VariablesHandler& stateVariableHandler,
+                                                 std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                                                 const std::vector<SubModel>& subModelList,
+                                                 const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList);
+
+    /**
+     * Initialize the ukf measurement model.
+     * @param handler pointer to the IParametersHandler interface.
+     * @note the following parameters are required by the class
+     * |         Parameter Name         |       Type      |                                       Description                                              | Mandatory |
+     * |:------------------------------:|:---------------:|:----------------------------------------------------------------------------------------------:|:---------:|
+     * |       `sampling_time`          |     `double`    |                                      Sampling time.                                            |    Yes    |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
+
+    /**
+     * Finalize the UkfMeasurement.
+     * @param handler variable handler.
+     * @note You should call this method after you initialize the UkfMeasurement.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& handler);
+
+    /**
+     * @brief setUkfInputProvider set the provider for the ukf input.
+     * @param ukfInputProvider a pointer to a structure containing the joint positions and the robot base pose, velocity and acceleration.
+     */
+    void setUkfInputProvider(std::shared_ptr<const UkfInputProvider> ukfInputProvider);
+
+    /**
+     * @brief getMeasurementVariableHandler access the `System::VariablesHandler` instance created during the initialization phase.
+     * @return the measurement variable handler containing all the measurement variables and their sizes and offsets.
+     */
+    System::VariablesHandler getMeasurementVariableHandler();
+
+    /**
+     * @brief predictedMeasure predict the new measurement depending on the state computed by the predict step.
+     * @param cur_states is the state computed by the prediction phase.
+     * @return a std::pair<bool, bfl::Data> where the bool value says if the measurement
+     * prediciton is done correctly and the bfl::Data is the predicted measure.
+     */
+    std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXd>& cur_states) const override;
+
+    /**
+     * @brief getNoiseCovarianceMatrix access the `Eigen::MatrixXd` representing the process covariance matrix.
+     * @return a boolean value and the measurement noise covariance matrix.
+     */
+    std::pair<bool, Eigen::MatrixXd> getNoiseCovarianceMatrix() const override;
+
+    /**
+     * @brief setProperty is not implemented.
+     * @param property is a string.
+     * @return false as it is not implemented.
+     */
+    bool setProperty(const std::string& property) override { return false; };
+
+    /**
+     * @brief getMeasurementDescription access the `bfl::VectorDescription`.
+     * @return the measurement vector description.
+     */
+    bfl::VectorDescription getMeasurementDescription() const override;
+
+    /**
+     * @brief getInputDescription access the `bfl::VectorDescription`.
+     * @return the input vector description.
+     */
+    bfl::VectorDescription getInputDescription() const override;
+
+    /**
+     * @brief getMeasurementSize access the length of the measurement vector
+     * @return the length of measurement vector
+     */
+    std::size_t getMeasurementSize();
+
+    /**
+     * Set a `System::VariableHandler` describing the variables composing the state.
+     * @param stateVariableHandler is the variable handler
+     */
+    void setStateVariableHandler(System::VariablesHandler stateVariableHandler) const;
+
+    /**
+     * @brief innovation computes the innovation step of the ukf update as the difference between the predicted_measurement
+     * and the measurement.
+     * @param predicted_measurements is a `blf::Data` reference representing the measurement predicted in the update step.
+     * @param measurements is a `blf::Data` reference representing the measurements coming from the user.
+     * @return a `std::pair<bool, bfl::Data>` where the boolean value is always true and the `bfl::Data` is the innovation term.
+     */
+    std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const override;
+
+    /**
+     * @brief measure get the updated measurement.
+     * @param data is a `const blf::Data` reference and is optional parameter.
+     * @return a pair of a boolean value which is always true and the measurements.
+     */
+    std::pair<bool, bfl::Data> measure(const bfl::Data& data = bfl::Data()) const override;
+
+    /**
+     * @brief freeze update the measurement using data from sensors.
+     * @param data is a generic object representing data coming from sensors.
+     * @return true.
+     * @note data in this case must be a `std::map<std::string, Eigen::VectorXd>` where
+     * the first element represents the name of each measurement dynamics
+     * and the second element is the vector containing the measurement
+     * of the sensor associated to that variable.
+     */
+    bool freeze(const bfl::Data& data = bfl::Data()) override;
+
+}; // classUkfMeasurement
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_UKF_MEASUREMENT_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/UkfState.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/UkfState.h
@@ -1,0 +1,196 @@
+/**
+ * @file UkfState.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_UKF_STATE_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_UKF_STATE_H
+
+#include <memory>
+#include <string>
+#include <Eigen/Dense>
+
+// BayesFilters
+#include <BayesFilters/AdditiveStateModel.h>
+
+// BLF
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * UkfState is a concrete class that represents the State of the estimator.
+ * The user should build the dynamic model of the state setting a variable handler
+ * describing the variables composing the state, the list of the dynamic model associated
+ * to each variable in the variable handler, and the matrix of covariances
+ * associated to the state. The user should set also a ukf input provider
+ * which provides the inputs needed to update the dynamics.
+ */
+class UkfState : public bfl::AdditiveStateModel
+{
+    /**
+     * Private implementation
+     */
+    struct Impl;
+    std::unique_ptr<Impl> m_pimpl;
+
+public:
+    /**
+     * Constructor.
+     */
+    UkfState();
+
+    /**
+     * Destructor.
+     */
+    virtual ~UkfState();
+
+    /**
+     * Build the ukf state model
+     * @param kinDyn a pointer to an iDynTree::KinDynComputations object that will be shared among
+     * all the dynamics.
+     * @param subModelList a vector of pairs (SubModel, SubModelKinDynWrapper) that will be shared among all the dynamics.
+     * @param handler pointer to the IParametersHandler interface.
+     * @note the following parameters are required by the class
+     * |         Parameter Name         |       Type      |                                           Description                                          | Mandatory |
+     * |:------------------------------:|:---------------:|:----------------------------------------------------------------------------------------------:|:---------:|
+     * |              `dT`              |     `double`    |                                      Sampling time.                                            |    Yes    |
+     * |         `dynamics_list`        |`vector<string>` |                          List of dynamics composing the state model.                           |    Yes    |
+     * For **each** dynamics listed in the parameter `dynamics_list` the user must specified all the parameters
+     * required by the dynamics itself but `dT` since is already specified in the parent group.
+     * Moreover the following parameters are required for each dynamics.
+     * |     Group     |         Parameter Name         |         Type         |                                           Description                                          | Mandatory |
+     * |:-------------:|:------------------------------:|:--------------------:|:----------------------------------------------------------------------------------------------:|:---------:|
+     * |`DYNAMICS_NAME`|             `name`             |        `string`      |                               String representing the name of the dynamics.                    |    Yes    |
+     * |`DYNAMICS_NAME`|           `elements`           |`std::vector<string>` |  Vector of strings representing the elements composing the specific dynamics.                  |    No     |
+     * |`DYNAMICS_NAME`|          `covariance`          |`std::vector<double>` |             Vector of double containing the covariance associated to each element.             |    Yes    |
+     * |`DYNAMICS_NAME`|         `dynamic_model`        |        `string`      |  String representing the type of dynamics. The string should match the name of the C++ class.  |    Yes    |
+     * |`DYNAMICS_NAME`|          `friction_k0`         |`std::vector<double>` | Vector of double containing the coefficient k0 of the friction model of each element.          |    No     |
+     * |`DYNAMICS_NAME`|          `friction_k1`         |`std::vector<double>` | Vector of double containing the coefficient k1 of the friction model of each element.          |    No     |
+     * |`DYNAMICS_NAME`|          `friction_k2`         |`std::vector<double>` | Vector of double containing the coefficient k2 of the friction model of each element.          |    No     |
+     * `DYNAMICS_NAME` is a placeholder for the name of the dynamics contained in the `dynamics_list` list.
+     * `name` can contain only the following values ("ds", "tau_m", "tau_F", "*_ft_sensor", "*_ft_sensor_bias", "*_ft_acc_bias", "*_ftgyro_bias").
+     * @note The following `ini` file presents an example of the configuration that can be used to
+     * build the UkfState.
+     *
+     * UkfState.ini
+     *
+     * dynamics_list                   ("JOINT_VELOCITY", "FRICTION_TORQUE", "RIGHT_LEG_FT", "RIGHT_FOOT_REAR_GYRO_BIAS")
+     *
+     * [JOINT_VELOCITY]
+     * name                            "ds"
+     * elements                        ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
+     * covariance                      (1e-3, 1e-3, 1e-3, 1e-3, 1e-3, 1e-3)
+     * dynamic_model                   "JointVelocityDynamics"
+     *
+     * [FRICTION_TORQUE]
+     * name                            "tau_F"
+     * elements                        ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
+     * covariance                      (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-1)
+     * dynamic_model                   "FrictionTorqueDynamics"
+     * friction_k0                     (9.106, 5.03, 4.93, 12.88, 14.34, 1.12)
+     * friction_k1                     (200.0, 6.9, 200.0, 59.87, 200.0, 200.0)
+     * friction_k2                     (1.767, 5.64, 0.27, 2.0, 3.0, 0.0)
+     *
+     * [RIGHT_LEG_FT]
+     * name                            "r_leg_ft_sensor"
+     * elements                        ("fx", "fy", "fz", "mx", "my", "mz")
+     * covariance                      (1e-3, 1e-3, 1e-3, 1e-4, 1e-4, 1e-4)
+     * dynamic_model                   "ZeroVelocityDynamics"
+     *
+     * [RIGHT_FOOT_REAR_GYRO_BIAS]
+     * name                            "r_foot_rear_ft_gyro_bias"
+     * elements                        ("x", "y", "z")
+     * covariance                      (8.2e-8, 1e-2, 9.3e-3)
+     * dynamic_model                   "ZeroVelocityDynamics"
+     *
+     * ~~~~~
+     * @return a std::unique_ptr to the UkfState.
+     * In case of issues, an empty BipedalLocomotion::System::VariablesHandler
+     * and an invalid pointer will be returned.
+     */
+    static std::unique_ptr<UkfState> build(std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
+                                           std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                                           const std::vector<SubModel>& subModelList,
+                                           const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList);
+
+    /**
+     * Initialize the ukf state model.
+     * @param handler pointer to the IParametersHandler interface.
+     * @note the following parameters are required by the class
+     * |         Parameter Name         |       Type      |                                       Description                                              | Mandatory |
+     * |:------------------------------:|:---------------:|:----------------------------------------------------------------------------------------------:|:---------:|
+     * |              `dT`              |     `double`    |                                      Sampling time.                                            |    Yes    |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
+
+    /**
+     * Finalize the UkfState.
+     * @param handler variable handler.
+     * @note You should call this method after you initialize the UkfState.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& handler);
+
+    /**
+     * @brief setUkfInputProvider set the provider for the ukf input.
+     * @param ukfInputProvider a pointer to a structure containing the joint positions and the robot base pose, velocity and acceleration.
+     */
+    void setUkfInputProvider(std::shared_ptr<const UkfInputProvider> ukfInputProvider);
+
+    /**
+     * @brief getStateVariableHandler access the `System::VariablesHandler` instance created during the initialization phase.
+     * @return the state variable handler containing all the state variables and their sizes and offsets.
+     */
+    System::VariablesHandler getStateVariableHandler();
+
+    /**
+     * @brief propagate implements the predict of the ukf
+     * @param cur_states is the state computed at the previous step
+     * @param prop_states is the predicted state
+     */
+    void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) override;
+
+    /**
+     * @brief getNoiseCovarianceMatrix access the `Eigen::MatrixXd` representing the process covariance matrix.
+     * @return the process noise covariance matrix.
+     */
+    Eigen::MatrixXd getNoiseCovarianceMatrix() override;
+
+    /**
+     * @brief setProperty is not implemented.
+     * @param property is a string.
+     * @return false as it is not implemented.
+     */
+    bool setProperty(const std::string& property) override { return false; };
+
+    /**
+     * @brief getStateDescription access the `bfl::VectorDescription`.
+     * @return the state vector description.
+     */
+    bfl::VectorDescription getStateDescription() override;
+
+    /**
+     * @brief getStateSize access the length of the state vector
+     * @return the length of state vector
+     */
+    std::size_t getStateSize();
+
+}; // class UKFModel
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_UKF_STATE_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityDynamics.h
@@ -1,0 +1,105 @@
+/**
+ * @file ZeroVelocityDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_ZERO_VELOCITY_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_ZERO_VELOCITY_DYNAMICS_H
+
+#include <memory>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The ZeroVelocityDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element if you do not know the specific dynamics of a state variable.
+ * The ZeroVelocityDynamics represents the following equation in the continuous time:
+ * \f[
+ * \dot{x} = 0
+ * \f]
+ * In the discrete time the following dynamics assigns the current state to the next state:
+ * \f[
+ * x_{k+1} = x_{k}
+ * \f]
+ */
+
+class ZeroVelocityDynamics : public Dynamics
+{
+protected:
+    Eigen::VectorXd m_currentState; /**< Current state. */
+    bool m_useBias{false}; /**< If true the dynamics depends on a bias additively. */
+    Eigen::VectorXd m_bias; /**< The bias is initialized and used only if m_useBias is true. False if not specified. */
+    std::string m_biasVariableName; /**< Name of the variable containing the bias in the variable handler. */
+
+    /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    bool checkStateVariableHandler() override;
+
+public:
+    /**
+     * Initialize the state dynamics.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               | `string` |   Name of the state contained in the `VariablesHandler` describing the state associated to this dynamics|    Yes    |
+     * |            `covariance`            | `vector` |                                Process covariances                                                      |    Yes    |
+     * |           `dynamic_model`          | `string` |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
+     * |             `elements`             | `vector` |  Vector of strings describing the list of sub variables composing the state associated to this dynamics.|    No     |
+     * |               `bias`               |`boolean` |     Boolean saying if the dynamics depends on a bias. False if not specified.                           |    No     |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param stateVariableHandler object describing the variables in the state vector.
+     * @note You should call this method after you add ALL the state dynamics to the state variable handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& stateVariableHandler) override;
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param kinDynWrapper pointer to a SubModelKinDynWrapper object.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+     * Update the content of the element.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics.
+     * @param ukfState reference to the ukf state.
+     */
+     void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+     /**
+      * Set a `UKFInput` object.
+      * @param ukfInput reference to the UKFInput struct.
+      */
+      void setInput(const UKFInput & ukfInput) override;
+
+}; // class ZeroVelocityDynamics
+
+BLF_REGISTER_DYNAMICS(ZeroVelocityDynamics, ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_ZERO_VELOCITY_DYNAMICS_H

--- a/src/Estimators/src/AccelerometerMeasurementDynamics.cpp
+++ b/src/Estimators/src/AccelerometerMeasurementDynamics.cpp
@@ -1,0 +1,338 @@
+/**
+ * @file AccelerometerMeasurementDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/AccelerometerMeasurementDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RDE::AccelerometerMeasurementDynamics::AccelerometerMeasurementDynamics() = default;
+
+RDE::AccelerometerMeasurementDynamics::~AccelerometerMeasurementDynamics() = default;
+
+bool RDE::AccelerometerMeasurementDynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[AccelerometerMeasurementDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covSingleVar))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the dynamic model type
+    if (!ptr->getParameter("dynamic_model", m_dynamicModel))
+    {
+        log()->error("{} Error while retrieving the dynamic_model variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->info("{} Variable elements not found.", errorPrefix);
+        m_elements = {};
+    }
+
+    if (!ptr->getParameter("sampling_time", m_dT))
+    {
+        log()->error("{} Error while retrieving the sampling_time variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the bias related variables if use_bias is true
+    if (!ptr->getParameter("use_bias", m_useBias))
+    {
+        log()->info("{} Variable use_bias not found. Set to false by default.", errorPrefix);
+    }
+    else
+    {
+        m_useBias = true;
+        m_biasVariableName = m_name + "_bias";
+    }
+
+    m_gravity.setZero();
+    m_gravity[2] = - BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+
+    m_JdotNu.resize(6);
+    m_JvdotBase.resize(6);
+    m_Jsdotdot.resize(6);
+
+    m_description = "Accelerometer measurement dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::AccelerometerMeasurementDynamics::finalize(const System::VariablesHandler &stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[AccelerometerMeasurementDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Search and save all the submodels containing the sensor
+    for (int submodelIndex = 0; submodelIndex < m_nrOfSubDynamics; submodelIndex++)
+    {
+       if (m_subDynamics[submodelIndex]->subModel.hasAccelerometer(m_name))
+       {
+            m_subModelsWithAcc.push_back(submodelIndex);
+       }
+    }
+
+    m_covariances.resize(m_covSingleVar.size() * m_subModelsWithAcc.size());
+    for (int index = 0; index < m_subModelsWithAcc.size(); index++)
+    {
+        m_covariances.segment(index*m_covSingleVar.size(), m_covSingleVar.size()) = m_covSingleVar;
+    }
+
+    m_size = m_covariances.size();
+
+    m_motorTorqueFullModel.resize(m_stateVariableHandler.getVariable("tau_m").size);
+    m_motorTorqueFullModel.setZero();
+
+    m_frictionTorqueFullModel.resize(m_stateVariableHandler.getVariable("tau_F").size);
+    m_frictionTorqueFullModel.setZero();
+
+    m_jointAccelerationFullModel.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_jointAccelerationFullModel.setZero();
+
+    m_jointVelocityFullModel.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_jointVelocityFullModel.setZero();
+
+    m_subModelJointAcc.resize(m_nrOfSubDynamics);
+
+    for (int idx = 0; idx < m_nrOfSubDynamics; idx++)
+    {
+        m_subModelJointAcc[idx].resize(m_subDynamics[idx]->subModel.getJointMapping().size());
+        m_subModelJointAcc[idx].setZero();
+    }
+
+    m_bias.resize(m_covSingleVar.size());
+    m_bias.setZero();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    return true;
+}
+
+bool RDE::AccelerometerMeasurementDynamics::setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    constexpr auto errorPrefix = "[AccelerometerMeasurementDynamics::setSubModels]";
+
+    for (int subModelIdx = 0; subModelIdx < subModelList.size(); subModelIdx++)
+    {
+        m_subDynamics.emplace_back(std::make_unique<RDE::SubModelDynamics>());
+
+        if(!m_subDynamics[subModelIdx]->setSubModel(subModelList[subModelIdx]))
+        {
+            log()->error("{} The submodel at index {} is not valid.", errorPrefix, subModelIdx);
+            return false;
+        }
+
+        if(!m_subDynamics[subModelIdx]->setKinDynWrapper(kinDynWrapperList[subModelIdx]))
+        {
+            log()->error("{} The submodel kindyn wrapper at index {} is not valid.", errorPrefix, subModelIdx);
+            return false;
+        }
+    }
+
+    m_nrOfSubDynamics = m_subDynamics.size();
+
+    m_isSubModelListSet = true;
+
+    for (int subModelIdx = 0; subModelIdx < m_nrOfSubDynamics; subModelIdx++)
+    {
+        if (!m_subDynamics.at(subModelIdx)->initialize())
+        {
+            log()->error("{} Cannot initialize the accelerometer measurement dynamics of the sub-model {}.", errorPrefix, subModelIdx);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool RDE::AccelerometerMeasurementDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[AccelerometerMeasurementDynamics::checkStateVariableHandler]";
+
+    if (!m_isSubModelListSet)
+    {
+        log()->error("{} Set the sub-model list before setting the variable handler", errorPrefix);
+        return false;
+    }
+
+    if (!m_stateVariableHandler.getVariable("tau_m").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `tau_m`.", errorPrefix);
+        return false;
+    }
+
+    // Check if the variable handler contains the variables used by this dynamics
+    if (!m_stateVariableHandler.getVariable("tau_F").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `tau_F`.", errorPrefix);
+        return false;
+    }
+
+    if (!m_stateVariableHandler.getVariable("ds").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `ds`.", errorPrefix);
+        return false;
+    }
+
+    if (m_useBias)
+    {
+        if (!m_stateVariableHandler.getVariable(m_biasVariableName).isValid())
+        {
+            log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_biasVariableName);
+            return false;
+        }
+    }
+
+    // check if all the sensors are part of the sub-model
+    for (int subModelIdx = 0; subModelIdx < m_nrOfSubDynamics; subModelIdx++)
+    {
+        for (int ftIdx = 0; ftIdx < m_subDynamics.at(subModelIdx)->subModel.getNrOfFTSensor(); ftIdx++)
+        {
+            if (!m_stateVariableHandler.getVariable(m_subDynamics.at(subModelIdx)->subModel.getFTSensor(ftIdx).name).isValid())
+            {
+                log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_subDynamics.at(subModelIdx)->subModel.getFTSensor(ftIdx).name);
+                return false;
+            }
+        }
+
+        for (int contactIdx = 0; contactIdx < m_subDynamics.at(subModelIdx)->subModel.getNrOfExternalContact(); contactIdx++)
+        {
+            if (!m_stateVariableHandler.getVariable(m_subDynamics.at(subModelIdx)->subModel.getExternalContact(contactIdx)).isValid())
+            {
+                log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_subDynamics.at(subModelIdx)->subModel.getExternalContact(contactIdx));
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool RDE::AccelerometerMeasurementDynamics::update()
+{
+    constexpr auto errorPrefix = "[AccelerometerMeasurementDynamics::update]";
+
+    // compute joint acceleration per each sub-model containing the accelerometer
+    for (int subDynamicsIdx = 0; subDynamicsIdx < m_subDynamics.size(); subDynamicsIdx++)
+    {
+        if (m_subDynamics[subDynamicsIdx]->subModel.getModel().getNrOfDOFs() > 0)
+        {
+            if (!m_subDynamics[subDynamicsIdx]->update(m_ukfInput.robotBaseAcceleration, m_jointAccelerationFullModel, m_subModelJointAcc[subDynamicsIdx]))
+            {
+                log()->error("{} Error updating the joint velocity dynamics for the sub-model {}.", errorPrefix, subDynamicsIdx);
+                return false;
+            }
+
+            for (int jointIdx = 0; jointIdx < m_subDynamics[subDynamicsIdx]->subModel.getJointMapping().size(); jointIdx++)
+            {
+                m_jointAccelerationFullModel[m_subDynamics[subDynamicsIdx]->subModel.getJointMapping()[jointIdx]] = m_subModelJointAcc[subDynamicsIdx][jointIdx];
+            }
+        }
+    }
+
+    // J_dot nu + base_J v_dot_base + joint_J s_dotdot - acc_Rot_world gravity + bias
+    for (int index = 0; index < m_subModelsWithAcc.size(); index++)
+    {
+        m_JdotNu = m_subDynamics[m_subModelsWithAcc[index]]->kinDynWrapper->getAccelerometerBiasAcceleration(m_name);
+
+        if (!m_subDynamics[m_subModelsWithAcc[index]]->kinDynWrapper->getBaseAcceleration(m_ukfInput.robotBaseAcceleration, m_jointAccelerationFullModel, m_subModelBaseAcc))
+        {
+            log()->error("{} Error getting the sub-model base acceleration.", errorPrefix);
+            return false;
+        }
+
+        m_JvdotBase = m_subDynamics[m_subModelsWithAcc[index]]->kinDynWrapper->getAccelerometerJacobian(m_name).block(0, 0, 6, 6) * m_subModelBaseAcc.coeffs();
+
+        m_accRg = m_subDynamics[m_subModelsWithAcc[index]]->kinDynWrapper->getAccelerometerRotation(m_name).rotation() * m_gravity;
+
+        m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size()) = m_JdotNu.segment(0, 3) + m_JvdotBase.segment(0, 3) - m_accRg + m_bias;
+
+        if (m_subDynamics[m_subModelsWithAcc[index]]->subModel.getJointMapping().size() > 0)
+        {
+            m_Jsdotdot = m_subDynamics[m_subModelsWithAcc[index]]->kinDynWrapper->getAccelerometerJacobian(m_name).block(0, 6, 6, m_subModelJointAcc[m_subModelsWithAcc[index]].size()) *
+                    m_subModelJointAcc[m_subModelsWithAcc[index]];
+
+            m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size()) += m_Jsdotdot.segment(0, 3);
+        }
+    }
+
+    return true;
+}
+
+void RDE::AccelerometerMeasurementDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_jointVelocityFullModel = ukfState.segment(m_stateVariableHandler.getVariable("ds").offset,
+                                                m_stateVariableHandler.getVariable("ds").size);
+
+    m_motorTorqueFullModel = ukfState.segment(m_stateVariableHandler.getVariable("tau_m").offset,
+                                              m_stateVariableHandler.getVariable("tau_m").size);
+
+    m_frictionTorqueFullModel = ukfState.segment(m_stateVariableHandler.getVariable("tau_F").offset,
+                                                 m_stateVariableHandler.getVariable("tau_F").size);
+
+    m_bias = ukfState.segment(m_stateVariableHandler.getVariable(m_biasVariableName).offset,
+                              m_stateVariableHandler.getVariable(m_biasVariableName).size);
+
+    for (int subDynamicsIdx = 0; subDynamicsIdx < m_subDynamics.size(); subDynamicsIdx++)
+    {
+        m_subDynamics.at(subDynamicsIdx)->setState(ukfState,
+                                                   m_jointVelocityFullModel,
+                                                   m_motorTorqueFullModel,
+                                                   m_frictionTorqueFullModel,
+                                                   m_stateVariableHandler);
+    }
+}
+
+void RDE::AccelerometerMeasurementDynamics::setInput(const UKFInput& ukfInput)
+{
+    m_ukfInput = ukfInput;
+}

--- a/src/Estimators/src/Dynamics.cpp
+++ b/src/Estimators/src/Dynamics.cpp
@@ -1,0 +1,74 @@
+/**
+ * @file Dynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::System;
+using namespace BipedalLocomotion::ParametersHandler;
+
+const RDE::UKFInput& RDE::UkfInputProvider::getOutput() const
+{
+    return m_ukfInput;
+}
+
+bool RDE::UkfInputProvider::advance()
+{
+    return true;
+}
+
+bool RDE::UkfInputProvider::setInput(const UKFInput& input)
+{
+    m_ukfInput = input;
+
+    return true;
+}
+
+bool RDE::UkfInputProvider::isOutputValid() const
+{
+    return m_ukfInput.robotJointPositions.size() != 0;
+}
+
+bool RDE::Dynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    return true;
+}
+
+bool RDE::Dynamics::finalize(const System::VariablesHandler& stateVariableHandler)
+{
+    return true;
+}
+
+bool RDE::Dynamics::setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    return true;
+}
+
+bool RDE::Dynamics::update()
+{
+    return true;
+}
+
+Eigen::Ref<const Eigen::VectorXd> RDE::Dynamics::getUpdatedVariable() const
+{
+    return m_updatedVariable;
+}
+
+int RDE::Dynamics::size() const
+{
+    return m_size;
+}
+
+Eigen::Ref<const Eigen::VectorXd> RDE::Dynamics::getCovariance()
+{
+    return m_covariances;
+}
+
+bool RDE::Dynamics::checkStateVariableHandler()
+{
+    return true;
+}

--- a/src/Estimators/src/FrictionTorqueStateDynamics.cpp
+++ b/src/Estimators/src/FrictionTorqueStateDynamics.cpp
@@ -1,0 +1,318 @@
+/**
+ * @file FrictionTorqueStateDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/FrictionTorqueStateDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RDE::FrictionTorqueStateDynamics::FrictionTorqueStateDynamics() = default;
+
+RDE::FrictionTorqueStateDynamics::~FrictionTorqueStateDynamics() = default;
+
+bool RDE::FrictionTorqueStateDynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[FrictionTorqueStateDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covariances))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the dynamic model type
+    if (!ptr->getParameter("dynamic_model", m_dynamicModel))
+    {
+        log()->error("{} Error while retrieving the dynamic_model variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->info("{} Variable elements not found.", errorPrefix);
+        m_elements = {};
+    }
+
+    // Set the friction parameters
+    if (!ptr->getParameter("friction_k0", m_k0))
+    {
+        log()->error("{} Error while retrieving the friction_k0 variable.", errorPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("friction_k1", m_k1))
+    {
+        log()->error("{} Error while retrieving the friction_k1 variable.", errorPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("friction_k2", m_k2))
+    {
+        log()->error("{} Error while retrieving the friction_k2 variable.", errorPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("sampling_time", m_dT))
+    {
+        log()->error("{} Error while retrieving the sampling_time variable.", errorPrefix);
+        return false;
+    }
+
+    m_description = "Friction torque state dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::FrictionTorqueStateDynamics::finalize(const System::VariablesHandler &stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[FrictionTorqueStateDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    m_size = m_covariances.size();
+
+    m_motorTorqueFullModel.resize(m_stateVariableHandler.getVariable("tau_m").size);
+    m_motorTorqueFullModel.setZero();
+
+    m_frictionTorqueFullModel.resize(m_stateVariableHandler.getVariable("tau_F").size);
+    m_frictionTorqueFullModel.setZero();
+
+    m_jointAccelerationFullModel.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_jointAccelerationFullModel.setZero();
+
+    m_jointVelocityFullModel.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_jointVelocityFullModel.setZero();
+
+    m_subModelUpdatedJointAcceleration.resize(m_nrOfSubDynamics);
+
+    for (int idx = 0; idx < m_nrOfSubDynamics; idx++)
+    {
+        m_subModelUpdatedJointAcceleration[idx].resize(m_subDynamics[idx]->subModel.getJointMapping().size());
+        m_subModelUpdatedJointAcceleration[idx].setZero();
+    }
+
+    m_currentFrictionTorque.resize(m_size);
+    m_currentFrictionTorque.setZero();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    m_tanhArgument.resize(m_size);
+    m_tanhArgument.setZero();
+
+    m_tanh.resize(m_size);
+    m_tanh.setZero();
+
+    m_k0k1.resize(m_size);
+    m_k0k1.setZero();
+
+    m_argParenthesis.resize(m_size);
+    m_argParenthesis.setZero();
+
+    m_dotTauF.resize(m_size);
+    m_dotTauF.setZero();
+
+    return true;
+}
+
+bool RDE::FrictionTorqueStateDynamics::setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    constexpr auto errorPrefix = "[FrictionTorqueStateDynamics::setSubModels]";
+
+    for (int subModelIdx = 0; subModelIdx < subModelList.size(); subModelIdx++)
+    {
+        if (subModelList[subModelIdx].getModel().getNrOfDOFs() > 0)
+        {
+            m_subDynamics.emplace_back(std::make_unique<RDE::SubModelDynamics>());
+
+            if(!m_subDynamics[subModelIdx]->setSubModel(subModelList[subModelIdx]))
+            {
+                log()->error("{} The submodel at index {} is not valid.", errorPrefix, subModelIdx);
+                return false;
+            }
+
+            if(!m_subDynamics[subModelIdx]->setKinDynWrapper(kinDynWrapperList[subModelIdx]))
+            {
+                log()->error("{} The submodel kindyn wrapper at index {} is not valid.", errorPrefix, subModelIdx);
+                return false;
+            }
+        }
+    }
+
+    m_nrOfSubDynamics = m_subDynamics.size();
+
+    m_isSubModelListSet = true;
+
+    for (int subModelIdx = 0; subModelIdx < m_nrOfSubDynamics; subModelIdx++)
+    {
+        if (!m_subDynamics.at(subModelIdx)->initialize())
+        {
+            log()->error("{} Cannot initialize the joint velocity dynamics of the sub-model {}.", errorPrefix, subModelIdx);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool RDE::FrictionTorqueStateDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[FrictionTorqueStateDynamics::checkStateVariableHandler]";
+
+    if (!m_isSubModelListSet)
+    {
+        log()->error("{} Set the sub-model list before setting the variable handler", errorPrefix);
+        return false;
+    }
+
+    if (!m_stateVariableHandler.getVariable("tau_m").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `tau_m`.", errorPrefix);
+        return false;
+    }
+
+    // Check if the variable handler contains the variables used by this dynamics
+    if (!m_stateVariableHandler.getVariable("tau_F").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `tau_F`.", errorPrefix);
+        return false;
+    }
+
+    if (!m_stateVariableHandler.getVariable("ds").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `ds`.", errorPrefix);
+        return false;
+    }
+
+    // check if all the sensors are part of the sub-model
+    for (int subModelIdx = 0; subModelIdx < m_nrOfSubDynamics; subModelIdx++)
+    {
+        for (int ftIdx = 0; ftIdx < m_subDynamics.at(subModelIdx)->subModel.getNrOfFTSensor(); ftIdx++)
+        {
+            if (!m_stateVariableHandler.getVariable(m_subDynamics.at(subModelIdx)->subModel.getFTSensor(ftIdx).name).isValid())
+            {
+                log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_subDynamics.at(subModelIdx)->subModel.getFTSensor(ftIdx).name);
+                return false;
+            }
+        }
+
+        for (int contactIdx = 0; contactIdx < m_subDynamics.at(subModelIdx)->subModel.getNrOfExternalContact(); contactIdx++)
+        {
+            if (!m_stateVariableHandler.getVariable(m_subDynamics.at(subModelIdx)->subModel.getExternalContact(contactIdx)).isValid())
+            {
+                log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_subDynamics.at(subModelIdx)->subModel.getExternalContact(contactIdx));
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool RDE::FrictionTorqueStateDynamics::update()
+{
+    constexpr auto errorPrefix = "[FrictionTorqueStateDynamics::update]";
+
+    // compute joint acceleration per each sub-model
+    for (int subDynamicsIdx = 0; subDynamicsIdx < m_subDynamics.size(); subDynamicsIdx++)
+    {
+        if (!m_subDynamics[subDynamicsIdx]->update(m_ukfInput.robotBaseAcceleration, m_jointAccelerationFullModel, m_subModelUpdatedJointAcceleration[subDynamicsIdx]))
+        {
+            log()->error("{} Error updating the joint velocity dynamics for the sub-model {}.", errorPrefix, subDynamicsIdx);
+            return false;
+        }
+
+        for (int jointIdx = 0; jointIdx < m_subDynamics[subDynamicsIdx]->subModel.getJointMapping().size(); jointIdx++)
+        {
+            m_jointAccelerationFullModel[m_subDynamics[subDynamicsIdx]->subModel.getJointMapping()[jointIdx]] = m_subModelUpdatedJointAcceleration[subDynamicsIdx][jointIdx];
+        }
+    }
+
+    // k_{1} \dot{s,k}
+    m_tanhArgument = m_k1.array() * m_jointVelocityFullModel.array();
+
+    // tanh (k_{1} \dot{s,k}))
+    m_tanh = m_tanhArgument.array().tanh();
+
+    // 1 - tanh^{2} (k_{1} \dot{s,k})
+    m_argParenthesis = 1 - m_tanh.array().square();
+
+    //  k_{0} k_{1}
+    m_k0k1 = m_k0.array() * m_k1.array();
+
+    // \ddot{s,k} ( k_{2} + k_{0} k_{1} (1 - tanh^{2} (k_{1} \dot{s,k})) )
+    m_dotTauF = m_jointAccelerationFullModel.array() * ( m_k2.array() + m_k0k1.array() * m_argParenthesis.array() );
+
+    // \tau_{F,k+1} = \tau_{F,k} + \Delta T * \dot{\tau_{F,k}}
+    m_updatedVariable = m_currentFrictionTorque + m_dT * m_dotTauF;
+
+    return true;
+}
+
+void RDE::FrictionTorqueStateDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_jointVelocityFullModel = ukfState.segment(m_stateVariableHandler.getVariable("ds").offset,
+                                                m_stateVariableHandler.getVariable("ds").size);
+
+    m_motorTorqueFullModel = ukfState.segment(m_stateVariableHandler.getVariable("tau_m").offset,
+                                              m_stateVariableHandler.getVariable("tau_m").size);
+
+    m_frictionTorqueFullModel = ukfState.segment(m_stateVariableHandler.getVariable("tau_F").offset,
+                                                 m_stateVariableHandler.getVariable("tau_F").size);
+
+    for (int subDynamicsIdx = 0; subDynamicsIdx < m_subDynamics.size(); subDynamicsIdx++)
+    {
+        m_subDynamics.at(subDynamicsIdx)->setState(ukfState,
+                                                   m_jointVelocityFullModel,
+                                                   m_motorTorqueFullModel,
+                                                   m_frictionTorqueFullModel,
+                                                   m_stateVariableHandler);
+    }
+}
+
+void RDE::FrictionTorqueStateDynamics::setInput(const UKFInput& ukfInput)
+{
+    m_ukfInput = ukfInput;
+}

--- a/src/Estimators/src/GyroscopeMeasurementDynamics.cpp
+++ b/src/Estimators/src/GyroscopeMeasurementDynamics.cpp
@@ -1,0 +1,238 @@
+/**
+ * @file GyroscopeMeasurementDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/GyroscopeMeasurementDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RDE::GyroscopeMeasurementDynamics::GyroscopeMeasurementDynamics() = default;
+
+RDE::GyroscopeMeasurementDynamics::~GyroscopeMeasurementDynamics() = default;
+
+bool RDE::GyroscopeMeasurementDynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[GyroscopeMeasurementDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covSingleVar))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the dynamic model type
+    if (!ptr->getParameter("dynamic_model", m_dynamicModel))
+    {
+        log()->error("{} Error while retrieving the dynamic_model variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->info("{} Variable elements not found.", errorPrefix);
+        m_elements = {};
+    }
+
+    if (!ptr->getParameter("sampling_time", m_dT))
+    {
+        log()->error("{} Error while retrieving the sampling_time variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the bias related variables if use_bias is true
+    if (!ptr->getParameter("use_bias", m_useBias))
+    {
+        log()->info("{} Variable use_bias not found. Set to false by default.", errorPrefix);
+    }
+    else
+    {
+        m_useBias = true;
+        m_biasVariableName = m_name + "_bias";
+    }
+
+    m_description = "Gyroscope measurement dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::GyroscopeMeasurementDynamics::finalize(const System::VariablesHandler &stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[GyroscopeMeasurementDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Search and save all the submodels containing the sensor
+    for (int submodelIndex = 0; submodelIndex < m_nrOfSubDynamics; submodelIndex++)
+    {
+       if (m_subModelList[submodelIndex].hasGyroscope(m_name))
+       {
+            m_subModelWithGyro.push_back(submodelIndex);
+       }
+    }
+
+    m_covariances.resize(m_covSingleVar.size() * m_subModelWithGyro.size());
+    for (int index = 0; index < m_subModelWithGyro.size(); index++)
+    {
+        m_covariances.segment(index*m_covSingleVar.size(), m_covSingleVar.size()) = m_covSingleVar;
+    }
+
+    m_size = m_covariances.size();
+
+    m_jointVelocityFullModel.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_jointVelocityFullModel.setZero();
+
+    m_subModelJointVel.resize(m_nrOfSubDynamics);
+
+    for (int idx = 0; idx < m_nrOfSubDynamics; idx++)
+    {
+        m_subModelJointVel[idx].resize(m_subModelList[idx].getJointMapping().size());
+        m_subModelJointVel[idx].setZero();
+    }
+
+    m_bias.resize(m_covSingleVar.size());
+    m_bias.setZero();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    return true;
+}
+
+bool RDE::GyroscopeMeasurementDynamics::setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    constexpr auto errorPrefix = "[GyroscopeMeasurementDynamics::setSubModels]";
+
+    m_subModelList = subModelList;
+    m_subModelKinDynList = kinDynWrapperList;
+
+    if (m_subModelList.size() == 0 || m_subModelKinDynList.size() == 0 || m_subModelList.size() != m_subModelKinDynList.size())
+    {
+        log()->error("{} Wrong size of input parameters", errorPrefix);
+        return false;
+    }
+
+    m_nrOfSubDynamics = m_subModelList.size();
+
+    m_isSubModelListSet = true;
+
+    return true;
+}
+
+bool RDE::GyroscopeMeasurementDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[GyroscopeMeasurementDynamics::checkStateVariableHandler]";
+
+    if (!m_isSubModelListSet)
+    {
+        log()->error("{} Set the sub-model list before setting the variable handler", errorPrefix);
+        return false;
+    }
+
+    if (!m_stateVariableHandler.getVariable("ds").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `ds`.", errorPrefix);
+        return false;
+    }
+
+    if (m_useBias)
+    {
+        if (!m_stateVariableHandler.getVariable(m_biasVariableName).isValid())
+        {
+            log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_biasVariableName);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool RDE::GyroscopeMeasurementDynamics::update()
+{
+    constexpr auto errorPrefix = "[GyroscopeMeasurementDynamics::update]";
+
+    // base_J v_base + joint_J s_dot + bias
+    for (int index = 0; index < m_subModelWithGyro.size(); index++)
+    {
+        m_subModelBaseVel = m_subModelKinDynList[m_subModelWithGyro[index]]->getBaseVelocity();
+
+        m_JvBase = m_subModelKinDynList[m_subModelWithGyro[index]]->getGyroscopeJacobian(m_name).block(0, 0, 6, 6) * m_subModelBaseVel.coeffs();
+
+        m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size()) = m_JvBase.segment(3, 3) + m_bias;
+
+        if (m_subModelList[m_subModelWithGyro[index]].getJointMapping().size() > 0)
+        {
+            m_Jsdot = m_subModelKinDynList[m_subModelWithGyro[index]]->getGyroscopeJacobian(m_name).block(0, 6, 6, m_subModelList[m_subModelWithGyro[index]].getModel().getNrOfDOFs()) *
+                    m_subModelJointVel[m_subModelWithGyro[index]];
+
+            m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size()) += m_Jsdot.segment(3, 3);
+        }
+    }
+
+    return true;
+}
+
+void RDE::GyroscopeMeasurementDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_jointVelocityFullModel = ukfState.segment(m_stateVariableHandler.getVariable("ds").offset,
+                                                m_stateVariableHandler.getVariable("ds").size);
+
+    for (int smIndex = 0; smIndex < m_subModelList.size(); smIndex++)
+    {
+        for (int jntIndex = 0; jntIndex < m_subModelList[smIndex].getModel().getNrOfDOFs(); jntIndex++)
+        {
+            m_subModelJointVel[smIndex][jntIndex] =
+                    m_jointVelocityFullModel[m_subModelList[smIndex].getJointMapping()[jntIndex]];
+        }
+    }
+
+    m_bias = ukfState.segment(m_stateVariableHandler.getVariable(m_biasVariableName).offset,
+                              m_stateVariableHandler.getVariable(m_biasVariableName).size);
+}
+
+void RDE::GyroscopeMeasurementDynamics::setInput(const UKFInput& ukfInput)
+{
+    m_ukfInput = ukfInput;
+}

--- a/src/Estimators/src/JointVelocityStateDynamics.cpp
+++ b/src/Estimators/src/JointVelocityStateDynamics.cpp
@@ -1,0 +1,264 @@
+/**
+ * @file JointVelocityStateDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <map>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/JointVelocityStateDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RDE::JointVelocityStateDynamics::JointVelocityStateDynamics() = default;
+
+RDE::JointVelocityStateDynamics::~JointVelocityStateDynamics() = default;
+
+bool RDE::JointVelocityStateDynamics::setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    constexpr auto errorPrefix = "[JointVelocityStateDynamics::setSubModels]";
+
+    for (int subModelIdx = 0; subModelIdx < subModelList.size(); subModelIdx++)
+    {
+        if (subModelList[subModelIdx].getModel().getNrOfDOFs() > 0)
+        {
+            m_subDynamics.emplace_back(std::make_unique<RDE::SubModelDynamics>());
+
+            if(!m_subDynamics[subModelIdx]->setSubModel(subModelList[subModelIdx]))
+            {
+                log()->error("{} The submodel at index {} is not valid.", errorPrefix, subModelIdx);
+                return false;
+            }
+
+            if(!m_subDynamics[subModelIdx]->setKinDynWrapper(kinDynWrapperList[subModelIdx]))
+            {
+                log()->error("{} The submodel kindyn wrapper at index {} is not valid.", errorPrefix, subModelIdx);
+                return false;
+            }
+        }
+    }
+
+    m_nrOfSubDynamics = m_subDynamics.size();
+
+    m_isSubModelListSet = true;
+
+    for (int subModelIdx = 0; subModelIdx < m_nrOfSubDynamics; subModelIdx++)
+    {
+        if (!m_subDynamics.at(subModelIdx)->initialize())
+        {
+            log()->error("{} Cannot initialize the joint velocity dynamics of the sub-model {}.", errorPrefix, subModelIdx);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool RDE::JointVelocityStateDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[JointVelocityStateDynamics::checkStateVariableHandler]";
+
+    if (!m_isSubModelListSet)
+    {
+        log()->error("{} Set the sub-model list before setting the variable handler", errorPrefix);
+        return false;
+    }
+
+    // Check if the variable handler contains the variables used by this dynamics
+    if (!m_stateVariableHandler.getVariable("tau_m").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `tau_m`.", errorPrefix);
+        return false;
+    }
+
+    if (!m_stateVariableHandler.getVariable("tau_F").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `tau_F`.", errorPrefix);
+        return false;
+    }
+
+    for (int subModelIdx = 0; subModelIdx < m_nrOfSubDynamics; subModelIdx++)
+    {
+        for (int ftIdx = 0; ftIdx < m_subDynamics.at(subModelIdx)->subModel.getNrOfFTSensor(); ftIdx++)
+        {
+            if (!m_stateVariableHandler.getVariable(m_subDynamics.at(subModelIdx)->subModel.getFTSensor(ftIdx).name).isValid())
+            {
+                log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_subDynamics.at(subModelIdx)->subModel.getFTSensor(ftIdx).name);
+                return false;
+            }
+        }
+
+        for (int contactIdx = 0; contactIdx < m_subDynamics.at(subModelIdx)->subModel.getNrOfExternalContact(); contactIdx++)
+        {
+            if (!m_stateVariableHandler.getVariable(m_subDynamics.at(subModelIdx)->subModel.getExternalContact(contactIdx)).isValid())
+            {
+                log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_subDynamics.at(subModelIdx)->subModel.getExternalContact(contactIdx));
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool RDE::JointVelocityStateDynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[JointVelocityStateDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covariances))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the dynamic model type
+    if (!ptr->getParameter("dynamic_model", m_dynamicModel))
+    {
+        log()->error("{} Error while retrieving the dynamic_model variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->info("{} Variable elements not found.", errorPrefix);
+        m_elements = {};
+    }
+
+    if (!ptr->getParameter("sampling_time", m_dT))
+    {
+        log()->info("{} Error while retrieving the sampling_time variable.", errorPrefix);
+        m_elements = {};
+    }
+
+    m_description = "Joint velocity state dynamics depending on the robot dynamic model";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::JointVelocityStateDynamics::finalize(const System::VariablesHandler &stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[JointVelocityStateDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    m_size = m_covariances.size();
+
+    m_motorTorqueFullModel.resize(m_stateVariableHandler.getVariable("tau_m").size);
+    m_motorTorqueFullModel.setZero();
+
+    m_frictionTorqueFullModel.resize(m_stateVariableHandler.getVariable("tau_F").size);
+    m_frictionTorqueFullModel.setZero();
+
+    m_jointVelocityFullModel.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_jointVelocityFullModel.setZero();
+
+    m_jointAccelerationFullModel.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_jointAccelerationFullModel.setZero();
+
+    m_updatedVariable.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_updatedVariable.setZero();
+
+    m_subModelUpdatedJointVelocity.resize(m_nrOfSubDynamics);
+    m_subModelUpdatedJointAcceleration.resize(m_nrOfSubDynamics);
+
+    for (int idx = 0; idx < m_nrOfSubDynamics; idx++)
+    {
+        m_subModelUpdatedJointVelocity[idx].resize(m_subDynamics[idx]->subModel.getJointMapping().size());
+        m_subModelUpdatedJointVelocity[idx].setZero();
+
+        m_subModelUpdatedJointAcceleration[idx].resize(m_subDynamics[idx]->subModel.getJointMapping().size());
+        m_subModelUpdatedJointAcceleration[idx].setZero();
+    }
+
+    return true;
+}
+
+
+bool RDE::JointVelocityStateDynamics::update()
+{
+    constexpr auto errorPrefix = "[JointVelocityStateDynamics::update]";
+
+    // compute joint acceleration per each sub-model
+    for (int subDynamicsIdx = 0; subDynamicsIdx < m_subDynamics.size(); subDynamicsIdx++)
+    {
+        if (!m_subDynamics[subDynamicsIdx]->update(m_ukfInput.robotBaseAcceleration, m_jointAccelerationFullModel, m_subModelUpdatedJointAcceleration[subDynamicsIdx]))
+        {
+            log()->error("{} Error updating the joint velocity dynamics for the sub-model {}.", errorPrefix, subDynamicsIdx);
+            return false;
+        }
+
+        m_subModelUpdatedJointVelocity[subDynamicsIdx] = m_subModelUpdatedJointVelocity[subDynamicsIdx] + m_dT * m_subModelUpdatedJointAcceleration[subDynamicsIdx];
+
+        for (int jointIdx = 0; jointIdx < m_subDynamics[subDynamicsIdx]->subModel.getJointMapping().size(); jointIdx++)
+        {
+            m_jointAccelerationFullModel[m_subDynamics[subDynamicsIdx]->subModel.getJointMapping()[jointIdx]] = m_subModelUpdatedJointAcceleration[subDynamicsIdx][jointIdx];
+
+            m_updatedVariable[m_subDynamics[subDynamicsIdx]->subModel.getJointMapping()[jointIdx]] = m_subModelUpdatedJointVelocity[subDynamicsIdx][jointIdx];
+        }
+    }
+
+    return true;
+}
+
+void RDE::JointVelocityStateDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_jointVelocityFullModel = ukfState.segment(m_stateVariableHandler.getVariable("ds").offset,
+                                                m_stateVariableHandler.getVariable("ds").size);
+
+    m_motorTorqueFullModel = ukfState.segment(m_stateVariableHandler.getVariable("tau_m").offset,
+                                              m_stateVariableHandler.getVariable("tau_m").size);
+
+    m_frictionTorqueFullModel = ukfState.segment(m_stateVariableHandler.getVariable("tau_F").offset,
+                                                 m_stateVariableHandler.getVariable("tau_F").size);
+
+    for (int subDynamicsIdx = 0; subDynamicsIdx < m_subDynamics.size(); subDynamicsIdx++)
+    {
+        m_subDynamics.at(subDynamicsIdx)->setState(ukfState,
+                                                   m_jointVelocityFullModel,
+                                                   m_motorTorqueFullModel,
+                                                   m_frictionTorqueFullModel,
+                                                   m_stateVariableHandler);
+    }
+}
+
+void RDE::JointVelocityStateDynamics::setInput(const UKFInput& ukfInput)
+{
+    m_ukfInput = ukfInput;
+}

--- a/src/Estimators/src/MotorCurrentMeasurementDynamics.cpp
+++ b/src/Estimators/src/MotorCurrentMeasurementDynamics.cpp
@@ -1,0 +1,149 @@
+/**
+ * @file MotorCurrentMeasurementDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/MotorCurrentMeasurementDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RDE::MotorCurrentMeasurementDynamics::MotorCurrentMeasurementDynamics() = default;
+
+RDE::MotorCurrentMeasurementDynamics::~MotorCurrentMeasurementDynamics() = default;
+
+bool RDE::MotorCurrentMeasurementDynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[MotorCurrentMeasurementDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", this->m_covariances))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the dynamic model type
+    if (!ptr->getParameter("dynamic_model", m_dynamicModel))
+    {
+        log()->error("{} Error while retrieving the dynamic_model variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->info("{} Variable elements not found.", errorPrefix);
+        m_elements = {};
+    }
+
+    // Set the torque constants
+    if (!ptr->getParameter("torque_constant", m_kTau))
+    {
+        log()->error("{} Error while retrieving the torque_constant variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the gearbox reduction ratio
+    if (!ptr->getParameter("gear_ratio", m_gearRatio))
+    {
+        log()->error("{} Error while retrieving the gear_ratio variable.", errorPrefix);
+        return false;
+    }
+
+    m_description = "Motor current measurement dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::MotorCurrentMeasurementDynamics::finalize(const System::VariablesHandler &stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[MotorCurrentMeasurementDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    m_size = m_covariances.size();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    m_motorTorque.resize(m_size);
+    m_motorTorque.setZero();
+
+    return true;
+}
+
+bool RDE::MotorCurrentMeasurementDynamics::setSubModels(const std::vector<RDE::SubModel>& subModelList, const std::vector<std::shared_ptr<RDE::SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    return true;
+}
+
+bool RDE::MotorCurrentMeasurementDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[MotorCurrentMeasurementDynamics::checkStateVariableHandler]";
+
+    // Check if the variable handler contains the variables used by this dynamics
+    if (!m_stateVariableHandler.getVariable("tau_m").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected measurement name {}.", errorPrefix, "tau_m");
+        return false;
+    }
+
+    return true;
+}
+
+bool RDE::MotorCurrentMeasurementDynamics::update()
+{
+    m_updatedVariable = m_motorTorque.array() / (m_kTau.array() * m_gearRatio.array());
+
+    return true;
+}
+
+void RDE::MotorCurrentMeasurementDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_motorTorque = ukfState.segment(m_stateVariableHandler.getVariable("tau_m").offset,
+                                     m_stateVariableHandler.getVariable("tau_m").size);
+}
+
+void RDE::MotorCurrentMeasurementDynamics::setInput(const UKFInput& ukfInput)
+{
+    return;
+}

--- a/src/Estimators/src/SubModel.cpp
+++ b/src/Estimators/src/SubModel.cpp
@@ -494,14 +494,99 @@ const RDE::FT& RDE::SubModel::getFTSensor(const int index) const
     return m_ftList.at(index);
 }
 
+const RDE::FT& RDE::SubModel::getFTSensor(const std::string name) const
+{
+    for (int ftIndex = 0; ftIndex < m_ftList.size(); ftIndex++)
+    {
+        if (m_ftList[ftIndex].name == name)
+        {
+            return m_ftList[ftIndex];
+        }
+    }
+
+    static const RDE::FT ft;
+
+    return ft;
+}
+
+bool RDE::SubModel::hasFTSensor(const std::string name) const
+{
+    for (int ftIndex = 0; ftIndex < m_ftList.size(); ftIndex++)
+    {
+        if (m_ftList[ftIndex].name == name)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 const RDE::Sensor& RDE::SubModel::getAccelerometer(const int index) const
 {
     return m_accelerometerList.at(index);
 }
 
+const RDE::Sensor& RDE::SubModel::getAccelerometer(const std::string name) const
+{
+    for (int accIndex = 0; accIndex < m_accelerometerList.size(); accIndex++)
+    {
+        if (m_accelerometerList[accIndex].name == name)
+        {
+            return m_accelerometerList[accIndex];
+        }
+    }
+
+    static const RDE::Sensor acc;
+
+    return acc;
+}
+
+bool RDE::SubModel::hasAccelerometer(const std::string name) const
+{
+    std::cout << "Name --> " << name << std::endl;
+    for (int accIndex = 0; accIndex < m_accelerometerList.size(); accIndex++)
+    {
+        if (m_accelerometerList[accIndex].name == name)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 const RDE::Sensor& RDE::SubModel::getGyroscope(const int index) const
 {
     return m_gyroscopeList.at(index);
+}
+
+const RDE::Sensor& RDE::SubModel::getGyroscope(const std::string name) const
+{
+    for (int gyroIndex = 0; gyroIndex < m_gyroscopeList.size(); gyroIndex++)
+    {
+        if (m_gyroscopeList[gyroIndex].name == name)
+        {
+            return m_gyroscopeList[gyroIndex];
+        }
+    }
+
+    static const RDE::Sensor gyro;
+
+    return gyro;
+}
+
+bool RDE::SubModel::hasGyroscope(const std::string name) const
+{
+    for (int gyroIndex = 0; gyroIndex < m_gyroscopeList.size(); gyroIndex++)
+    {
+        if (m_gyroscopeList[gyroIndex].name == name)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 const std::string& RDE::SubModel::getExternalContact(const int index) const

--- a/src/Estimators/src/SubModelDynamics.cpp
+++ b/src/Estimators/src/SubModelDynamics.cpp
@@ -1,0 +1,181 @@
+/**
+ * @file SubModelDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <map>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RDE::SubModelDynamics::SubModelDynamics() = default;
+
+RDE::SubModelDynamics::~SubModelDynamics() = default;
+
+/**
+ * Set the SubModelKinDynWrapper object.
+ * Parameter kinDynWrapper pointer to a SubModelKinDynWrapper object.
+ * Return true in case of success, false otherwise.
+ */
+bool RDE::SubModelDynamics::setKinDynWrapper(std::shared_ptr<SubModelKinDynWrapper> kinDynWrapper)
+{
+    constexpr auto errorPrefix = "[SubModelDynamics::setKinDynWrapper]";
+
+    this->kinDynWrapper = kinDynWrapper;
+
+    if (kinDynWrapper == nullptr)
+    {
+        log()->error("{} Error while setting the `SubModelKinDynWrapper` object.", errorPrefix);
+        return false;
+    }
+
+    return true;
+}
+
+bool RDE::SubModelDynamics::setSubModel(const RDE::SubModel& subModel)
+{
+    constexpr auto errorPrefix = "[SubModelDynamics::setSubModel]";
+
+    this->subModel = subModel;
+
+    if (!subModel.isValid())
+    {
+        log()->error("{} Set a valid `SubModel` object.", errorPrefix);
+        return false;
+    }
+
+    return true;
+}
+
+
+bool RDE::SubModelDynamics::initialize()
+{
+    constexpr auto errorPrefix = "[SubModelDynamics::initialize]";
+
+    // Inialize map of the ft sensors
+    if (!subModel.isValid())
+    {
+        log()->error("{} Set a valid `SubModel` object before calling initialize.", errorPrefix);
+        return false;
+    }
+
+    for (int idx = 0; idx < subModel.getNrOfFTSensor(); idx++)
+    {
+        FTMap[subModel.getFTSensor(idx).name].setZero();
+    }
+
+    // Inialize map of the external contacts
+    for (int idx = 0; idx < subModel.getNrOfExternalContact(); idx++)
+    {
+        extContactMap[subModel.getExternalContact(idx)].setZero();
+    }
+
+    // Resize and initialize variables
+    baseAcceleration.setZero();
+
+    motorTorque.resize(subModel.getModel().getNrOfDOFs());
+    motorTorque.setZero();
+
+    frictionTorque.resize(subModel.getModel().getNrOfDOFs());
+    frictionTorque.setZero();
+
+    jointVelocity.resize(subModel.getModel().getNrOfDOFs());
+    jointVelocity.setZero();
+
+    totalTorqueFromContacts.resize(subModel.getModel().getNrOfDOFs());
+    totalTorqueFromContacts.setZero();
+
+    torqueFromContact.resize(subModel.getModel().getNrOfDOFs());
+    torqueFromContact.setZero();
+
+    wrench.setZero();
+
+    return true;
+}
+
+void RDE::SubModelDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState,
+                                     const Eigen::Ref<const Eigen::VectorXd> jointVelocityFullModel,
+                                     const Eigen::Ref<const Eigen::VectorXd> motorTorqueFullModel,
+                                     const Eigen::Ref<const Eigen::VectorXd> frictionTorqueFullModel,
+                                     const System::VariablesHandler& variableHandler)
+{
+    for (int idx = 0; idx < subModel.getModel().getNrOfDOFs(); idx++)
+    {
+        jointVelocity(idx) = jointVelocityFullModel(subModel.getJointMapping().at(idx));
+    }
+
+    for (int idx = 0; idx < subModel.getModel().getNrOfDOFs(); idx++)
+    {
+        motorTorque(idx) = motorTorqueFullModel(subModel.getJointMapping().at(idx));
+    }
+
+    for (int idx = 0; idx < subModel.getModel().getNrOfDOFs(); idx++)
+    {
+        frictionTorque(idx) = frictionTorqueFullModel(subModel.getJointMapping().at(idx));
+    }
+
+    for (int idx = 0; idx < subModel.getNrOfFTSensor(); idx++)
+    {
+        FTMap[subModel.getFTSensor(idx).name] = ukfState.segment(variableHandler.getVariable(subModel.getFTSensor(idx).name).offset,
+                                                                 variableHandler.getVariable(subModel.getFTSensor(idx).name).size);
+    }
+
+    for (int idx = 0; idx < subModel.getNrOfExternalContact(); idx++)
+    {
+        FTMap[subModel.getExternalContact(idx)] = ukfState.segment(variableHandler.getVariable(subModel.getExternalContact(idx)).offset,
+                                                                   variableHandler.getVariable(subModel.getExternalContact(idx)).size);
+    }
+}
+
+bool RDE::SubModelDynamics::update(manif::SE3d::Tangent& fullModelBaseAcceleration,
+                                   Eigen::Ref<const Eigen::VectorXd> fullModelJointAcceleration,
+                                   Eigen::Ref<Eigen::VectorXd> updatedJointAcceleration)
+{
+    constexpr auto errorPrefix = "[SubModelDynamics::update]";
+
+    computeTotalTorqueFromContacts();
+
+    if (!kinDynWrapper->getBaseAcceleration(fullModelBaseAcceleration, fullModelJointAcceleration, baseAcceleration))
+    {
+        log()->error("{} Cannot compute the sub-model base acceleration.", errorPrefix);
+        return false;
+    }
+
+    if (!kinDynWrapper->forwardDynamics(motorTorque,
+                                        frictionTorque,
+                                        totalTorqueFromContacts,
+                                        baseAcceleration.coeffs(),
+                                        updatedJointAcceleration))
+    {
+        log()->error("{} Cannot compute the inverse dynamics.", errorPrefix);
+        return false;
+    }
+
+    return true;
+}
+
+void RDE::SubModelDynamics::computeTotalTorqueFromContacts()
+{
+    totalTorqueFromContacts.setZero();
+
+    // Contribution of FT measurements
+    for (int idx = 0; idx < subModel.getNrOfFTSensor(); idx++)
+    {
+        wrench = (int)subModel.getFTSensor(idx).forceDirection * FTMap[subModel.getFTSensor(idx).name].array();
+
+        torqueFromContact = kinDynWrapper->getFTJacobian(subModel.getFTSensor(idx).name).block(0, 6, 6, subModel.getModel().getNrOfDOFs()).transpose() * wrench;
+
+        totalTorqueFromContacts = totalTorqueFromContacts.array() + torqueFromContact.array();
+    }
+
+    // Contribution of unknown external contacts
+    for (int idx = 0; idx < subModel.getNrOfExternalContact(); idx++)
+    {
+        torqueFromContact = kinDynWrapper->getFTJacobian(subModel.getFTSensor(idx).name).block(0, 6, 6, subModel.getModel().getNrOfDOFs()).transpose() * FTMap[subModel.getExternalContact(idx)];
+
+        totalTorqueFromContacts = totalTorqueFromContacts.array() + torqueFromContact.array();
+    }
+}

--- a/src/Estimators/src/UkfMeasurement.cpp
+++ b/src/Estimators/src/UkfMeasurement.cpp
@@ -1,0 +1,383 @@
+/**
+ * @file UkfMeasurement.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <map>
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/Math/Constants.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/UkfMeasurement.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+struct RDE::UkfMeasurement::Impl
+{
+    bool isInitialized{false};
+    bool isFinalized{false};
+
+    bfl::VectorDescription measurementDescription_;
+    bfl::VectorDescription inputDescription_;
+
+    Eigen::Vector3d gravity{0, 0, -Math::StandardAccelerationOfGravitation}; /**< Gravity vector. */
+
+    Eigen::MatrixXd covarianceR; /**< Covariance matrix. */
+    std::size_t measurementSize; /**< Length of the measurement vector. */
+    double dT; /**< Sampling time */
+
+    std::map<std::string, std::shared_ptr<Dynamics>> dynamicsList; /**< List of the dynamics composing the process model. */
+
+    System::VariablesHandler measurementVariableHandler; /**< Variable handler describing the measurement vector. */
+    System::VariablesHandler stateVariableHandler; /**< Variable handler describing the state vector. */
+
+    std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel; /**< KinDynComputation object for the full model. */
+    std::vector<SubModel> subModelList; /**< List of SubModel object describing the sub-models composing the full model. */
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperList; /**< List of SubModelKinDynWrapper objects containing kinematic and dynamic information specific of each sub-model. */
+
+    std::shared_ptr<const UkfInputProvider> ukfInputProvider; /**< Provider containing the updated robot state. */
+    UKFInput ukfInput; /**< Struct containing the inputs for the ukf populated by the ukfInputProvider. */
+
+    Eigen::VectorXd jointVelocityState; /**< Joint velocity compute by the ukf. */
+
+    Eigen::VectorXd currentState; /**< State estimated in the previous step. */
+    Eigen::VectorXd predictedMeasurement; /**< Vector containing the updated measurement. */
+
+    Eigen::VectorXd measurement; /**< Measurements coming from the sensors. */
+
+    std::map<std::string, Eigen::VectorXd> measurementMap; /**< Measurement map <measurement name, measurement value>. */
+
+    int offsetMeasurement; /**< Offset used to fill the measurement vector. */
+};
+
+RDE::UkfMeasurement::UkfMeasurement()
+{
+    m_pimpl = std::make_unique<RDE::UkfMeasurement::Impl>();
+}
+
+RDE::UkfMeasurement::~UkfMeasurement() = default;
+
+bool RDE::UkfMeasurement::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler)
+{
+    constexpr auto logPrefix = "[UkfMeasurement::initialize]";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        BipedalLocomotion::log()->error("{} The parameter handler is not valid.", logPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("sampling_time", m_pimpl->dT))
+    {
+        BipedalLocomotion::log()->error("{} Unable to find the `sampling_time` variable", logPrefix);
+        return false;
+    }
+
+    m_pimpl->isInitialized = true;
+
+    return true;
+}
+
+bool RDE::UkfMeasurement::finalize(const System::VariablesHandler& handler)
+{
+    constexpr auto logPrefix = "[UkfMeasurement::finalize]";
+
+    if (!m_pimpl->isInitialized)
+    {
+        BipedalLocomotion::log()->error("{} Please call initialize() before finalize().", logPrefix);
+        return false;
+    }
+
+    m_pimpl->isFinalized = false;
+
+    m_pimpl->measurementSize = 0;
+
+    // finalize all the dynamics
+    for (auto& [name, dynamics] : m_pimpl->dynamicsList)
+    {
+        if(!dynamics->finalize(handler))
+        {
+            BipedalLocomotion::log()->error("{} Error while finalizing the dynamics named {}", logPrefix, name);
+            return false;
+        }
+
+        m_pimpl->measurementSize += dynamics->size();
+    }
+
+    // Set value of measurement covariance matrix
+    m_pimpl->covarianceR.resize(m_pimpl->measurementSize, m_pimpl->measurementSize);
+
+    for (auto& [name, dynamics] : m_pimpl->dynamicsList)
+    {
+        m_pimpl->measurementVariableHandler.addVariable(name, dynamics->getCovariance().size());
+
+        m_pimpl->covarianceR.block(m_pimpl->measurementVariableHandler.getVariable(name).offset, m_pimpl->measurementVariableHandler.getVariable(name).offset,
+                                   m_pimpl->measurementVariableHandler.getVariable(name).size, m_pimpl->measurementVariableHandler.getVariable(name).size) = dynamics->getCovariance().asDiagonal();
+    }
+
+    m_pimpl->jointVelocityState.resize(m_pimpl->kinDynFullModel->model().getNrOfDOFs());
+
+    m_pimpl->currentState.resize(m_pimpl->measurementSize);
+    m_pimpl->currentState.setZero();
+
+    m_pimpl->predictedMeasurement.resize(m_pimpl->measurementSize);
+    m_pimpl->predictedMeasurement.setZero();
+
+    m_pimpl->measurement.resize(m_pimpl->measurementSize);
+    m_pimpl->measurement.setZero();
+
+    m_pimpl->isFinalized = true;
+
+    return true;
+}
+
+std::unique_ptr<RDE::UkfMeasurement> RDE::UkfMeasurement::build(std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
+                                                                System::VariablesHandler& stateVariableHandler,
+                                                                std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                                                                const std::vector<SubModel>& subModelList,
+                                                                const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    constexpr auto logPrefix = "[UkfMeasurement::build]";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        BipedalLocomotion::log()->error("{} Invalid parameter handler.", logPrefix);
+        return nullptr;
+    }
+
+    std::unique_ptr<RDE::UkfMeasurement> measurement = std::make_unique<RDE::UkfMeasurement>();
+
+    if (!measurement->initialize(ptr))
+    {
+        BipedalLocomotion::log()->error("{} Unable to initialize the measurement object of the ukf.", logPrefix);
+        return nullptr;
+    }
+
+    std::vector<std::string> dynamicsList;
+    if (!ptr->getParameter("dynamics_list", dynamicsList))
+    {
+        BipedalLocomotion::log()->error("{} Unable to find the parameter 'dynamics_list'.", logPrefix);
+        return nullptr;
+    }
+
+    if (kinDynFullModel == nullptr)
+    {
+        BipedalLocomotion::log()->error("{} The pointer to the `KinDynComputation` object is not valid.", logPrefix);
+        return nullptr;
+    }
+
+    measurement->m_pimpl->stateVariableHandler = stateVariableHandler;
+
+    // Set KinDynComputation for the full model
+    measurement->m_pimpl->kinDynFullModel = kinDynFullModel;
+
+    // Set the list of SubModel
+    measurement->m_pimpl->subModelList.reserve(subModelList.size());
+    measurement->m_pimpl->subModelList = subModelList;
+
+    // set the list of SubModelKinDynWrapper
+    measurement->m_pimpl->kinDynWrapperList.reserve(kinDynWrapperList.size());
+    measurement->m_pimpl->kinDynWrapperList = kinDynWrapperList;
+
+    // per each dynamics add variable to the variableHandler
+    // and add the dynamics to the list
+    for (const auto& dynamicsGroupName : dynamicsList)
+    {
+        auto dynamicsGroupTmp = ptr->getGroup(dynamicsGroupName).lock();
+        if (dynamicsGroupTmp == nullptr)
+        {
+            BipedalLocomotion::log()->error("{} Unable to find the group '{}'.", logPrefix, dynamicsGroupName);
+            return nullptr;
+        }
+
+        // add dT parameter since it is required by all the dynamics
+        auto dynamicsGroup = dynamicsGroupTmp->clone();
+        dynamicsGroup->setParameter("sampling_time", measurement->m_pimpl->dT);
+
+        // create variable handler
+        std::string dynamicsName;
+        std::vector<double> covariances;
+        std::vector<std::string> dynamicsElements;
+        if (!dynamicsGroup->getParameter("name", dynamicsName))
+        {
+            BipedalLocomotion::log()->error("{} Unable to find the parameter 'name'.", logPrefix);
+            return nullptr;
+        }
+        if (!dynamicsGroup->getParameter("covariance", covariances))
+        {
+            BipedalLocomotion::log()->error("{} Unable to find the parameter 'covariance'.", logPrefix);
+            return nullptr;
+        }
+        if (!dynamicsGroup->getParameter("elements", dynamicsElements))
+        {
+            BipedalLocomotion::log()->error("{} Unable to find the parameter 'elements'.", logPrefix);
+            return nullptr;
+        }
+
+        std::string dynamicModel;
+        if (!dynamicsGroup->getParameter("dynamic_model", dynamicModel))
+        {
+            BipedalLocomotion::log()->error("{} Unable to find the parameter 'dynamic_model'.", logPrefix);
+            return nullptr;
+        }
+
+        std::shared_ptr<Dynamics> dynamicsInstance = RDE::DynamicsFactory::createInstance(dynamicModel);
+        if (dynamicsInstance == nullptr)
+        {
+            BipedalLocomotion::log()->error("{} The dynamic model '{}' has not been registered.", logPrefix, dynamicModel);
+            return nullptr;
+        }
+
+        dynamicsInstance->setSubModels(subModelList, kinDynWrapperList);
+
+        dynamicsInstance->initialize(dynamicsGroup);
+
+        // add dynamics to the list
+        measurement->m_pimpl->dynamicsList.insert({dynamicsName, dynamicsInstance});
+    }
+
+    // finalize estimator
+    if (!measurement->finalize(measurement->m_pimpl->stateVariableHandler))
+    {
+        BipedalLocomotion::log()->error("{} Unable to finalize the RobotDynamicsEstimator.", logPrefix);
+        return nullptr;
+    }
+
+    return measurement;
+}
+
+void RDE::UkfMeasurement::setUkfInputProvider(std::shared_ptr<const UkfInputProvider> ukfInputProvider)
+{
+    m_pimpl->ukfInputProvider = ukfInputProvider;
+}
+
+std::pair<bool, Eigen::MatrixXd> RDE::UkfMeasurement::getNoiseCovarianceMatrix() const
+{
+    return std::make_pair(true, m_pimpl->covarianceR);
+}
+
+bfl::VectorDescription RDE::UkfMeasurement::getMeasurementDescription() const
+{
+    return bfl::VectorDescription(m_pimpl->measurementSize);
+}
+
+bfl::VectorDescription RDE::UkfMeasurement::getInputDescription() const
+{
+    return bfl::VectorDescription(m_pimpl->currentState.size(), 0, m_pimpl->measurementSize);
+}
+
+std::pair<bool, bfl::Data> RDE::UkfMeasurement::predictedMeasure(const Eigen::Ref<const Eigen::MatrixXd>& cur_states) const
+{
+    constexpr auto logPrefix = "[UkfMeasurement::propagate]";
+
+    // Check that everything is initialized and set
+    if (!m_pimpl->isFinalized)
+    {
+        BipedalLocomotion::log()->error("{} The ukf state is not well initialized.", logPrefix);
+        throw std::runtime_error("Error");
+    }
+
+    if (m_pimpl->ukfInputProvider == nullptr)
+    {
+        BipedalLocomotion::log()->error("{} The ukf input provider is not set.", logPrefix);
+        throw std::runtime_error("Error");
+    }
+
+    // Get input of ukf from provider
+    m_pimpl->ukfInput = m_pimpl->ukfInputProvider->getOutput();
+
+    m_pimpl->currentState = cur_states;
+
+    m_pimpl->jointVelocityState = m_pimpl->currentState.segment(m_pimpl->stateVariableHandler.getVariable("ds").offset,
+                                                                m_pimpl->stateVariableHandler.getVariable("ds").size);
+
+    // Update kindyn full model
+    m_pimpl->kinDynFullModel->setRobotState(m_pimpl->ukfInput.robotBasePose.transform(),
+                                            m_pimpl->ukfInput.robotJointPositions,
+                                            iDynTree::make_span(m_pimpl->ukfInput.robotBaseVelocity.data(), manif::SE3d::Tangent::DoF),
+                                            m_pimpl->jointVelocityState,
+                                            m_pimpl->gravity);
+
+    // Update kindyn sub-models
+    for (int subModelIdx = 0; subModelIdx < m_pimpl->subModelList.size(); subModelIdx++)
+    {
+        m_pimpl->kinDynWrapperList[subModelIdx]->updateInternalKinDynState();
+    }
+
+    // TODO
+    // This could be parallelized
+
+    // Update all the dynamics
+    for (auto& [name, dynamics] : m_pimpl->dynamicsList)
+    {
+        dynamics->setState(m_pimpl->currentState);
+
+        dynamics->setInput(m_pimpl->ukfInput);
+
+        if (!dynamics->update())
+        {
+            BipedalLocomotion::log()->error("{} Cannot update the dynamics with name `{}`.", logPrefix, name);
+            throw std::runtime_error("Error");
+        }
+
+        m_pimpl->predictedMeasurement.segment(m_pimpl->measurementVariableHandler.getVariable(name).offset,
+                                              m_pimpl->measurementVariableHandler.getVariable(name).size) = dynamics->getUpdatedVariable();
+    }
+
+    return std::make_pair(true, std::move(m_pimpl->predictedMeasurement));
+}
+
+std::pair<bool, bfl::Data> RDE::UkfMeasurement::innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const
+{
+    Eigen::MatrixXd innovation = -(bfl::any::any_cast<Eigen::MatrixXd>(predicted_measurements).colwise()
+                                   - bfl::any::any_cast<Eigen::MatrixXd>(measurements).col(0));
+
+    return std::make_pair(true, std::move(innovation));
+}
+
+std::size_t RDE::UkfMeasurement::getMeasurementSize()
+{
+    return m_pimpl->measurementSize;
+}
+
+BipedalLocomotion::System::VariablesHandler RDE::UkfMeasurement::getMeasurementVariableHandler()
+{
+    return m_pimpl->measurementVariableHandler;
+}
+
+void RDE::UkfMeasurement::setStateVariableHandler(System::VariablesHandler stateVariableHandler) const
+{
+    m_pimpl->stateVariableHandler = stateVariableHandler;
+}
+
+std::pair<bool, bfl::Data> RDE::UkfMeasurement::measure(const bfl::Data& data) const
+{
+    return std::make_pair(true, m_pimpl->measurement);
+}
+
+bool RDE::UkfMeasurement::freeze(const bfl::Data& data)
+{
+    m_pimpl->measurementMap = bfl::any::any_cast<std::map<std::string, Eigen::VectorXd>>(data);
+
+    for (auto& [name, dynamics] : m_pimpl->dynamicsList)
+    {
+        m_pimpl->offsetMeasurement = m_pimpl->measurementVariableHandler.getVariable(name).offset;
+
+        while(m_pimpl->offsetMeasurement < (m_pimpl->measurementVariableHandler.getVariable(name).offset + m_pimpl->measurementVariableHandler.getVariable(name).size))
+        {
+            m_pimpl->measurement.segment(m_pimpl->offsetMeasurement, m_pimpl->measurementMap[name].size())
+                    = m_pimpl->measurementMap[name];
+
+            m_pimpl->offsetMeasurement += m_pimpl->measurementMap[name].size();
+        }
+    }
+
+    return true;
+}

--- a/src/Estimators/src/UkfState.cpp
+++ b/src/Estimators/src/UkfState.cpp
@@ -95,7 +95,7 @@ bool RDE::UkfState::finalize(const System::VariablesHandler& handler)
     {
         if(!dynamics->finalize(handler))
         {
-            log()->error("{} Error while finalizing the dynamics names {}", logPrefix, name);
+            log()->error("{} Error while finalizing the dynamics named {}", logPrefix, name);
             return false;
         }
 
@@ -144,7 +144,7 @@ std::unique_ptr<RDE::UkfState> RDE::UkfState::build(std::weak_ptr<const Paramete
 
     if (!state->initialize(ptr))
     {
-        log()->error("{} Unable to initialize the RobotDynamicsEstimator.", logPrefix);
+        log()->error("{} Unable to initialize the state object of the ukf.", logPrefix);
         return nullptr;
     }
 

--- a/src/Estimators/src/UkfState.cpp
+++ b/src/Estimators/src/UkfState.cpp
@@ -1,0 +1,327 @@
+/**
+ * @file UkfState.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <map>
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/Math/Constants.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/UkfState.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityDynamics.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/FrictionTorqueStateDynamics.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/JointVelocityStateDynamics.h>
+
+using namespace BipedalLocomotion;
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+struct RDE::UkfState::Impl
+{
+    bool isInitialized{false};
+    bool isFinalized{false};
+
+    Eigen::Vector3d gravity{0, 0, -Math::StandardAccelerationOfGravitation}; /**< Gravity vector. */
+
+    Eigen::MatrixXd covarianceQ; /**< Covariance matrix. */
+    std::size_t stateSize; /**< Length of the state vector. */
+    double dT; /**< Sampling time */
+
+    std::map<std::string, std::shared_ptr<Dynamics>> dynamicsList; /**< List of the dynamics composing the process model. */
+
+    System::VariablesHandler stateVariableHandler; /**< Variable handler describing the state vector. */
+
+    std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel; /**< KinDynComputation object for the full model. */
+    std::vector<SubModel> subModelList; /**< List of SubModel object describing the sub-models composing the full model. */
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperList; /**< List of SubModelKinDynWrapper objects containing kinematic and dynamic information specific of each sub-model. */
+
+    std::shared_ptr<const UkfInputProvider> ukfInputProvider; /**< Provider containing the updated robot state. */
+    UKFInput ukfInput; /**< Struct containing the inputs for the ukf populated by the ukfInputProvider. */
+
+    Eigen::VectorXd jointVelocityState; /**< Joint velocity compute by the ukf. */
+    Eigen::VectorXd currentState; /**< State estimated in the previous step. */
+    Eigen::VectorXd nextState; /**< Vector containing all the updated states. */
+};
+
+RDE::UkfState::UkfState()
+{
+    m_pimpl = std::make_unique<RDE::UkfState::Impl>();
+}
+
+RDE::UkfState::~UkfState() = default;
+
+bool RDE::UkfState::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler)
+{
+    constexpr auto logPrefix = "[UkfState::initialize]";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", logPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("sampling_time", m_pimpl->dT))
+    {
+        log()->error("{} Unable to find the `sampling_time` variable", logPrefix);
+        return false;
+    }
+
+    m_pimpl->isInitialized = true;
+
+    return true;
+}
+
+bool RDE::UkfState::finalize(const System::VariablesHandler& handler)
+{
+    constexpr auto logPrefix = "[UkfState::finalize]";
+
+    if (!m_pimpl->isInitialized)
+    {
+        log()->error("{} Please call initialize() before finalize().", logPrefix);
+        return false;
+    }
+
+    m_pimpl->isFinalized = false;
+
+    m_pimpl->stateSize = 0;
+
+    // finalize all the dynamics
+    for (auto& [name, dynamics] : m_pimpl->dynamicsList)
+    {
+        if(!dynamics->finalize(handler))
+        {
+            log()->error("{} Error while finalizing the dynamics names {}", logPrefix, name);
+            return false;
+        }
+
+        m_pimpl->stateSize += dynamics->size();
+    }
+
+
+    // Set value of process covariance matrix
+    m_pimpl->covarianceQ.resize(m_pimpl->stateSize, m_pimpl->stateSize);
+    m_pimpl->covarianceQ.setZero();
+
+    for (auto& [name, dynamics] : m_pimpl->dynamicsList)
+    {
+        m_pimpl->covarianceQ.block(handler.getVariable(name).offset, handler.getVariable(name).offset,
+                                   handler.getVariable(name).size, handler.getVariable(name).size) = dynamics->getCovariance().asDiagonal();
+    }
+
+    m_pimpl->jointVelocityState.resize(m_pimpl->kinDynFullModel->model().getNrOfDOFs());
+
+    m_pimpl->currentState.resize(m_pimpl->stateSize);
+    m_pimpl->currentState.setZero();
+
+    m_pimpl->nextState.resize(m_pimpl->stateSize);
+    m_pimpl->nextState.setZero();
+
+    m_pimpl->isFinalized = true;
+
+    return true;
+}
+
+std::unique_ptr<RDE::UkfState> RDE::UkfState::build(std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
+                                                    std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                                                    const std::vector<SubModel>& subModelList,
+                                                    const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    constexpr auto logPrefix = "[UkfState::build]";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} Invalid parameter handler.", logPrefix);
+        return nullptr;
+    }
+
+    std::unique_ptr<RDE::UkfState> state = std::make_unique<RDE::UkfState>();
+
+    if (!state->initialize(ptr))
+    {
+        log()->error("{} Unable to initialize the RobotDynamicsEstimator.", logPrefix);
+        return nullptr;
+    }
+
+    std::vector<std::string> dynamicsList;
+    if (!ptr->getParameter("dynamics_list", dynamicsList))
+    {
+        log()->error("{} Unable to find the parameter 'dynamics_list'.", logPrefix);
+        return nullptr;
+    }
+
+    if (kinDynFullModel == nullptr)
+    {
+        log()->error("{} The pointer to the `KinDynComputation` object is not valid.", logPrefix);
+        return nullptr;
+    }
+
+    // Set KinDynComputation for the full model
+    state->m_pimpl->kinDynFullModel = kinDynFullModel;
+
+    // Set the list of SubModel
+    state->m_pimpl->subModelList.reserve(subModelList.size());
+    state->m_pimpl->subModelList = subModelList;
+
+    // set the list of SubModelKinDynWrapper
+    state->m_pimpl->kinDynWrapperList.reserve(kinDynWrapperList.size());
+    state->m_pimpl->kinDynWrapperList = kinDynWrapperList;
+
+    // per each dynamics add variable to the variableHandler
+    // and add the dynamics to the list
+    for (const auto& dynamicsGroupName : dynamicsList)
+    {
+        auto dynamicsGroupTmp = ptr->getGroup(dynamicsGroupName).lock();
+        if (dynamicsGroupTmp == nullptr)
+        {
+            log()->error("{} Unable to find the group '{}'.", logPrefix, dynamicsGroupName);
+            return nullptr;
+        }
+
+        // add dT parameter since it is required by all the dynamics
+        auto dynamicsGroup = dynamicsGroupTmp->clone();
+        dynamicsGroup->setParameter("sampling_time", state->m_pimpl->dT);
+
+        // create variable handler
+        std::string dynamicsName;
+        std::vector<double> covariances;
+        std::vector<std::string> dynamicsElements;
+        if (!dynamicsGroup->getParameter("name", dynamicsName))
+        {
+            log()->error("{} Unable to find the parameter 'name'.", logPrefix);
+            return nullptr;
+        }
+        if (!dynamicsGroup->getParameter("covariance", covariances))
+        {
+            log()->error("{} Unable to find the parameter 'covariance'.", logPrefix);
+            return nullptr;
+        }
+        if (!dynamicsGroup->getParameter("elements", dynamicsElements))
+        {
+            log()->error("{} Unable to find the parameter 'elements'.", logPrefix);
+            return nullptr;
+        }
+        state->m_pimpl->stateVariableHandler.addVariable(dynamicsName, covariances.size(), dynamicsElements);
+
+        std::string dynamicModel;
+        if (!dynamicsGroup->getParameter("dynamic_model", dynamicModel))
+        {
+            log()->error("{} Unable to find the parameter 'dynamic_model'.", logPrefix);
+            return nullptr;
+        }
+
+        std::shared_ptr<Dynamics> dynamicsInstance = RDE::DynamicsFactory::createInstance(dynamicModel);
+        if (dynamicsInstance == nullptr)
+        {
+            log()->error("{} The dynamic model '{}' has not been registered.", logPrefix, dynamicModel);
+            return nullptr;
+        }
+
+        dynamicsInstance->setSubModels(subModelList, kinDynWrapperList);
+
+        dynamicsInstance->initialize(dynamicsGroup);
+
+        // add dynamics to the list
+        state->m_pimpl->dynamicsList.insert({dynamicsName, dynamicsInstance});
+    }
+
+    // finalize estimator
+    if (!state->finalize(state->m_pimpl->stateVariableHandler))
+    {
+        log()->error("{} Unable to finalize the RobotDynamicsEstimator.", logPrefix);
+        return nullptr;
+    }
+
+    return state;
+}
+
+void RDE::UkfState::setUkfInputProvider(std::shared_ptr<const UkfInputProvider> ukfInputProvider)
+{
+    m_pimpl->ukfInputProvider = ukfInputProvider;
+}
+
+Eigen::MatrixXd RDE::UkfState::getNoiseCovarianceMatrix()
+{
+    return m_pimpl->covarianceQ;
+}
+
+System::VariablesHandler RDE::UkfState::getStateVariableHandler()
+{
+    return m_pimpl->stateVariableHandler;
+}
+
+void RDE::UkfState::propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states)
+{
+    constexpr auto logPrefix = "[UkfState::propagate]";
+
+    // Check that everything is initialized and set
+    if (!m_pimpl->isFinalized)
+    {
+        log()->error("{} The ukf state is not well initialized.", logPrefix);
+        throw std::runtime_error("Error");
+    }
+
+    if (m_pimpl->ukfInputProvider == nullptr)
+    {
+        log()->error("{} The ukf input provider is not set.", logPrefix);
+        throw std::runtime_error("Error");
+    }
+
+    // Get input of ukf from provider
+    m_pimpl->ukfInput = m_pimpl->ukfInputProvider->getOutput();
+
+    m_pimpl->currentState = cur_states;
+
+    m_pimpl->jointVelocityState = m_pimpl->currentState.segment(m_pimpl->stateVariableHandler.getVariable("ds").offset,
+                                                                m_pimpl->stateVariableHandler.getVariable("ds").size);
+
+    // Update kindyn full model
+    m_pimpl->kinDynFullModel->setRobotState(m_pimpl->ukfInput.robotBasePose.transform(),
+                                            m_pimpl->ukfInput.robotJointPositions,
+                                            iDynTree::make_span(m_pimpl->ukfInput.robotBaseVelocity.data(), manif::SE3d::Tangent::DoF),
+                                            m_pimpl->jointVelocityState,
+                                            m_pimpl->gravity);
+
+    // Update kindyn sub-models
+    for (int subModelIdx = 0; subModelIdx < m_pimpl->subModelList.size(); subModelIdx++)
+    {
+        m_pimpl->kinDynWrapperList[subModelIdx]->updateInternalKinDynState();
+    }
+
+    // TODO
+    // This could be parallelized
+
+    // Update all the dynamics
+    for (auto& [name, dynamics] : m_pimpl->dynamicsList)
+    {
+        dynamics->setState(m_pimpl->currentState);
+
+        dynamics->setInput(m_pimpl->ukfInput);
+
+        if (!dynamics->update())
+        {
+            log()->error("{} Cannot update the dynamics with name `{}`.", logPrefix, name);
+            throw std::runtime_error("Error");
+        }
+
+        m_pimpl->nextState.segment(m_pimpl->stateVariableHandler.getVariable(name).offset,
+                                   m_pimpl->stateVariableHandler.getVariable(name).size) = dynamics->getUpdatedVariable();
+    }
+
+    prop_states = m_pimpl->nextState;
+}
+
+bfl::VectorDescription RDE::UkfState::getStateDescription()
+{
+    return bfl::VectorDescription(m_pimpl->stateSize);
+}
+
+std::size_t RDE::UkfState::getStateSize()
+{
+    return m_pimpl->stateSize;
+}

--- a/src/Estimators/src/ZeroVelocityDynamics.cpp
+++ b/src/Estimators/src/ZeroVelocityDynamics.cpp
@@ -1,0 +1,169 @@
+/**
+ * @file ZeroVelocityDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+bool RDE::ZeroVelocityDynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[ZeroVelocityDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covariances))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the dynamic model type
+    if (!ptr->getParameter("dynamic_model", m_dynamicModel))
+    {
+        log()->error("{} Error while retrieving the dynamic_model variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->info("{} Variable elements not found.", errorPrefix);
+        m_elements = {};
+    }
+
+    // Set the bias related variables if use_bias is true
+    if (!ptr->getParameter("use_bias", m_useBias))
+    {
+        log()->info("{} Variable use_bias not found. Set to false by default.", errorPrefix);
+    }
+    else
+    {
+        m_useBias = true;
+        m_biasVariableName = m_name + "_bias";
+    }
+
+    m_description = "Zero velocity dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::ZeroVelocityDynamics::finalize(const System::VariablesHandler &stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[ZeroVelocityDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    m_size = m_covariances.size();
+
+    m_currentState.resize(m_size);
+    m_currentState.setZero();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    // Set the bias related variables if use_bias is true
+    if (m_useBias)
+    {
+        m_bias.resize(m_size);
+        m_bias.setZero();
+    }
+
+    return true;
+}
+
+bool RDE::ZeroVelocityDynamics::setSubModels(const std::vector<RDE::SubModel>& subModelList, const std::vector<std::shared_ptr<RDE::SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    return true;
+}
+
+bool RDE::ZeroVelocityDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[FrictionTorqueStateDynamics::checkStateVariableHandler]";
+
+    // Check if the variable handler contains the variables used by this dynamics
+    if (!m_stateVariableHandler.getVariable(m_name).isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_name);
+        return false;
+    }
+
+    if (m_useBias)
+    {
+        if (!m_stateVariableHandler.getVariable(m_biasVariableName).isValid())
+        {
+            log()->error("{} The variable handler does not contain the expected state name {}.", errorPrefix, m_biasVariableName);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool RDE::ZeroVelocityDynamics::update()
+{
+    if (m_useBias)
+    {
+        m_updatedVariable = m_currentState + m_bias;
+    }
+    else
+    {
+        m_updatedVariable = m_currentState;
+    }
+
+    return true;
+}
+
+void RDE::ZeroVelocityDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_currentState = ukfState.segment(m_stateVariableHandler.getVariable(m_name).offset,
+                                      m_stateVariableHandler.getVariable(m_name).size);
+
+    if (m_useBias)
+    {
+        m_bias = ukfState.segment(m_stateVariableHandler.getVariable(m_biasVariableName).offset,
+                                  m_stateVariableHandler.getVariable(m_biasVariableName).size);
+    }
+}
+
+void RDE::ZeroVelocityDynamics::setInput(const UKFInput& ukfInput)
+{
+    return;
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/AccelerometerMeasurementDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/AccelerometerMeasurementDynamicsTest.cpp
@@ -1,5 +1,5 @@
-﻿/**
- * @file FrictionTorqueDynamicsTest.cpp
+/**
+ * @file AccelerometerMeasurementDynamics.cpp
  * @authors Ines Sorrentino
  * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the BSD-3-Clause license.
@@ -17,7 +17,7 @@
 #include <BipedalLocomotion/System/VariablesHandler.h>
 #include <BipedalLocomotion/Math/Constants.h>
 
-#include <BipedalLocomotion/RobotDynamicsEstimator/FrictionTorqueStateDynamics.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/AccelerometerMeasurementDynamics.h>
 
 using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
 using namespace BipedalLocomotion::ParametersHandler;
@@ -93,48 +93,53 @@ TEST_CASE("Friction Torque Dynamics")
     // Create parameter handler
     auto parameterHandler = std::make_shared<StdImplementation>();
 
-    const std::string name = "tau_F";
-    Eigen::VectorXd covariance(6);
-    covariance << 1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3;
-    const std::string model = "FrictionTorqueStateDynamics";
-    const std::vector<std::string> elements = {"r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll"};
-    Eigen::VectorXd k0(6);
-    k0 << 9.106, 5.03, 4.93, 12.88, 14.34, 1.12;
-    Eigen::VectorXd k1(6);
-    k1 << 200.0, 6.9, 200.0, 59.87, 200.0, 200.0;
-    Eigen::VectorXd k2(6);
-    k2 << 1.767, 5.64, 0.27, 2.0, 3.0, 0.0;
+    const std::string name = "r_leg_ft_acc";
+    Eigen::VectorXd covariance(3);
+    covariance << 2.3e-3, 1.9e-3, 3.1e-3;
+    const std::string model = "AccelerometerMeasurementDynamics";
+    const bool useBias = true;
+
     double dT = 0.01;
+
+    const std::vector<std::string> jointList = {"r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll"};
 
     parameterHandler->setParameter("name", name);
     parameterHandler->setParameter("covariance", covariance);
     parameterHandler->setParameter("dynamic_model", model);
-    parameterHandler->setParameter("elements", elements);
-    parameterHandler->setParameter("friction_k0", k0);
-    parameterHandler->setParameter("friction_k1", k1);
-    parameterHandler->setParameter("friction_k2", k2);
     parameterHandler->setParameter("sampling_time", dT);
+    parameterHandler->setParameter("use_bias", useBias);
 
-    // Create variable handler
+    // Create state variable handler
     constexpr size_t sizeVariable = 6;
     VariablesHandler variableHandler;
     REQUIRE(variableHandler.addVariable("ds", sizeVariable));
     REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
     REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_acc_bias", 3));
 
+    // Create model variable handler to load the robot model
     auto modelParamHandler = std::make_shared<StdImplementation>();
     auto emptyGroupNamesFrames = std::make_shared<StdImplementation>();
     std::vector<std::string> emptyVectorString;
     emptyGroupNamesFrames->setParameter("names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("frames", emptyVectorString);
     REQUIRE(modelParamHandler->setGroup("FT", emptyGroupNamesFrames));
-    REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", emptyGroupNamesFrames));
     REQUIRE(modelParamHandler->setGroup("GYROSCOPE", emptyGroupNamesFrames));
+
+    auto accGroup = std::make_shared<StdImplementation>();
+    std::vector<std::string> accNameList = {"r_leg_ft_acc"};
+    std::vector<std::string> accFrameList = {"r_leg_ft_sensor"};
+    accGroup->setParameter("names", accNameList);
+    accGroup->setParameter("frames", accFrameList);
+    REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", accGroup));
+
     auto emptyGroupFrames = std::make_shared<StdImplementation>();
     emptyGroupFrames->setParameter("frames", emptyVectorString);
     REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupFrames));
-    modelParamHandler->setParameter("joint_list", elements);
 
+    modelParamHandler->setParameter("joint_list", jointList);
+
+    // Load model
     iDynTree::ModelLoader modelLoader;
     createModelLoader(modelParamHandler, modelLoader);
 
@@ -158,11 +163,10 @@ TEST_CASE("Friction Torque Dynamics")
         REQUIRE(kinDynWrapperList.at(idx)->updateInternalKinDynState());
     }
 
-    FrictionTorqueStateDynamics tau_F_dynamics;
-
-    REQUIRE(tau_F_dynamics.setSubModels(subModelList, kinDynWrapperList));
-    REQUIRE(tau_F_dynamics.initialize(parameterHandler));
-    REQUIRE(tau_F_dynamics.finalize(variableHandler));
+    AccelerometerMeasurementDynamics accDynamics;
+    REQUIRE(accDynamics.setSubModels(subModelList, kinDynWrapperList));
+    REQUIRE(accDynamics.initialize(parameterHandler));
+    REQUIRE(accDynamics.finalize(variableHandler));
 
     manif::SE3d::Tangent robotBaseAcceleration;
     robotBaseAcceleration.setZero();
@@ -178,12 +182,12 @@ TEST_CASE("Friction Torque Dynamics")
 
     kinDyn->inverseDynamics(iDynTree::make_span(robotBaseAcceleration.data(),
                                                 manif::SE3d::Tangent::DoF),
-                            robotJointAcceleration,
-                            extWrench,
-                            jointTorques);
+                                                robotJointAcceleration,
+                                                extWrench,
+                                                jointTorques);
 
     Eigen::VectorXd state;
-    state.resize(variableHandler.getVariable("tau_F").offset + variableHandler.getVariable("tau_F").size + 1);
+    state.resize(variableHandler.getNumberOfVariables());
     state.setZero();
 
     int offset = variableHandler.getVariable("tau_m").offset;
@@ -193,23 +197,33 @@ TEST_CASE("Friction Torque Dynamics")
         state[offset+jointIndex] = jointTorques.jointTorques()[jointIndex];
     }
 
-    tau_F_dynamics.setState(state);
-    REQUIRE(tau_F_dynamics.update());
-    for (int idx = 0; idx < tau_F_dynamics.getUpdatedVariable().size(); idx++)
+    // Create an input for the ukf state
+    UKFInput input;
+
+    // Define joint positions
+    Eigen::VectorXd jointPos;
+    jointPos.resize(kinDyn->model().getNrOfDOFs());
+    jointPos.setZero();
+    input.robotJointPositions = jointPos;
+
+    // Define base pose
+    manif::SE3d basePose;
+    basePose.setIdentity();
+    input.robotBasePose = basePose;
+
+    // Define base velocity and acceleration
+    manif::SE3d::Tangent baseVelocity, baseAcceleration;
+    baseVelocity.setZero();
+    baseAcceleration.setZero();
+    input.robotBaseVelocity = baseVelocity;
+    input.robotBaseAcceleration = baseAcceleration;
+
+    accDynamics.setInput(input);
+    accDynamics.setState(state);
+
+    REQUIRE(accDynamics.update());
+    for (int idx = 0; idx < accDynamics.getUpdatedVariable().size(); idx++)
     {
-        REQUIRE(std::abs(tau_F_dynamics.getUpdatedVariable()(idx)) < 0.1);
+        REQUIRE(std::abs(accDynamics.getUpdatedVariable()(idx)) < 10);
     }
-
-    // Set random friction torque
-    Eigen::VectorXd currentStateTauF(covariance.size());
-    for (int index = 0; index < currentStateTauF.size(); index++)
-    {
-        currentStateTauF(index) = GENERATE(take(1, random(-30, 30)));
-    }
-
-    state.segment(variableHandler.getVariable("tau_F").offset, variableHandler.getVariable("tau_F").size) = currentStateTauF;
-
-    tau_F_dynamics.setState(state);
-
-    REQUIRE(tau_F_dynamics.update());
 }

--- a/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
+++ b/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
@@ -53,8 +53,36 @@ if(FRAMEWORK_USE_icub-models AND FRAMEWORK_COMPILE_YarpImplementation)
                            MANIF::manif
                            )
 
+    add_bipedal_test(NAME    AccelerometerMeasurementDynamics
+                     SOURCES AccelerometerMeasurementDynamicsTest.cpp
+                     LINKS   BipedalLocomotion::RobotDynamicsEstimator
+                             BipedalLocomotion::ParametersHandler
+                             BipedalLocomotion::ParametersHandlerYarpImplementation
+                             BipedalLocomotion::System
+                             icub-models::icub-models
+                             Eigen3::Eigen
+                             MANIF::manif
+                     )
+
+    add_bipedal_test(NAME GyroscopeMeasurementDynamics
+                  SOURCES GyroscopeMeasurementDynamicsTest.cpp
+                  LINKS   BipedalLocomotion::RobotDynamicsEstimator
+                          BipedalLocomotion::ParametersHandler
+                          BipedalLocomotion::ParametersHandlerYarpImplementation
+                          BipedalLocomotion::System
+                          icub-models::icub-models
+                          Eigen3::Eigen
+                          MANIF::manif
+                  )
+
     add_bipedal_test(NAME     UkfState
                      SOURCES  UkfStateTest.cpp
+                     LINKS    BipedalLocomotion::RobotDynamicsEstimator BipedalLocomotion::ManifConversions BipedalLocomotion::ParametersHandlerYarpImplementation
+                              icub-models::icub-models
+                     )
+
+    add_bipedal_test(NAME     UkfMeasurement
+                     SOURCES  UkfMeasurementTest.cpp
                      LINKS    BipedalLocomotion::RobotDynamicsEstimator BipedalLocomotion::ManifConversions BipedalLocomotion::ParametersHandlerYarpImplementation
                               icub-models::icub-models
                      )

--- a/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
+++ b/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
@@ -23,6 +23,42 @@ if(FRAMEWORK_USE_icub-models AND FRAMEWORK_COMPILE_YarpImplementation)
                            MANIF::manif
                            )
 
+    add_bipedal_test(NAME ZeroVelocityDynamics
+                     SOURCES ZeroVelocityDynamicsTest.cpp
+                     LINKS BipedalLocomotion::RobotDynamicsEstimator
+                           BipedalLocomotion::ParametersHandler
+                           BipedalLocomotion::ParametersHandlerYarpImplementation
+                           icub-models::icub-models
+                           Eigen3::Eigen
+                           )
+
+    add_bipedal_test(NAME FrictionTorqueStateDynamics
+                     SOURCES FrictionTorqueStateDynamicsTest.cpp
+                     LINKS BipedalLocomotion::RobotDynamicsEstimator
+                           BipedalLocomotion::ParametersHandler
+                           BipedalLocomotion::ParametersHandlerYarpImplementation
+                           BipedalLocomotion::System
+                           icub-models::icub-models
+                           Eigen3::Eigen
+                           )
+
+    add_bipedal_test(NAME JointVelocityStateDynamics
+                     SOURCES JointVelocityStateDynamicsTest.cpp
+                     LINKS BipedalLocomotion::RobotDynamicsEstimator
+                           BipedalLocomotion::ParametersHandler
+                           BipedalLocomotion::ParametersHandlerYarpImplementation
+                           BipedalLocomotion::System
+                           icub-models::icub-models
+                           Eigen3::Eigen
+                           MANIF::manif
+                           )
+
+    add_bipedal_test(NAME     UkfState
+                     SOURCES  UkfStateTest.cpp
+                     LINKS    BipedalLocomotion::RobotDynamicsEstimator BipedalLocomotion::ManifConversions BipedalLocomotion::ParametersHandlerYarpImplementation
+                              icub-models::icub-models
+                     )
+
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/ConfigFolderPath.h.in" "${CMAKE_CURRENT_BINARY_DIR}/ConfigFolderPath.h" @ONLY)
 

--- a/src/Estimators/tests/RobotDynamicsEstimator/FrictionTorqueStateDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/FrictionTorqueStateDynamicsTest.cpp
@@ -1,0 +1,216 @@
+﻿/**
+ * @file FrictionTorqueDynamicsTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <ConfigFolderPath.h>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/Math/Constants.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/FrictionTorqueStateDynamics.h>
+
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+
+void createModelLoader(IParametersHandler::shared_ptr group,
+                       iDynTree::ModelLoader& mdlLdr)
+{
+    // List of joints and fts to load the model
+    std::vector<SubModel> subModelList;
+
+    const std::string modelPath = iCubModels::getModelFile("iCubGenova09");
+
+    std::vector<std::string> jointList;
+    REQUIRE(group->getParameter("joint_list", jointList));
+
+    std::vector<std::string> ftFramesList;
+    auto ftGroup = group->getGroup("FT").lock();
+    REQUIRE(ftGroup->getParameter("frames", ftFramesList));
+
+    std::vector<std::string> jointsAndFTs;
+    jointsAndFTs.insert(jointsAndFTs.begin(), jointList.begin(), jointList.end());
+//    jointsAndFTs.insert(jointsAndFTs.end(), ftFramesList.begin(), ftFramesList.end());
+
+    REQUIRE(mdlLdr.loadReducedModelFromFile(modelPath, jointsAndFTs));
+}
+
+void createSubModels(iDynTree::ModelLoader& mdlLdr,
+                     std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                     IParametersHandler::shared_ptr group,
+                     SubModelCreator& subModelCreator)
+{
+    subModelCreator.setModelAndSensors(mdlLdr.model(), mdlLdr.sensors());
+    REQUIRE(subModelCreator.setKinDyn(kinDynFullModel));
+
+    REQUIRE(subModelCreator.createSubModels(group));
+}
+
+bool setStaticState(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    size_t dofs = kinDyn->getNrOfDegreesOfFreedom();
+    iDynTree::Transform worldTbase;
+    Eigen::VectorXd baseVel(6);
+    Eigen::Vector3d gravity;
+
+    Eigen::VectorXd qj(dofs), dqj(dofs), ddqj(dofs);
+
+    worldTbase = iDynTree::Transform(iDynTree::Rotation::Identity(), iDynTree::Position::Zero());
+
+    Eigen::Matrix4d transform = toEigen(worldTbase.asHomogeneousTransform());
+
+    gravity.setZero();
+    gravity(2) = - BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+
+    baseVel.setZero();
+
+    for (size_t dof = 0; dof < dofs; dof++)
+    {
+        qj(dof) = 0.0;
+        dqj(dof) = 0.0;
+        ddqj(dof) = 0.0;
+    }
+
+    return kinDyn->setRobotState(transform,
+                                 iDynTree::make_span(qj.data(), qj.size()),
+                                 iDynTree::make_span(baseVel.data(), baseVel.size()),
+                                 iDynTree::make_span(dqj.data(), dqj.size()),
+                                 iDynTree::make_span(gravity.data(), gravity.size()));
+}
+
+TEST_CASE("Friction Torque Dynamics")
+{
+    // Create parameter handler
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    const std::string name = "tau_F";
+    Eigen::VectorXd covariance(6);
+    covariance << 1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3;
+    const std::string model = "FrictionTorqueStateDynamics";
+    const std::vector<std::string> elements = {"r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll"};
+    Eigen::VectorXd k0(6);
+    k0 << 9.106, 5.03, 4.93, 12.88, 14.34, 1.12;
+    Eigen::VectorXd k1(6);
+    k1 << 200.0, 6.9, 200.0, 59.87, 200.0, 200.0;
+    Eigen::VectorXd k2(6);
+    k2 << 1.767, 5.64, 0.27, 2.0, 3.0, 0.0;
+    double dT = 0.01;
+
+    parameterHandler->setParameter("name", name);
+    parameterHandler->setParameter("covariance", covariance);
+    parameterHandler->setParameter("dynamic_model", model);
+    parameterHandler->setParameter("elements", elements);
+    parameterHandler->setParameter("friction_k0", k0);
+    parameterHandler->setParameter("friction_k1", k1);
+    parameterHandler->setParameter("friction_k2", k2);
+    parameterHandler->setParameter("sampling_time", dT);
+
+    // Create variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+
+    auto modelParamHandler = std::make_shared<StdImplementation>();
+    auto emptyGroupNamesFrames = std::make_shared<StdImplementation>();
+    std::vector<std::string> emptyVectorString;
+    emptyGroupNamesFrames->setParameter("names", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("frames", emptyVectorString);
+    REQUIRE(modelParamHandler->setGroup("FT", emptyGroupNamesFrames));
+    REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", emptyGroupNamesFrames));
+    REQUIRE(modelParamHandler->setGroup("GYROSCOPE", emptyGroupNamesFrames));
+    auto emptyGroupFrames = std::make_shared<StdImplementation>();
+    emptyGroupFrames->setParameter("frames", emptyVectorString);
+    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupFrames));
+    modelParamHandler->setParameter("joint_list", elements);
+
+    iDynTree::ModelLoader modelLoader;
+    createModelLoader(modelParamHandler, modelLoader);
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    REQUIRE(kinDyn->loadRobotModel(modelLoader.model()));
+    REQUIRE(kinDyn->setFrameVelocityRepresentation(iDynTree::BODY_FIXED_REPRESENTATION));
+
+    REQUIRE(setStaticState(kinDyn));
+
+    SubModelCreator subModelCreator;
+    createSubModels(modelLoader, kinDyn, modelParamHandler, subModelCreator);
+
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperList;
+    const auto & subModelList = subModelCreator.getSubModelList();
+
+    for (int idx = 0; idx < subModelCreator.getSubModelList().size(); idx++)
+    {
+        kinDynWrapperList.emplace_back(std::make_shared<SubModelKinDynWrapper>());
+        REQUIRE(kinDynWrapperList.at(idx)->setKinDyn(kinDyn));
+        REQUIRE(kinDynWrapperList.at(idx)->initialize(subModelList[idx]));
+        REQUIRE(kinDynWrapperList.at(idx)->updateInternalKinDynState());
+    }
+
+    FrictionTorqueStateDynamics tau_F_dynamics;
+
+    REQUIRE(tau_F_dynamics.setSubModels(subModelList, kinDynWrapperList));
+    REQUIRE(tau_F_dynamics.initialize(parameterHandler));
+    REQUIRE(tau_F_dynamics.finalize(variableHandler));
+
+    manif::SE3d::Tangent robotBaseAcceleration;
+    robotBaseAcceleration.setZero();
+
+    Eigen::VectorXd robotJointAcceleration(kinDyn->model().getNrOfDOFs());
+    robotJointAcceleration.setZero();
+
+    iDynTree::LinkNetExternalWrenches extWrench(kinDyn->model());
+    extWrench.zero();
+
+    // Compute joint torques in static configuration from inverse dynamics on the full model
+    iDynTree::FreeFloatingGeneralizedTorques jointTorques(kinDyn->model());
+
+    kinDyn->inverseDynamics(iDynTree::make_span(robotBaseAcceleration.data(),
+                                                manif::SE3d::Tangent::DoF),
+                            robotJointAcceleration,
+                            extWrench,
+                            jointTorques);
+
+    Eigen::VectorXd state;
+    state.resize(variableHandler.getVariable("tau_F").offset + variableHandler.getVariable("tau_F").size + 1);
+    state.setZero();
+
+    int offset = variableHandler.getVariable("tau_m").offset;
+    int size = variableHandler.getVariable("tau_m").size;
+    for (int jointIndex = 0; jointIndex < size; jointIndex++)
+    {
+        state[offset+jointIndex] = jointTorques.jointTorques()[jointIndex];
+    }
+
+    // Test with state set to zero.
+    tau_F_dynamics.setState(state);
+    REQUIRE(tau_F_dynamics.update());
+    for (int idx = 0; idx < tau_F_dynamics.getUpdatedVariable().size(); idx++)
+    {
+        REQUIRE(std::abs(tau_F_dynamics.getUpdatedVariable()(idx)) < 0.1);
+    }
+
+    // Set random friction torque
+    Eigen::VectorXd currentStateTauF(covariance.size());
+    for (int index = 0; index < currentStateTauF.size(); index++)
+    {
+        currentStateTauF(index) = GENERATE(take(1, random(-30, 30)));
+    }
+
+    state.segment(variableHandler.getVariable("tau_F").offset, variableHandler.getVariable("tau_F").size) = currentStateTauF;
+
+    tau_F_dynamics.setState(state);
+
+    REQUIRE(tau_F_dynamics.update());
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/JointVelocityStateDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/JointVelocityStateDynamicsTest.cpp
@@ -1,0 +1,263 @@
+/**
+ * @file FrictionTorqueDynamicsTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <ConfigFolderPath.h>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+
+// iDynTree
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/Math/Constants.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/JointVelocityStateDynamics.h>
+
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+
+IParametersHandler::shared_ptr loadParameterHandler()
+{
+    std::shared_ptr<YarpImplementation> originalHandler = std::make_shared<YarpImplementation>();
+    IParametersHandler::shared_ptr parameterHandler = originalHandler;
+
+    yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
+    rf.setDefaultConfigFile("/config/model.ini");
+
+    std::vector<std::string> arguments = {" ", "--from ", getConfigPath()};
+
+    std::vector<char*> argv;
+    for (const auto& arg : arguments)
+        argv.push_back((char*)arg.data());
+    argv.push_back(nullptr);
+
+    rf.configure(argv.size() - 1, argv.data());
+
+    REQUIRE_FALSE(rf.isNull());
+    parameterHandler->clear();
+    REQUIRE(parameterHandler->isEmpty());
+    originalHandler->set(rf);
+
+    auto group = parameterHandler->getGroup("MODEL").lock();
+    REQUIRE(group != nullptr);
+
+    return group;
+}
+
+void createModelLoader(IParametersHandler::shared_ptr group,
+                       iDynTree::ModelLoader& mdlLdr)
+{
+    // List of joints and fts to load the model
+    std::vector<SubModel> subModelList;
+
+    const std::string modelPath = iCubModels::getModelFile("iCubGenova09");
+
+    std::vector<std::string> jointList;
+    REQUIRE(group->getParameter("joint_list", jointList));
+
+    std::vector<std::string> ftFramesList;
+    auto ftGroup = group->getGroup("FT").lock();
+    REQUIRE(ftGroup->getParameter("frames", ftFramesList));
+
+    std::vector<std::string> jointsAndFTs;
+    jointsAndFTs.insert(jointsAndFTs.begin(), jointList.begin(), jointList.end());
+    jointsAndFTs.insert(jointsAndFTs.end(), ftFramesList.begin(), ftFramesList.end());
+
+    REQUIRE(mdlLdr.loadReducedModelFromFile(modelPath, jointsAndFTs));
+}
+
+void createSubModels(iDynTree::ModelLoader& mdlLdr,
+                     std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                     IParametersHandler::shared_ptr group,
+                     bool useFTSensors,
+                     SubModelCreator& subModelCreator)
+{
+    subModelCreator.setModelAndSensors(mdlLdr.model(), mdlLdr.sensors());
+    REQUIRE(subModelCreator.setKinDyn(kinDynFullModel));
+
+    if (useFTSensors)
+    {
+        REQUIRE(subModelCreator.createSubModels(group));
+    }
+    else
+    {
+        auto groupEmpty = group->clone();
+        groupEmpty->clear();
+
+        std::vector<std::string> jointList;
+        group->getParameter("joint_list", jointList);
+        groupEmpty->setParameter("joint_list", jointList);
+
+        std::shared_ptr<IParametersHandler> emptySubGroup = groupEmpty->clone();
+        emptySubGroup->clear();
+        std::vector<std::string> emptyVector;
+        emptySubGroup->setParameter("names", emptyVector);
+        emptySubGroup->setParameter("frames", emptyVector);
+        groupEmpty->setGroup("FT", emptySubGroup);
+        groupEmpty->setGroup("ACCELEROMETER", emptySubGroup);
+        groupEmpty->setGroup("GYROSCOPE", emptySubGroup);
+        groupEmpty->setGroup("EXTERNAL_CONTACT", emptySubGroup);
+
+        REQUIRE(subModelCreator.createSubModels(groupEmpty));
+    }
+}
+
+bool setStaticState(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    size_t dofs = kinDyn->getNrOfDegreesOfFreedom();
+    iDynTree::Transform worldTbase;
+    Eigen::VectorXd baseVel(6);
+    Eigen::Vector3d gravity;
+
+    Eigen::VectorXd qj(dofs), dqj(dofs), ddqj(dofs);
+
+    worldTbase = iDynTree::Transform(iDynTree::Rotation::Identity(), iDynTree::Position::Zero());
+
+    Eigen::Matrix4d transform = toEigen(worldTbase.asHomogeneousTransform());
+
+    gravity.setZero();
+    gravity(2) = -BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+
+    baseVel.setZero();
+
+    for (size_t dof = 0; dof < dofs; dof++)
+    {
+        qj(dof) = 0.0;
+        dqj(dof) = 0.0;
+        ddqj(dof) = 0.0;
+    }
+
+    return kinDyn->setRobotState(transform,
+                                 iDynTree::make_span(qj.data(), qj.size()),
+                                 iDynTree::make_span(baseVel.data(), baseVel.size()),
+                                 iDynTree::make_span(dqj.data(), dqj.size()),
+                                 iDynTree::make_span(gravity.data(), gravity.size()));
+}
+
+TEST_CASE("Joint Velocity Dynamics")
+{
+    // Create parameter handler
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    const std::string name = "ds";
+    Eigen::VectorXd covariance(6);
+    covariance << 1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3;
+    std::string model = "JointVelocityStateDynamics";
+    const std::vector<std::string> elements = {"r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll"};
+    double dT = 0.01;
+
+    parameterHandler->setParameter("name", name);
+    parameterHandler->setParameter("covariance", covariance);
+    parameterHandler->setParameter("dynamic_model", model);
+    parameterHandler->setParameter("elements", elements);
+    parameterHandler->setParameter("sampling_time", dT);
+
+    // Create variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_sensor", 6));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_sensor", 6));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft_sensor", 6));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_sensor_bias", 6));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_sensor_bias", 6));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft_sensor_bias", 6));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_acc_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_acc_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft_acc_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_gyro_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_gyro_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft_gyro_bias", 3));
+
+    auto handlerFromConfig = loadParameterHandler();
+
+    iDynTree::ModelLoader modelLoader;
+    createModelLoader(handlerFromConfig, modelLoader);
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    REQUIRE(kinDyn->loadRobotModel(modelLoader.model()));
+
+    REQUIRE(setStaticState(kinDyn));
+
+    bool useFT = true;
+
+    SubModelCreator subModelCreatorWithFT;
+    createSubModels(modelLoader, kinDyn, handlerFromConfig, useFT, subModelCreatorWithFT);
+
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperListWithFT;
+    const auto & subModelListWithFT = subModelCreatorWithFT.getSubModelList();
+
+    for (int idx = 0; idx < subModelCreatorWithFT.getSubModelList().size(); idx++)
+    {
+        kinDynWrapperListWithFT.emplace_back(std::make_shared<SubModelKinDynWrapper>());
+        REQUIRE(kinDynWrapperListWithFT.at(idx)->setKinDyn(kinDyn));
+        REQUIRE(kinDynWrapperListWithFT.at(idx)->initialize(subModelListWithFT[idx]));
+        REQUIRE(kinDynWrapperListWithFT.at(idx)->updateInternalKinDynState());
+    }
+
+    JointVelocityStateDynamics dsSplit;
+    model = "JointVelocityStateDynamics";
+    parameterHandler->setParameter("dynamic_model", model);
+    REQUIRE(dsSplit.setSubModels(subModelListWithFT, kinDynWrapperListWithFT));
+    REQUIRE(dsSplit.initialize(parameterHandler));
+    REQUIRE(dsSplit.finalize(variableHandler));
+
+    Eigen::VectorXd state;
+    state.resize(variableHandler.getVariable("r_foot_rear_ft_gyro_bias").offset + variableHandler.getVariable("r_foot_rear_ft_gyro_bias").size + 1);
+    state.setZero();
+
+    auto massSecondSubModel = subModelListWithFT.at(1).getModel().getTotalMass();
+    state(variableHandler.getVariable("r_leg_ft_sensor").offset+2) = massSecondSubModel * BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+
+    dsSplit.setState(state);
+
+    REQUIRE(dsSplit.update());
+
+    std::cout << "Updated state splitting the model" << std::endl;
+    std::cout << dsSplit.getUpdatedVariable() << std::endl;
+
+    useFT = false;
+
+    SubModelCreator subModelCreatorWithoutFT;
+    createSubModels(modelLoader, kinDyn, handlerFromConfig, useFT, subModelCreatorWithoutFT);
+
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperListWithoutFT;
+    const auto & subModelListWithoutFT = subModelCreatorWithoutFT.getSubModelList();
+
+    for (int idx = 0; idx < subModelCreatorWithoutFT.getSubModelList().size(); idx++)
+    {
+        kinDynWrapperListWithoutFT.emplace_back(std::make_shared<SubModelKinDynWrapper>());
+        REQUIRE(kinDynWrapperListWithoutFT.at(idx)->setKinDyn(kinDyn));
+        REQUIRE(kinDynWrapperListWithoutFT.at(idx)->initialize(subModelListWithoutFT[idx]));
+        REQUIRE(kinDynWrapperListWithoutFT.at(idx)->updateInternalKinDynState());
+    }
+
+        JointVelocityStateDynamics dsNotSplit;
+        model = "JointVelocityStateDynamics";
+        parameterHandler->setParameter("dynamic_model", model);
+        REQUIRE(dsNotSplit.setSubModels(subModelListWithoutFT, kinDynWrapperListWithoutFT));
+        REQUIRE(dsNotSplit.initialize(parameterHandler));
+        REQUIRE(dsNotSplit.finalize(variableHandler));
+
+        dsNotSplit.setState(state);
+
+        REQUIRE(dsNotSplit.update());
+
+        std::cout << "Updated state without splitting the model" << std::endl;
+        std::cout << dsNotSplit.getUpdatedVariable() << std::endl;
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/UkfMeasurementTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/UkfMeasurementTest.cpp
@@ -1,0 +1,252 @@
+/**
+ * @file UkfMeasurementTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch.hpp>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+#include <ConfigFolderPath.h>
+
+//BLF
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+
+// iDynTree
+#include <iDynTree/ModelIO/ModelLoader.h>
+#include <iDynTree/KinDynComputations.h>
+
+//LIBRARYTOTEST
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/UkfMeasurement.h>
+
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+IParametersHandler::shared_ptr loadParameterHandler()
+{
+    std::shared_ptr<YarpImplementation> originalHandler = std::make_shared<YarpImplementation>();
+    IParametersHandler::shared_ptr parameterHandler = originalHandler;
+
+    yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
+    rf.setDefaultConfigFile("/config/config.ini");
+
+    std::vector<std::string> arguments = {" ", "--from ", getConfigPath()};
+
+    std::vector<char*> argv;
+    for (const auto& arg : arguments)
+        argv.push_back((char*)arg.data());
+    argv.push_back(nullptr);
+
+    rf.configure(argv.size() - 1, argv.data());
+
+    REQUIRE_FALSE(rf.isNull());
+    parameterHandler->clear();
+    REQUIRE(parameterHandler->isEmpty());
+
+    originalHandler->set(rf);
+
+    return parameterHandler;
+}
+
+void createModelLoader(IParametersHandler::weak_ptr group,
+                       iDynTree::ModelLoader& mdlLdr)
+{
+    // List of joints and fts to load the model
+    std::vector<SubModel> subModelList;
+
+    const std::string modelPath = iCubModels::getModelFile("iCubGenova09");
+
+    std::vector<std::string> jointList;
+    REQUIRE(group.lock()->getParameter("joint_list", jointList));
+
+    std::vector<std::string> ftFramesList;
+    auto ftGroup = group.lock()->getGroup("FT").lock();
+    REQUIRE(ftGroup->getParameter("frames", ftFramesList));
+
+    std::vector<std::string> jointsAndFTs;
+    jointsAndFTs.insert(jointsAndFTs.begin(), jointList.begin(), jointList.end());
+    jointsAndFTs.insert(jointsAndFTs.end(), ftFramesList.begin(), ftFramesList.end());
+
+    REQUIRE(mdlLdr.loadReducedModelFromFile(modelPath, jointsAndFTs));
+}
+
+TEST_CASE("UkfMeasurement")
+{
+    auto parameterHandler = loadParameterHandler();
+
+    iDynTree::ModelLoader modelLoader;
+    auto modelHandler = parameterHandler->getGroup("MODEL").lock();
+
+    REQUIRE_FALSE(modelHandler == nullptr);
+
+    createModelLoader(modelHandler, modelLoader);
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    REQUIRE(kinDyn->loadRobotModel(modelLoader.model()));
+
+    std::vector<std::pair<std::shared_ptr<SubModel>, std::shared_ptr<SubModelKinDynWrapper>>> subModelMap;
+
+    SubModelCreator subModelCreator;
+    subModelCreator.setModelAndSensors(kinDyn->model(), modelLoader.sensors());
+    REQUIRE(subModelCreator.setKinDyn(kinDyn));
+
+    REQUIRE(subModelCreator.createSubModels(modelHandler));
+
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperList;
+
+    const auto & subModelList = subModelCreator.getSubModelList();
+
+    for (int idx = 0; idx < subModelList.size(); idx++)
+    {
+        kinDynWrapperList.emplace_back(std::make_shared<SubModelKinDynWrapper>());
+        REQUIRE(kinDynWrapperList.at(idx)->setKinDyn(kinDyn));
+        REQUIRE(kinDynWrapperList.at(idx)->initialize(subModelList[idx]));
+        REQUIRE(kinDynWrapperList.at(idx)->updateInternalKinDynState());
+    }
+
+    // Build the UkfState
+    auto groupUKF = parameterHandler->getGroup("UKF").lock();
+    REQUIRE_FALSE(groupUKF == nullptr);
+
+    auto groupUKFMeasurementTmp = groupUKF->getGroup("UKF_MEASUREMENT").lock();
+    REQUIRE_FALSE(groupUKFMeasurementTmp == nullptr);
+
+    auto groupUKFMeasurement = groupUKFMeasurementTmp->clone();
+    double dT;
+    REQUIRE(parameterHandler->getGroup("GENERAL").lock()->getParameter("sampling_time", dT));
+    groupUKFMeasurement->setParameter("sampling_time", dT);
+
+    // Create the state variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler stateVariableHandler;
+    REQUIRE(stateVariableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(stateVariableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(stateVariableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(stateVariableHandler.addVariable("r_leg_ft_sensor", 6));
+    REQUIRE(stateVariableHandler.addVariable("r_foot_front_ft_sensor", 6));
+    REQUIRE(stateVariableHandler.addVariable("r_foot_rear_ft_sensor", 6));
+    REQUIRE(stateVariableHandler.addVariable("r_leg_ft_sensor_bias", 6));
+    REQUIRE(stateVariableHandler.addVariable("r_foot_front_ft_sensor_bias", 6));
+    REQUIRE(stateVariableHandler.addVariable("r_foot_rear_ft_sensor_bias", 6));
+    REQUIRE(stateVariableHandler.addVariable("r_leg_ft_acc_bias", 3));
+    REQUIRE(stateVariableHandler.addVariable("r_foot_front_ft_acc_bias", 3));
+    REQUIRE(stateVariableHandler.addVariable("r_foot_rear_ft_acc_bias", 3));
+    REQUIRE(stateVariableHandler.addVariable("r_leg_ft_gyro_bias", 3));
+    REQUIRE(stateVariableHandler.addVariable("r_foot_front_ft_gyro_bias", 3));
+    REQUIRE(stateVariableHandler.addVariable("r_foot_rear_ft_gyro_bias", 3));
+
+    std::unique_ptr<UkfMeasurement> measurementModel = UkfMeasurement::build(groupUKFMeasurement,
+                                                                             stateVariableHandler,
+                                                                             kinDyn,
+                                                                             subModelList,
+                                                                             kinDynWrapperList);
+
+    REQUIRE(measurementModel != nullptr);
+
+    // Create an input for the ukf state
+    UKFInput input;
+
+    // Define joint positions
+    Eigen::VectorXd jointPos;
+    jointPos.resize(kinDyn->model().getNrOfDOFs());
+    jointPos.setZero();
+    input.robotJointPositions = jointPos;
+
+    // Define base pose
+    manif::SE3d basePose;
+    basePose.setIdentity();
+    input.robotBasePose = basePose;
+
+    // Define base velocity and acceleration
+    manif::SE3d::Tangent baseVelocity, baseAcceleration;
+    baseVelocity.setZero();
+    baseAcceleration.setZero();
+    input.robotBaseVelocity = baseVelocity;
+    input.robotBaseAcceleration = baseAcceleration;
+
+    std::shared_ptr<UkfInputProvider> inputProvider = std::make_shared<UkfInputProvider>();
+
+    BipedalLocomotion::System::VariablesHandler measurementHandler = measurementModel->getMeasurementVariableHandler();
+//    int measurementSize = measurementModel->getMeasurementSize();
+    int stateSize = stateVariableHandler.getNumberOfVariables();
+
+    measurementModel->setUkfInputProvider(inputProvider);
+
+    Eigen::VectorXd currentState;
+    currentState.resize(stateSize);
+    currentState.setZero();
+
+    Eigen::VectorXd motorTorques;
+    motorTorques.resize(kinDyn->model().getNrOfDOFs());
+    motorTorques << -1.6298, -1.10202, 0, -0.74, 0.0877, -0.00173;
+    Eigen::VectorXd wrenchFTtLeg;
+    wrenchFTtLeg.resize(6);
+    wrenchFTtLeg << 0, 0, 100.518, 0.748, 0.91, 0;
+    Eigen::VectorXd wrenchFTFootFront;
+    wrenchFTFootFront.resize(6);
+    wrenchFTFootFront << 0, 0, 1.761, -0.001, 0.0003, 0;
+    Eigen::VectorXd wrenchFTFootRear;
+    wrenchFTFootRear.resize(6);
+    wrenchFTFootRear << 0, 0, 1.752, 0.000876, 0.000649, 0;
+
+    currentState.segment(stateVariableHandler.getVariable("tau_m").offset, stateVariableHandler.getVariable("tau_m").size) = motorTorques;
+    currentState.segment(stateVariableHandler.getVariable("r_leg_ft_sensor").offset, stateVariableHandler.getVariable("r_leg_ft_sensor").size) = wrenchFTtLeg;
+    currentState.segment(stateVariableHandler.getVariable("r_foot_front_ft_sensor").offset, stateVariableHandler.getVariable("r_foot_front_ft_sensor").size) = wrenchFTFootFront;
+    currentState.segment(stateVariableHandler.getVariable("r_foot_rear_ft_sensor").offset, stateVariableHandler.getVariable("r_foot_rear_ft_sensor").size) = wrenchFTFootRear;
+    currentState.segment(stateVariableHandler.getVariable("r_foot_rear_ft_sensor").offset, stateVariableHandler.getVariable("r_foot_rear_ft_sensor").size) = wrenchFTFootRear;
+
+    REQUIRE(inputProvider->setInput(input));
+
+    std::map<std::string, Eigen::VectorXd> measurement;
+
+    Eigen::VectorXd i_m;
+    i_m.resize(kinDyn->model().getNrOfDOFs());
+    i_m << -0.1468, 0.2345, 0, -0.0667, 0.008, -0.000692;
+    measurement["i_m"] = i_m;
+    measurement["r_leg_ft_sensor"] = wrenchFTtLeg;
+    measurement["r_foot_front_ft_sensor"] = wrenchFTFootFront;
+    measurement["r_foot_rear_ft_sensor"] = wrenchFTFootRear;
+
+    Eigen::Vector3d zeroVec3;
+    zeroVec3.setZero();
+
+    measurement["r_leg_ft_gyro"] = zeroVec3;
+    measurement["r_foot_front_ft_gyro"] = zeroVec3;
+    measurement["r_foot_rear_ft_gyro"] = zeroVec3;
+
+    Eigen::Vector3d gravVec;
+    gravVec.setZero();
+    gravVec(2) = 9.8066;
+
+    measurement["r_leg_ft_acc"] = gravVec;
+    measurement["r_foot_front_ft_acc"] = gravVec;
+    measurement["r_foot_rear_ft_acc"] = gravVec;
+
+    Eigen::VectorXd zeroVector6(stateVariableHandler.getVariable("tau_m").size);
+    zeroVector6.setZero();
+    measurement["ds"] = zeroVector6;
+
+    bfl::Data updatedMeasurementTmp;
+
+    bool resultOk;
+
+    REQUIRE(measurementModel->freeze(measurement));
+
+    std::tie(resultOk, updatedMeasurementTmp) = measurementModel->predictedMeasure(currentState);
+
+    REQUIRE(resultOk);
+
+    Eigen::VectorXd updatedMeasurement = bfl::any::any_cast<Eigen::VectorXd&&>(std::move(updatedMeasurementTmp));
+
+    for (int idx = 0; idx < updatedMeasurement.size(); idx++)
+    {
+        REQUIRE(std::abs(updatedMeasurement[idx]) < 200);
+    }
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/UkfStateTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/UkfStateTest.cpp
@@ -1,0 +1,192 @@
+/**
+ * @file UkfStateTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch.hpp>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+#include <ConfigFolderPath.h>
+
+//BLF
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+
+// iDynTree
+#include <iDynTree/ModelIO/ModelLoader.h>
+#include <iDynTree/KinDynComputations.h>
+
+//LIBRARYTOTEST
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/UkfState.h>
+
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+IParametersHandler::shared_ptr loadParameterHandler()
+{
+    std::shared_ptr<YarpImplementation> originalHandler = std::make_shared<YarpImplementation>();
+    IParametersHandler::shared_ptr parameterHandler = originalHandler;
+
+    yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
+    rf.setDefaultConfigFile("/config/config.ini");
+
+    std::vector<std::string> arguments = {" ", "--from ", getConfigPath()};
+
+    std::vector<char*> argv;
+    for (const auto& arg : arguments)
+        argv.push_back((char*)arg.data());
+    argv.push_back(nullptr);
+
+    rf.configure(argv.size() - 1, argv.data());
+
+    REQUIRE_FALSE(rf.isNull());
+    parameterHandler->clear();
+    REQUIRE(parameterHandler->isEmpty());
+
+    originalHandler->set(rf);
+
+    return parameterHandler;
+}
+
+void createModelLoader(IParametersHandler::weak_ptr group,
+                       iDynTree::ModelLoader& mdlLdr)
+{
+    // List of joints and fts to load the model
+    std::vector<SubModel> subModelList;
+
+    const std::string modelPath = iCubModels::getModelFile("iCubGenova09");
+
+    std::vector<std::string> jointList;
+    REQUIRE(group.lock()->getParameter("joint_list", jointList));
+
+    std::vector<std::string> ftFramesList;
+    auto ftGroup = group.lock()->getGroup("FT").lock();
+    REQUIRE(ftGroup->getParameter("frames", ftFramesList));
+
+    std::vector<std::string> jointsAndFTs;
+    jointsAndFTs.insert(jointsAndFTs.begin(), jointList.begin(), jointList.end());
+    jointsAndFTs.insert(jointsAndFTs.end(), ftFramesList.begin(), ftFramesList.end());
+
+    REQUIRE(mdlLdr.loadReducedModelFromFile(modelPath, jointsAndFTs));
+}
+
+TEST_CASE("UkfState")
+{
+    auto parameterHandler = loadParameterHandler();
+
+    iDynTree::ModelLoader modelLoader;
+    auto modelHandler = parameterHandler->getGroup("MODEL").lock();
+
+    REQUIRE_FALSE(modelHandler == nullptr);
+
+    createModelLoader(modelHandler, modelLoader);
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    REQUIRE(kinDyn->loadRobotModel(modelLoader.model()));
+
+    std::vector<std::pair<std::shared_ptr<SubModel>, std::shared_ptr<SubModelKinDynWrapper>>> subModelMap;
+
+    SubModelCreator subModelCreator;
+    subModelCreator.setModelAndSensors(kinDyn->model(), modelLoader.sensors());
+    REQUIRE(subModelCreator.setKinDyn(kinDyn));
+
+    REQUIRE(subModelCreator.createSubModels(modelHandler));
+
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperList;
+
+    const auto & subModelList = subModelCreator.getSubModelList();
+
+    for (int idx = 0; idx < subModelList.size(); idx++)
+    {
+        kinDynWrapperList.emplace_back(std::make_shared<SubModelKinDynWrapper>());
+        REQUIRE(kinDynWrapperList.at(idx)->setKinDyn(kinDyn));
+        REQUIRE(kinDynWrapperList.at(idx)->initialize(subModelList[idx]));
+        REQUIRE(kinDynWrapperList.at(idx)->updateInternalKinDynState());
+    }
+
+    // Build the UkfState
+    auto groupUKF = parameterHandler->getGroup("UKF").lock();
+    REQUIRE_FALSE(groupUKF == nullptr);
+
+    auto groupUKFStateTmp = groupUKF->getGroup("UKF_STATE").lock();
+    REQUIRE_FALSE(groupUKFStateTmp == nullptr);
+
+    auto groupUKFState = groupUKFStateTmp->clone();
+    double dT;
+    REQUIRE(parameterHandler->getGroup("GENERAL").lock()->getParameter("sampling_time", dT));
+    groupUKFState->setParameter("sampling_time", dT);
+
+    std::unique_ptr<UkfState> stateModel = UkfState::build(groupUKFState,
+                                                           kinDyn,
+                                                           subModelList,
+                                                           kinDynWrapperList);
+
+    // Create an input for the ukf state
+    UKFInput input;
+
+    // Define joint positions
+    Eigen::VectorXd jointPos;
+    jointPos.resize(kinDyn->model().getNrOfDOFs());
+    jointPos.setZero();
+    input.robotJointPositions = jointPos;
+
+    // Define base pose
+    manif::SE3d basePose;
+    basePose.setIdentity();
+    input.robotBasePose = basePose;
+
+    // Define base velocity and acceleration
+    manif::SE3d::Tangent baseVelocity, baseAcceleration;
+    baseVelocity.setZero();
+    baseAcceleration.setZero();
+    input.robotBaseVelocity = baseVelocity;
+    input.robotBaseAcceleration = baseAcceleration;
+
+    std::shared_ptr<UkfInputProvider> inputProvider = std::make_shared<UkfInputProvider>();
+
+    BipedalLocomotion::System::VariablesHandler stateHandler = stateModel->getStateVariableHandler();
+    int stateSize = stateModel->getStateSize();
+
+    stateModel->setUkfInputProvider(inputProvider);
+
+    Eigen::VectorXd currentState;
+    currentState.resize(stateSize);
+    currentState.setZero();
+
+    Eigen::VectorXd motorTorques;
+    motorTorques.resize(kinDyn->model().getNrOfDOFs());
+    motorTorques << -1.6298, -1.10202, 0, -0.74, 0.0877, -0.00173;
+    Eigen::VectorXd wrenchFTtLeg;
+    wrenchFTtLeg.resize(6);
+    wrenchFTtLeg << 0, 0, 100.518, 0.748, 0.91, 0;
+    Eigen::VectorXd wrenchFTFootFront;
+    wrenchFTFootFront.resize(6);
+    wrenchFTFootFront << 0, 0, 1.761, -0.001, 0.0003, 0;
+    Eigen::VectorXd wrenchFTFootRear;
+    wrenchFTFootRear.resize(6);
+    wrenchFTFootRear << 0, 0, 1.752, 0.000876, 0.000649, 0;
+
+    currentState.segment(stateHandler.getVariable("tau_m").offset, stateHandler.getVariable("tau_m").size) = motorTorques;
+    currentState.segment(stateHandler.getVariable("r_leg_ft_sensor").offset, stateHandler.getVariable("r_leg_ft_sensor").size) = wrenchFTtLeg;
+    currentState.segment(stateHandler.getVariable("r_foot_front_ft_sensor").offset, stateHandler.getVariable("r_foot_front_ft_sensor").size) = wrenchFTFootFront;
+    currentState.segment(stateHandler.getVariable("r_foot_rear_ft_sensor").offset, stateHandler.getVariable("r_foot_rear_ft_sensor").size) = wrenchFTFootRear;
+
+    Eigen::VectorXd updatedState;
+    updatedState.resize(stateSize);
+
+    REQUIRE(inputProvider->setInput(input));
+
+    stateModel->propagate(currentState, updatedState);
+
+    for (int idx = 0; idx < updatedState.size(); idx++)
+    {
+        REQUIRE(std::abs(updatedState[idx]) < 200);
+    }
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/ZeroVelocityDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/ZeroVelocityDynamicsTest.cpp
@@ -1,0 +1,101 @@
+/**
+ * @file ZeroVelocityDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <ConfigFolderPath.h>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityDynamics.h>
+
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+
+TEST_CASE("Zero Velocity Dynamics")
+{
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    // Test without bias
+    const std::string name0 = "tau_m";
+    Eigen::VectorXd covariance0(6);
+    covariance0 << 1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3;
+    const std::string model0 = "ZeroVelocityDynamics";
+
+    parameterHandler->setParameter("name", name0);
+    parameterHandler->setParameter("covariance", covariance0);
+    parameterHandler->setParameter("dynamic_model", model0);
+    parameterHandler->setParameter("sampling_time", 0.01);
+
+    // Create variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_sensor", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_sensor_bias", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_sensor", sizeVariable));
+
+    ZeroVelocityDynamics tau_m;
+
+    REQUIRE(tau_m.initialize(parameterHandler));
+    REQUIRE(tau_m.finalize(variableHandler));
+
+    Eigen::VectorXd currentState(sizeVariable);
+    for (int index = 0; index < sizeVariable; index++)
+    {
+        currentState(index) = GENERATE(take(1, random(-100, 100)));
+    }
+
+    Eigen::VectorXd state;
+    state.resize(sizeVariable * variableHandler.getNumberOfVariables());
+    state.setZero();
+    state.segment(variableHandler.getVariable("tau_m").offset, variableHandler.getVariable("tau_m").size) = currentState;
+
+    tau_m.setState(state);
+
+    REQUIRE(tau_m.update());
+
+    Eigen::VectorXd nextState(covariance0.size());
+    nextState = tau_m.getUpdatedVariable();
+
+    REQUIRE(currentState == nextState);
+
+    // Test with bias
+    const std::string name1 = "r_leg_ft_sensor";
+    Eigen::VectorXd covariance1(6);
+    covariance1 << 1e-7, 1e-2, 5e0, 5e-3, 5e-1, 5e-10;
+    const std::string model1 = "ZeroVelocityDynamics";
+    const bool useBias = true;
+
+    parameterHandler->clear();
+    parameterHandler->setParameter("name", name1);
+    parameterHandler->setParameter("covariance", covariance1);
+    parameterHandler->setParameter("dynamic_model", model1);
+    parameterHandler->setParameter("sampling_time", 0.01);
+    parameterHandler->setParameter("use_bias", useBias);
+
+    ZeroVelocityDynamics ft;
+
+    REQUIRE(ft.initialize(parameterHandler));
+    REQUIRE(ft.finalize(variableHandler));
+
+    state.segment(variableHandler.getVariable("r_leg_ft_sensor_bias").offset, variableHandler.getVariable("r_leg_ft_sensor_bias").size) = currentState;
+
+    ft.setState(state);
+    REQUIRE(ft.update());
+
+    Eigen::VectorXd updatedVariable = ft.getUpdatedVariable();
+    Eigen::VectorXd ftPre = state.segment(variableHandler.getVariable("r_leg_ft_sensor").offset, variableHandler.getVariable("r_leg_ft_sensor").size);
+    REQUIRE(std::abs(((currentState.array() + ftPre.array()) - updatedVariable.array()).array().sum()) == 0.0);
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/config.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/config.ini
@@ -4,3 +4,4 @@ sampling_time 0.01
 
 [include MODEL "model.ini"]
 
+[include UKF "ukf.ini"]

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/ukf.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/ukf.ini
@@ -1,0 +1,4 @@
+[include UKF_STATE "ukf/ukf_state.ini"]
+
+[include UKF_MEASUREMENT "ukf/ukf_measurement.ini"]
+

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_measurement.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_measurement.ini
@@ -1,0 +1,46 @@
+# The state list should match the group names, otherwise the states are not loaded in the ukf model
+measurement_list ("JOINT_VELOCITY",
+                  "MOTOR_CURRENT",
+                  "FT",
+                  "ACCELEROMETER",
+                  "GYROSCOPE")
+
+[JOINT_VELOCITY]
+name ("ds")
+elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
+covariance (1e-4, 1e-4, 1e-4, 1e-4, 1e-4, 1e-4)
+dynamic_model "LinearModel"
+
+[MOTOR_CURRENT]
+name ("i_m")
+elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
+covariance (7.5e-4, 7.6e-4, 1.6e-3, 1.4e-3, 1.3e-4, 7.4e-4)
+dynamic_model "MotorCurrentModel"
+
+[FT]
+name ("r_leg_ft_sensor", "r_foot_front_ft_sensor", "r_foot_rear_ft_sensor")
+elements ("fx", "fy", "fz", "mx", "my", "mz")
+covariance (1e-2, 1e-2, 1e-2, 1e-3, 1e-3, 1e-3,
+            1e-2, 1e-2, 1e-2, 1e-5, 1e-5, 1e-5,
+            1e-2, 1e-2, 1e-2, 1e-5, 1e-5, 1e-5)
+use_bias 1
+dynamic_model "LinearModel"
+
+[ACCELEROMETER]
+name ("r_leg_ft_acc", "r_foot_front_ft_acc", "r_foot_rear_ft_acc")
+elements ("x", "y", "z")
+covariance (2.3e-3, 1.9e-3, 3.1e-3,
+            2.7e-3, 1.99e-3, 2.78e-3,
+            2.5e-3, 2.3e-3, 3e-3)
+use_bias 1
+dynamic_model "AccelerometerModel"
+
+[GYROSCOPE]
+name ("r_leg_ft_gyro", "r_foot_front_ft_gyro", "r_foot_rear_ft_gyro")
+elements ("x", "y", "z")
+covariance (0.000000283, 0.0127, 0.0000001,
+            4.1e-4, 3.3e-4, 3.2e-4,
+            4.9e-4, 4.2e-4, 3.3e-4)
+use_bias 1
+dynamic_model "GyroscopeModel"
+

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_measurement.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_measurement.ini
@@ -1,46 +1,71 @@
-# The state list should match the group names, otherwise the states are not loaded in the ukf model
-measurement_list ("JOINT_VELOCITY",
-                  "MOTOR_CURRENT",
-                  "FT",
-                  "ACCELEROMETER",
-                  "GYROSCOPE")
+dynamics_list ("JOINT_VELOCITY", "MOTOR_CURRENT", "RIGHT_LEG_FT", "RIGHT_FOOT_FRONT_FT", "RIGHT_FOOT_REAR_FT", "RIGHT_LEG_ACC", "RIGHT_LEG_GYRO")
 
 [JOINT_VELOCITY]
-name ("ds")
+name "ds"
 elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
 covariance (1e-4, 1e-4, 1e-4, 1e-4, 1e-4, 1e-4)
-dynamic_model "LinearModel"
+dynamic_model "ZeroVelocityDynamics"
 
 [MOTOR_CURRENT]
-name ("i_m")
+name "i_m"
 elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
 covariance (7.5e-4, 7.6e-4, 1.6e-3, 1.4e-3, 1.3e-4, 7.4e-4)
-dynamic_model "MotorCurrentModel"
+gear_ratio (100.0, -100.0, 100.0, 100.0, 100.0, 100.0)
+torque_constant (0.111, 0.047, 0.047, 0.111, 0.111, 0.025)
+dynamic_model "MotorCurrentMeasurementDynamics"
 
-[FT]
-name ("r_leg_ft_sensor", "r_foot_front_ft_sensor", "r_foot_rear_ft_sensor")
+[RIGHT_LEG_FT]
+name "r_leg_ft_sensor"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
-covariance (1e-2, 1e-2, 1e-2, 1e-3, 1e-3, 1e-3,
-            1e-2, 1e-2, 1e-2, 1e-5, 1e-5, 1e-5,
-            1e-2, 1e-2, 1e-2, 1e-5, 1e-5, 1e-5)
+covariance (1e-2, 1e-2, 1e-2, 1e-3, 1e-3, 1e-3)
 use_bias 1
-dynamic_model "LinearModel"
+dynamic_model "ZeroVelocityDynamics"
 
-[ACCELEROMETER]
-name ("r_leg_ft_acc", "r_foot_front_ft_acc", "r_foot_rear_ft_acc")
+[RIGHT_FOOT_FRONT_FT]
+name "r_foot_front_ft_sensor"
+elements ("fx", "fy", "fz", "mx", "my", "mz")
+covariance (1e-2, 1e-2, 1e-2, 1e-5, 1e-5, 1e-5)
+use_bias 1
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_FOOT_REAR_FT]
+name "r_foot_rear_ft_sensor"
+elements ("fx", "fy", "fz", "mx", "my", "mz")
+covariance (1e-2, 1e-2, 1e-2, 1e-5, 1e-5, 1e-5)
+use_bias 1
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_LEG_ACC]
+name "r_leg_ft_acc"
 elements ("x", "y", "z")
-covariance (2.3e-3, 1.9e-3, 3.1e-3,
-            2.7e-3, 1.99e-3, 2.78e-3,
-            2.5e-3, 2.3e-3, 3e-3)
+covariance (2.3e-3, 1.9e-3, 3.1e-3)
 use_bias 1
-dynamic_model "AccelerometerModel"
+dynamic_model "AccelerometerMeasurementDynamics"
 
-[GYROSCOPE]
-name ("r_leg_ft_gyro", "r_foot_front_ft_gyro", "r_foot_rear_ft_gyro")
+[RIGHT_LEG_GYRO]
+name "r_leg_ft_gyro"
 elements ("x", "y", "z")
-covariance (0.000000283, 0.0127, 0.0000001,
-            4.1e-4, 3.3e-4, 3.2e-4,
-            4.9e-4, 4.2e-4, 3.3e-4)
+covariance (0.000000283, 0.0127, 0.0000001)
 use_bias 1
-dynamic_model "GyroscopeModel"
+dynamic_model "GyroscopeMeasurementDynamics"
 
+#[ACCELEROMETER]
+#name ("r_leg_ft_acc", "r_foot_front_ft_acc", "r_foot_rear_ft_acc")
+#elements ("x", "y", "z")
+#covariance (2.3e-3, 1.9e-3, 3.1e-3,
+#            2.7e-3, 1.99e-3, 2.78e-3,
+#            2.5e-3, 2.3e-3, 3e-3)
+#use_bias 1
+#dynamic_model "AccelerometerMeasurementDynamics"
+
+#[GYROSCOPE]
+#name ("r_leg_ft_gyro", "r_foot_front_ft_gyro", "r_foot_rear_ft_gyro")
+#elements ("x", "y", "z")
+#covariance (0.000000283, 0.0127, 0.0000001,
+#            4.1e-4, 3.3e-4, 3.2e-4,
+#            4.9e-4, 4.2e-4, 3.3e-4)
+#use_bias 1
+#dynamic_model "GyroscopeMeasurementDynamics"
+
+#               "RIGHT_LEG_ACC", "RIGHT_FOOT_FRONT_ACC", "RIGHT_FOOT_REAR_ACC", "RIGHT_LEG_GYRO",
+#               "RIGHT_FOOT_FRONT_GYRO", "RIGHT_FOOT_REAR_GYRO")

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_state.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_state.ini
@@ -1,0 +1,98 @@
+dynamics_list ("JOINT_VELOCITY", "MOTOR_TORQUE", "FRICTION_TORQUE", "RIGHT_LEG_FT", "RIGHT_FOOT_FRONT_FT", "RIGHT_FOOT_REAR_FT",
+               "RIGHT_LEG_FT_BIAS", "RIGHT_FOOT_FRONT_FT_BIAS", "RIGHT_FOOT_REAR_FT_BIAS", "RIGHT_LEG_ACC_BIAS",
+               "RIGHT_FOOT_FRONT_ACC_BIAS", "RIGHT_FOOT_REAR_ACC_BIAS", "RIGHT_LEG_GYRO_BIAS", "RIGHT_FOOT_FRONT_GYRO_BIAS",
+               "RIGHT_FOOT_REAR_GYRO_BIAS")
+
+[JOINT_VELOCITY]
+name "ds"
+elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
+covariance (1e-3, 1e-3, 1e-3, 1e-3, 1e-3, 1e-3)
+dynamic_model "JointVelocityStateDynamics"
+
+[MOTOR_TORQUE]
+name "tau_m"
+elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
+covariance (1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3)
+dynamic_model "ZeroVelocityDynamics"
+
+[FRICTION_TORQUE]
+name "tau_F"
+elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
+covariance (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-1)
+dynamic_model "FrictionTorqueStateDynamics"
+friction_k0 (9.106, 5.03, 4.93, 12.88, 14.34, 1.12)
+friction_k1 (200.0, 6.9, 200.0, 59.87, 200.0, 200.0)
+friction_k2 (1.767, 5.64, 0.27, 2.0, 3.0, 0.0)
+
+[RIGHT_LEG_FT]
+name "r_leg_ft_sensor"
+elements ("fx", "fy", "fz", "mx", "my", "mz")
+covariance (1e-3, 1e-3, 1e-3, 1e-4, 1e-4, 1e-4)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_FOOT_FRONT_FT]
+name "r_foot_front_ft_sensor"
+elements ("fx", "fy", "fz", "mx", "my", "mz")
+covariance (1e-3, 1e-3, 1e-3, 1e-6, 1e-6, 1e-6)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_FOOT_REAR_FT]
+name "r_foot_rear_ft_sensor"
+elements ("fx", "fy", "fz", "mx", "my", "mz")
+covariance (1e-3, 1e-3, 1e-3, 1e-6, 1e-6, 1e-6)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_LEG_FT_BIAS]
+name "r_leg_ft_sensor_bias"
+elements ("fx", "fy", "fz", "mx", "my", "mz")
+covariance (1e-6, 1e-6, 1e-6, 1e-6, 1e-6, 1e-6)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_FOOT_FRONT_FT_BIAS]
+name "r_foot_front_ft_sensor_bias"
+elements ("fx", "fy", "fz", "mx", "my", "mz")
+covariance (1e-6, 1e-6, 1e-6, 1e-6, 1e-6, 1e-6)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_FOOT_REAR_FT_BIAS]
+name "r_foot_rear_ft_sensor_bias"
+elements ("fx", "fy", "fz", "mx", "my", "mz")
+covariance (1e-6, 1e-6, 1e-6, 1e-6, 1e-6, 1e-6)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_LEG_ACC_BIAS]
+name "r_leg_ft_acc_bias"
+elements ("x", "y", "z")
+covariance (7.9e-5, 1.9e-5, 4.4e-5)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_FOOT_FRONT_ACC_BIAS]
+name "r_foot_front_ft_acc_bias"
+elements ("x", "y", "z")
+covariance (7.4e-5, 1.2e-5, 4.4e-5)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_FOOT_REAR_ACC_BIAS]
+name "r_foot_rear_ft_acc_bias"
+elements ("x", "y", "z")
+covariance (5.5e-5, 1.1e-5, 1.7e-5)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_LEG_GYRO_BIAS]
+name "r_leg_ft_gyro_bias"
+elements ("x", "y", "z")
+covariance (4e-4, 4.7e-4, 4.7e-4)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_FOOT_FRONT_GYRO_BIAS]
+name "r_foot_front_ft_gyro_bias"
+elements ("x", "y", "z")
+covariance (1.3e-2, 9.9e-3, 9e-3)
+dynamic_model "ZeroVelocityDynamics"
+
+[RIGHT_FOOT_REAR_GYRO_BIAS]
+name "r_foot_rear_ft_gyro_bias"
+elements ("x", "y", "z")
+covariance (8.2e-8, 1e-2, 9.3e-3)
+dynamic_model "ZeroVelocityDynamics"
+


### PR DESCRIPTION
Implemented classes and tests for the following models:
- joint velocity dynamic model
- accelerometer dynamic model
- gyroscope dynamic model

The classes are used to build the UkfMeasurement object.