### PR TITLE
Implement NamedTuple and the CentroidalDynamics classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented in this file.
 - Add the support of `std::chrono` in The text logging (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 - Add the possibility to retrieve and set duration from the `IParametersHandler` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 - Add the possibility to update the contact list in the swing foot trajectory planner (https://github.com/ami-iit/bipedal-locomotion-framework/pull/637)
+- Implement `System::NamedTuple` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/642)
+- Implement `ContinuousDynamicalSystem::CentroidalDynamics` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/642)
 
 ### Changed
 - Update the `IK tutorial` to use `QPInverseKinematics::build` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/621)
@@ -23,6 +25,7 @@ All notable changes to this project are documented in this file.
 - Update the python bindings to consider the time with `std::chrono::nanoseconds` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 - Robustify SubModelCreator and SubModelKinDynWrapper tests (https://github.com/ami-iit/bipedal-locomotion-framework/pull/631)
 - `SwingFootTrajectoryPlanner::advance()` must be called before getting the output (https://github.com/ami-iit/bipedal-locomotion-framework/pull/637)
+- Update the already existing classes in `ContinuousDynamicalSystem`to be compatible with the `System::NamedTuple` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/642)
 
 ### Fixed
 - Return an error if an invalid `KinDynComputations` object is passed to `QPInverseKinematics::build()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/622)

--- a/bindings/python/ContinuousDynamicalSystem/CMakeLists.txt
+++ b/bindings/python/ContinuousDynamicalSystem/CMakeLists.txt
@@ -1,15 +1,16 @@
 # Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT). All rights reserved.
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
+if(FRAMEWORK_COMPILE_ContinuousDynamicalSystem)
+  set(H_PREFIX include/BipedalLocomotion/bindings/ContinuousDynamicalSystem)
 
-set(H_PREFIX include/BipedalLocomotion/bindings/ContinuousDynamicalSystem)
-
-add_bipedal_locomotion_python_module(
-  NAME ContinuousDynamicalSystemBindings
-  SOURCES src/MultiStateWeightProvider.cpp src/LinearTimeInvariantSystem.cpp src/FloatingBaseSystemKinematics.cpp src/Module.cpp
-  HEADERS ${H_PREFIX}/DynamicalSystem.h ${H_PREFIX}/LinearTimeInvariantSystem.h ${H_PREFIX}/FloatingBaseSystemKinematics.h ${H_PREFIX}/Integrator.h
-          ${H_PREFIX}/MultiStateWeightProvider.h
-          ${H_PREFIX}/Module.h
-  LINK_LIBRARIES BipedalLocomotion::ContinuousDynamicalSystem
-  TESTS tests/test_linear_system.py tests/test_floating_base_system_kinematics.py
-  )
+  add_bipedal_locomotion_python_module(
+    NAME ContinuousDynamicalSystemBindings
+    SOURCES src/MultiStateWeightProvider.cpp src/LinearTimeInvariantSystem.cpp src/FloatingBaseSystemKinematics.cpp src/Module.cpp
+    HEADERS ${H_PREFIX}/DynamicalSystem.h ${H_PREFIX}/LinearTimeInvariantSystem.h ${H_PREFIX}/FloatingBaseSystemKinematics.h ${H_PREFIX}/Integrator.h
+            ${H_PREFIX}/MultiStateWeightProvider.h
+            ${H_PREFIX}/Module.h
+    LINK_LIBRARIES BipedalLocomotion::ContinuousDynamicalSystem
+    TESTS tests/test_linear_system.py tests/test_floating_base_system_kinematics.py
+    )
+endif()

--- a/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/DynamicalSystem.h
+++ b/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/DynamicalSystem.h
@@ -36,18 +36,43 @@ void CreateDynamicalSystem(pybind11::module& module, const std::string& name)
                 return impl.initialize(handler);
             },
             py::arg("param_handler"))
-        .def("set_state", &_DynamicalSystem::setState, py::arg("state"))
-        .def("get_state", &_DynamicalSystem::getState)
+        .def(
+            "set_state",
+            [](_DynamicalSystem& impl,
+               const typename _DynamicalSystem::State::underlying_tuple& state) -> bool {
+                typename _DynamicalSystem::State tempState;
+                tempState = state;
+                return impl.setState(tempState);
+            },
+            py::arg("state"))
+        .def("get_state",
+             [](const _DynamicalSystem& impl) ->
+             typename _DynamicalSystem::State::underlying_tuple {
+                 return impl.getState().to_tuple();
+             })
         .def_property(
             "state",
-            &_DynamicalSystem::getState,
-            [](_DynamicalSystem& impl, const typename _DynamicalSystem::State& state) {
-                if (!impl.setState(state))
+            [](const _DynamicalSystem& impl) -> typename _DynamicalSystem::State::underlying_tuple {
+                return impl.getState().to_tuple();
+            },
+            [](_DynamicalSystem& impl,
+               const typename _DynamicalSystem::State::underlying_tuple& state) {
+                typename _DynamicalSystem::State tempState;
+                tempState = state;
+                if (!impl.setState(tempState))
                 {
                     throw py::value_error("Invalid state.");
                 };
             })
-        .def("set_control_input", &_DynamicalSystem::setControlInput, py::arg("control_input"));
+        .def(
+            "set_control_input",
+            [](_DynamicalSystem& impl,
+               const typename _DynamicalSystem::Input::underlying_tuple& input) -> bool {
+                typename _DynamicalSystem::Input tempInput;
+                tempInput = input;
+                return impl.setControlInput(tempInput);
+            },
+            py::arg("control_input"));
 }
 
 } // namespace ContinuousDynamicalSystem

--- a/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/Integrator.h
+++ b/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/Integrator.h
@@ -63,7 +63,11 @@ void CreateIntegrator(pybind11::module& module, const std::string& name)
                     throw py::value_error("The Dynamical system is not valid.");
                 }
             })
-        .def("get_solution", &Integrator<_Derived>::getSolution)
+        .def("get_solution",
+             [](const Integrator<_Derived>& impl) ->
+             typename Integrator<_Derived>::State::underlying_tuple {
+                 return impl.getSolution().to_tuple();
+             })
         .def("integrate",
              &Integrator<_Derived>::integrate,
              py::arg("initial_time"),

--- a/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/Integrator.h
+++ b/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/Integrator.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_BINDINGS_CONTINUOUS_DYNAMICAL_SYSTEM_INTEGRATOR_H
 #define BIPEDAL_LOCOMOTION_BINDINGS_CONTINUOUS_DYNAMICAL_SYSTEM_INTEGRATOR_H
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -15,6 +16,7 @@
 #include <BipedalLocomotion/ContinuousDynamicalSystem/ForwardEuler.h>
 #include <BipedalLocomotion/ContinuousDynamicalSystem/Integrator.h>
 
+#include <pybind11/chrono.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -92,7 +94,7 @@ void CreateFixedStepIntegrator(pybind11::module& module, const std::string& name
         .def("get_integration_step", &FixedStepIntegrator<_Derived>::getIntegrationStep)
         .def_property("integration_step",
                       &FixedStepIntegrator<_Derived>::getIntegrationStep,
-                      [](FixedStepIntegrator<_Derived>& impl, double dt) {
+                      [](FixedStepIntegrator<_Derived>& impl, const std::chrono::nanoseconds& dt) {
                           if (!impl.setIntegrationStep(dt))
                           {
                               throw py::value_error("Invalid integration step.");

--- a/bindings/python/ContinuousDynamicalSystem/tests/test_floating_base_system_kinematics.py
+++ b/bindings/python/ContinuousDynamicalSystem/tests/test_floating_base_system_kinematics.py
@@ -4,12 +4,14 @@ import bipedal_locomotion_framework.bindings as blf
 import numpy as np
 import manifpy as manif
 
+from datetime import timedelta
+
 def close_form_solution(t, position0, rotation0, joint_position0, twist, joint_velocity):
     return position0 + t * twist[0:3], \
         manif.SO3Tangent(twist[3:6] *t) + rotation0, \
         joint_position0 + t * joint_velocity
 
-def test_linear_system():
+def test_floating_base_system_kinematics():
 
     tolerance = 1e-3
     dt = 0.0001
@@ -31,7 +33,7 @@ def test_linear_system():
 
     integrator = blf.continuous_dynamical_system.FloatingBaseSystemKinematicsForwardEulerIntegrator()
     assert integrator.set_dynamical_system(system)
-    integrator.integration_step = dt
+    integrator.integration_step = timedelta(seconds=dt)
 
 
     for i in range(0, int(simulation_time / dt)):
@@ -43,4 +45,4 @@ def test_linear_system():
         assert base_rotation.rotation() == pytest.approx(base_rotation_exact.rotation(), abs=tolerance)
         assert joint_position == pytest.approx(joint_position_exact, abs=tolerance)
 
-        assert integrator.integrate(0, dt)
+        assert integrator.integrate(timedelta(seconds=0), timedelta(seconds=dt))

--- a/bindings/python/ContinuousDynamicalSystem/tests/test_linear_system.py
+++ b/bindings/python/ContinuousDynamicalSystem/tests/test_linear_system.py
@@ -3,6 +3,8 @@ import pytest
 import bipedal_locomotion_framework.bindings as blf
 import numpy as np
 
+from datetime import timedelta
+
 def close_form_solution(t):
     return np.array([1 - np.exp(-t) * (np.cos(t) + np.sin(t)), 2 * np.exp(-t) * np.sin(t)])
 
@@ -22,11 +24,11 @@ def test_linear_system():
 
     integrator = blf.continuous_dynamical_system.LinearTimeInvariantSystemForwardEulerIntegrator()
     assert integrator.set_dynamical_system(system)
-    assert integrator.set_integration_step(dt)
+    assert integrator.set_integration_step(timedelta(seconds=dt))
 
     tolerance = 1e-3
 
     for i in range(0, int(simulation_time / dt)):
         solution, = integrator.get_solution()
         assert solution == pytest.approx(close_form_solution(i * dt), abs=tolerance)
-        assert integrator.integrate(0, dt)
+        assert integrator.integrate(timedelta(seconds=0), timedelta(seconds=dt))

--- a/bindings/python/IK/tests/test_QP_inverse_kinematics.py
+++ b/bindings/python/IK/tests/test_QP_inverse_kinematics.py
@@ -8,6 +8,8 @@ import numpy as np
 import icub_models
 import idyntree.swig as idyn
 
+from datetime import timedelta
+
 def test_custom_task():
     class CustomTask(blf.ik.IKLinearTask):
         def __init__(self):
@@ -183,7 +185,7 @@ def test_joint_limits_task():
     joint_limits_param_handler.set_parameter_bool(name="use_model_limits",value=False)
     joint_limits_param_handler.set_parameter_vector_float(name="upper_limits",value=np.array(joint_values) + 0.01)
     joint_limits_param_handler.set_parameter_vector_float(name="lower_limits",value=np.array(joint_values) - 0.01)
-    joint_limits_param_handler.set_parameter_float(name="sampling_time",value=0.01)
+    joint_limits_param_handler.set_parameter_datetime(name="sampling_time",value=timedelta(milliseconds=10))
 
     # Initialize the task
     joint_limits_task = blf.ik.JointLimitsTask()

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -154,7 +154,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_Unicycle
 
 framework_dependent_option(FRAMEWORK_COMPILE_ContinuousDynamicalSystem
   "Compile System ContinuousDynamicalSystem?" ON
-  "FRAMEWORK_COMPILE_ContactModels;FRAMEWORK_COMPILE_Math" OFF)
+  "FRAMEWORK_COMPILE_ContactModels;FRAMEWORK_COMPILE_Math;FRAMEWORK_COMPILE_Contact" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_AutoDiffCppAD
   "Compile CppAD-Eigen wrapper?" ON

--- a/src/ContinuousDynamicalSystem/CMakeLists.txt
+++ b/src/ContinuousDynamicalSystem/CMakeLists.txt
@@ -17,11 +17,12 @@ if(FRAMEWORK_COMPILE_ContinuousDynamicalSystem)
                            ${H_PREFIX}/CompliantContactWrench.h
                            ${H_PREFIX}/MultiStateWeightProvider.h
     PRIVATE_HEADERS        ${H_PREFIX}/impl/traits.h
-    SOURCES                src/LinearTimeInvariantSystem.cpp src/FloatingBaseSystemKinematics.cpp src/CompliantContactWrench.cpp src/FloatingBaseDynamicsWithCompliantContacts.cpp src/FixedBaseDynamics.cpp
+    SOURCES                src/LinearTimeInvariantSystem.cpp src/FloatingBaseSystemKinematics.cpp src/CompliantContactWrench.cpp
+                           src/FloatingBaseDynamicsWithCompliantContacts.cpp src/FixedBaseDynamics.cpp src/CentroidalDynamics.cpp
                            src/FirstOrderSmoother.cpp src/MultiStateWeightProvider.cpp
     PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ContactModels BipedalLocomotion::System
                            iDynTree::idyntree-high-level iDynTree::idyntree-model
-                           Eigen3::Eigen BipedalLocomotion::TextLogging BipedalLocomotion::Math
+                           Eigen3::Eigen BipedalLocomotion::TextLogging BipedalLocomotion::Math BipedalLocomotion::Contacts
                            BipedalLocomotion::GenericContainer
     PRIVATE_LINK_LIBRARIES BipedalLocomotion::CommonConversions
     SUBDIRECTORIES         tests

--- a/src/ContinuousDynamicalSystem/CMakeLists.txt
+++ b/src/ContinuousDynamicalSystem/CMakeLists.txt
@@ -12,6 +12,7 @@ if(FRAMEWORK_COMPILE_ContinuousDynamicalSystem)
     NAME                   ContinuousDynamicalSystem
     PUBLIC_HEADERS         ${H_PREFIX}/DynamicalSystem.h ${H_PREFIX}/LinearTimeInvariantSystem.h
                            ${H_PREFIX}/FloatingBaseSystemKinematics.h ${H_PREFIX}/FloatingBaseDynamicsWithCompliantContacts.h ${H_PREFIX}/FixedBaseDynamics.h ${H_PREFIX}/FirstOrderSmoother.h
+                           ${H_PREFIX}/CentroidalDynamics.h
                            ${H_PREFIX}/Integrator.h  ${H_PREFIX}/FixedStepIntegrator.h ${H_PREFIX}/ForwardEuler.h
                            ${H_PREFIX}/CompliantContactWrench.h
                            ${H_PREFIX}/MultiStateWeightProvider.h
@@ -21,6 +22,7 @@ if(FRAMEWORK_COMPILE_ContinuousDynamicalSystem)
     PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ContactModels BipedalLocomotion::System
                            iDynTree::idyntree-high-level iDynTree::idyntree-model
                            Eigen3::Eigen BipedalLocomotion::TextLogging BipedalLocomotion::Math
+                           BipedalLocomotion::GenericContainer
     PRIVATE_LINK_LIBRARIES BipedalLocomotion::CommonConversions
     SUBDIRECTORIES         tests
     )

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h
@@ -8,10 +8,11 @@
 #ifndef BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_CENROIDAL_DYNAMICS_H
 #define BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_CENROIDAL_DYNAMICS_H
 
+#include <chrono>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 #include <BipedalLocomotion/Contacts/Contact.h>
 #include <BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h>
@@ -29,8 +30,8 @@ namespace BipedalLocomotion::ContinuousDynamicalSystem::internal
 {
 template <> struct traits<CentroidalDynamics>
 {
-    using Contacts = std::unordered_map<std::string, //
-                                        BipedalLocomotion::Contacts::DiscreteGeometryContact>;
+    using Contacts = std::map<std::string, //
+                              BipedalLocomotion::Contacts::DiscreteGeometryContact>;
     using ExternalForce = std::optional<Eigen::Vector3d>;
 
     using State = GenericContainer::named_tuple<BLF_NAMED_PARAM(com_pos, Eigen::Vector3d),
@@ -127,7 +128,7 @@ public:
      * @param stateDynamics tuple containing a reference to the element of the state derivative
      * @return true in case of success, false otherwise.
      */
-    bool dynamics(const double& time, StateDerivative& stateDerivative);
+    bool dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative);
 
     /**
      * Set the state of the dynamical system.

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h
@@ -1,0 +1,155 @@
+/**
+ * @file CentroidalDynamics.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_CENROIDAL_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_CENROIDAL_DYNAMICS_H
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include <BipedalLocomotion/Contacts/Contact.h>
+#include <BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h>
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/GenericContainer/NamedTuple.h>
+
+#include <Eigen/Dense>
+
+namespace BipedalLocomotion::ContinuousDynamicalSystem
+{
+class CentroidalDynamics;
+} // namespace BipedalLocomotion::ContinuousDynamicalSystem
+
+namespace BipedalLocomotion::ContinuousDynamicalSystem::internal
+{
+template <> struct traits<CentroidalDynamics>
+{
+    using Contacts = std::unordered_map<std::string, //
+                                        BipedalLocomotion::Contacts::DiscreteGeometryContact>;
+    using ExternalForce = std::optional<Eigen::Vector3d>;
+
+    using State = GenericContainer::named_tuple<BLF_NAMED_PARAM(com_pos, Eigen::Vector3d),
+                                      BLF_NAMED_PARAM(com_vel, Eigen::Vector3d),
+                                      BLF_NAMED_PARAM(angular_momentum, Eigen::Vector3d)>;
+    using StateDerivative
+        = GenericContainer::named_tuple<BLF_NAMED_PARAM(com_vel, Eigen::Vector3d),
+                              BLF_NAMED_PARAM(com_acc, Eigen::Vector3d),
+                              BLF_NAMED_PARAM(angular_momentum_rate, Eigen::Vector3d)>;
+    using Input = GenericContainer::named_tuple<BLF_NAMED_PARAM(contacts, Contacts),
+                                      BLF_NAMED_PARAM(external_force, ExternalForce)>;
+    using DynamicalSystem = CentroidalDynamics;
+};
+} // namespace BipedalLocomotion::ContinuousDynamicalSystem::internal
+
+namespace BipedalLocomotion
+{
+namespace ContinuousDynamicalSystem
+{
+
+/**
+ * CentroidalDynamics describes the centroidal dynamics of a multi-body system.
+ * The centroidal momentum \f${}_{\bar{G}} h ^\top= \begin{bmatrix} {}_{\bar{G}} h^{p\top} & {}_{\bar{G}} h^{\omega\top} \end{bmatrix} \in \mathbb{R}^6\f$
+ * is the aggregate linear and angular momentum of each link of the robot referred to the robot
+ * center of mass (CoM). The vectors \f${}_{\bar{G}} h^p \in \mathbb{R}^3\f$ and
+ * \f${}_{\bar{G}} h^\omega * \in \mathbb{R}^3\f$ are the linear and angular momentum, respectively.
+ * The coordinates of \f${}_{\bar{G}} h\f$ are expressed w.r.t. a frame centered in the robot CoM
+ * and oriented as the inertial frame \f$\mathcal{I}\f$
+ * The CentroidalDynamics class describes the dynamics of the centroidal momentum and of the CoM.
+ * Indeed the time derivative of the centroidal momentum depends on the external contact wrenches
+ * acting on the system, thus leading to:
+ * \f[
+ * {}_{\bar{G}} \dot{h} = \sum_{i = 1}^{n_c}
+ * \begin{bmatrix}
+ * I_3 & 0_3 \
+ * (p_{\mathcal{C}_i} - p_{\text{CoM}})^\wedge & I_3
+ * \end{bmatrix} \mathrm{f}_i + m\bar{g}
+ * \f]
+ * where \f$\bar{g}^\top = \begin{bmatrix} g^\top & 0_{1\times3} \end{bmatrix}\f$, \f$m\f$
+ * is the mass of the robot and \f$n_c\f$ the number of active contacts.
+ * The relation between the linear momentum \f${}_{\bar{G}} h^{p}\f$ and the robot CoM velocity
+ * is linear and depends on the robot mass \f$m\f$, i.e. \f${}_{\bar{G}} h^{p} = m v_{\text{CoM}}\f$.
+ *
+ * The CentroidalDynamics inherits from a generic DynamicalSystem where the State is
+ * described by a BipedalLocomotion::GenericContainer::named_tuple
+ * |        Name       |        Type       |                                        Description                                        |
+ * |:-----------------:|:-----------------:|:-----------------------------------------------------------------------------------------:|
+ * |      `com_pos`    | `Eigen::Vector3d` |                   Position of the CoM written in the inertial frame                       |
+ * |      `com_vel`    | `Eigen::Vector3d` |                   Velocity of the CoM written in the inertial frame                       |
+ * |`angular_momentum` | `Eigen::Vector3d` | The centroidal angular momentum whose coordinates are written respect the inertial frame. |
+ *
+ * The `StateDerivative` is described by a BipedalLocomotion::GenericContainer::named_tuple
+ * |           Name         |        Type       |                                     Description                                    |
+ * |:----------------------:|:-----------------:|:----------------------------------------------------------------------------------:|
+ * |        `com_vel`       | `Eigen::Vector3d` |              Velocity of the CoM written in the inertial frame                     |
+ * |        `com_acc`       | `Eigen::Vector3d` |            Acceleration of the CoM written in the inertial frame                   |
+ * |`angular_momentum_rate` | `Eigen::Vector3d` | The centroidal angular momentum rate of change written respect the inertial frame. |
+ *
+ * The `Input` is described by a BipedalLocomotion::GenericContainer::named_tuple
+ * |       Name       |                                          Type                                           |                                                         Description                                                         |
+ * |:----------------:|:---------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------:|
+ * |    `contacts`    | `std::unordered_map<std::string, BipedalLocomotion::Contacts::DiscreteGeometryContact>` |  List of contact where each force applied in the discere geometry contact is expressed with respect to the inertial frame   |
+ * | `external_force` |                           `std::optional<Eigen::Vector3d>`                              |          Optional force applied to the robot center of mass. The coordinates are expressed in the inertial frame            |
+ */
+class CentroidalDynamics : public DynamicalSystem<CentroidalDynamics>
+
+{
+    /** Gravity vector expressed in the inertial frame*/
+    Eigen::Vector3d m_gravity{0, 0, -Math::StandardAccelerationOfGravitation};
+    double m_mass{1}; /**< Entire mass of the robot in kg */
+
+    State m_state; /**< State of the dynamical system */
+    Input m_controlInput; /**< Input of the dynamical system */
+
+public:
+
+    /**
+     * Initialize the CentroidalDynamics system.
+     * @param handler pointer to the parameter handler.
+     * @note The following parameters are used
+     * | Parameter Name |   Type   |                                          Description                                         | Mandatory |
+     * |:--------------:|:--------:|:--------------------------------------------------------------------------------------------:|:---------:|
+     * |   `gravity`    | `double` |     Value of the Gravity. If not defined Math::StandardAccelerationOfGravitation is used     |    No     |
+     * |     `mass`     | `double` |                   Value of the mass in kg. If not defined 1 is used.                         |    No     |
+     * @return true in case of success/false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
+
+    /**
+     * Computes the centroidal momentum dynamics. It return \f$f(x, u, t)\f$.
+     * @note The control input and the state have to be set separately with the methods
+     * setControlInput and setState.
+     * @param time the time at witch the dynamics is computed.
+     * @param stateDynamics tuple containing a reference to the element of the state derivative
+     * @return true in case of success, false otherwise.
+     */
+    bool dynamics(const double& time, StateDerivative& stateDerivative);
+
+    /**
+     * Set the state of the dynamical system.
+     * @param state tuple containing a const reference to the state elements.
+     * @return true in case of success, false otherwise.
+     */
+    bool setState(const State& state);
+
+    /**
+     * Get the state to the dynamical system.
+     * @return the current state of the dynamical system
+     */
+    const State& getState() const;
+
+    /**
+     * Set the control input to the dynamical system.
+     * @param controlInput the value of the control input used to compute the system dynamics.
+     * @return true in case of success, false otherwise.
+     */
+    bool setControlInput(const Input& controlInput);
+};
+} // namespace ContinuousDynamicalSystem
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_CENROIDAL_DYNAMICS_H

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_DYNAMICAL_SYSTEM_H
 #define BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_DYNAMICAL_SYSTEM_H
 
+#include <chrono>
 #include <memory>
 #include <tuple>
 
@@ -132,7 +133,7 @@ public:
      * @warning Please implement the function in your custom dynamical system.
      * @return true in case of success, false otherwise.
      */
-    bool dynamics(const double& time, StateDerivative& stateDerivative);
+    bool dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative);
 };
 
 template <class _Derived>
@@ -160,7 +161,7 @@ bool DynamicalSystem<_Derived>::setControlInput(const typename DynamicalSystem<_
 }
 
 template <class _Derived>
-bool DynamicalSystem<_Derived>::dynamics(const double& time, StateDerivative& stateDerivative)
+bool DynamicalSystem<_Derived>::dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative)
 {
     return this->derived().dynamics(time, stateDerivative);
 }

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h
@@ -12,6 +12,7 @@
 #include <tuple>
 
 #include <BipedalLocomotion/ContinuousDynamicalSystem/impl/traits.h>
+#include <BipedalLocomotion/GenericContainer/NamedTuple.h>
 #include <BipedalLocomotion/GenericContainer/TemplateHelpers.h>
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 
@@ -75,24 +76,28 @@ public:
                                                                                    */
     using Input = typename internal::traits<_Derived>::Input; /**< Input type */
 
-    static_assert(is_specialization<State, std::tuple>::value,
-                  "Please define the internal structure of the dynamical system with "
-                  "BLF_DEFINE_CONTINUOUS_DYNAMICAL_SYSTEM_INTERAL_STRUCTURE() macro.");
+    static_assert(
+        (is_specialization<State, std::tuple>::value
+         || is_specialization<State, ::BipedalLocomotion::GenericContainer::named_tuple>::value),
+        "State must specialize std::tuple or ::BipedalLocomotion::GenericContainer::named_tuple");
 
-    static_assert(is_specialization<StateDerivative, std::tuple>::value,
-                  "Please define the internal structure of the dynamical system with "
-                  "BLF_DEFINE_CONTINUOUS_DYNAMICAL_SYSTEM_INTERAL_STRUCTURE() macro.");
+    static_assert((is_specialization<StateDerivative, std::tuple>::value
+                   || is_specialization<StateDerivative,
+                                        ::BipedalLocomotion::GenericContainer::named_tuple>::value),
+                  "StateDerivative must specialize std::tuple or "
+                  "::BipedalLocomotion::GenericContainer::named_tuple");
 
-    static_assert(is_specialization<Input, std::tuple>::value,
-                  "Please define the internal structure of the dynamical system with "
-                  "BLF_DEFINE_CONTINUOUS_DYNAMICAL_SYSTEM_INTERAL_STRUCTURE() macro.");
+    static_assert(
+        (is_specialization<Input, std::tuple>::value
+         || is_specialization<Input, ::BipedalLocomotion::GenericContainer::named_tuple>::value),
+        "Input must specialize std::tuple or ::BipedalLocomotion::GenericContainer::named_tuple");
 
     /**
      * Initialize the Dynamical system.
      * @param handler pointer to the parameter handler.
      * @return true in case of success/false otherwise.
      */
-    bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
 
     /**
      * Set the state of the dynamical system.
@@ -132,7 +137,7 @@ public:
 
 template <class _Derived>
 bool DynamicalSystem<_Derived>::initialize(
-    std::weak_ptr<ParametersHandler::IParametersHandler> handler)
+    std::weak_ptr<const ParametersHandler::IParametersHandler> handler)
 {
     return this->derived().initialize(handler);
 }

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedBaseDynamics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedBaseDynamics.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_FIXED_BASE_DYNAMICS_H
 #define BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_FIXED_BASE_DYNAMICS_H
 
+#include <chrono>
 #include <memory>
 #include <tuple>
 #include <vector>
@@ -128,7 +129,7 @@ public:
      * @param stateDynamics tuple containing a reference to the element of the state derivative
      * @return true in case of success, false otherwise.
      */
-    bool dynamics(const double& time, StateDerivative& stateDerivative);
+    bool dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative);
 
     /**
      * Set the state of the dynamical system.

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedBaseDynamics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedBaseDynamics.h
@@ -12,7 +12,6 @@
 #include <tuple>
 #include <vector>
 
-
 #include <BipedalLocomotion/ContinuousDynamicalSystem/CompliantContactWrench.h>
 #include <BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h>
 #include <BipedalLocomotion/ContinuousDynamicalSystem/impl/traits.h>
@@ -30,33 +29,44 @@ class FixedBaseDynamics;
 }
 } // namespace BipedalLocomotion
 
+namespace BipedalLocomotion::ContinuousDynamicalSystem::internal
+{
+template <> struct traits<FixedBaseDynamics>
+{
+    using State = GenericContainer::named_tuple<BLF_NAMED_PARAM(s, Eigen::VectorXd),
+                                      BLF_NAMED_PARAM(ds, Eigen::VectorXd)>;
+    using StateDerivative = GenericContainer::named_tuple<BLF_NAMED_PARAM(ds, Eigen::VectorXd),
+                                                BLF_NAMED_PARAM(dds, Eigen::VectorXd)>;
+    using Input = GenericContainer::named_tuple<BLF_NAMED_PARAM(tau, Eigen::VectorXd)>;
+    using DynamicalSystem = FixedBaseDynamics;
+};
+} // namespace BipedalLocomotion::ContinuousDynamicalSystem::internal
 
-// Please read it as
-// BLF_DEFINE_CONTINUOUS_DYNAMICAL_SYSTEM_INTERAL_STRUCTURE(
-//     FixedBaseDynamics,
-//     (joint velocities, joint positions),
-//     (joint accelerations, joints velocities),
-//     (joint torques)
-BLF_DEFINE_CONTINUOUS_DYNAMICAL_SYSTEM_INTERAL_STRUCTURE(FixedBaseDynamics,
-                                                         (Eigen::VectorXd, Eigen::VectorXd),
-                                                         (Eigen::VectorXd, Eigen::VectorXd),
-                                                         (Eigen::VectorXd));
 
 namespace BipedalLocomotion
 {
 namespace ContinuousDynamicalSystem
 {
+
 /**
- * FixedBaseDynamics describes a fixed base dynamical system.
- * The FixedBaseDynamics inherits from a generic DynamicalSystem where:
- * - DynamicalSystem::State is described by an std::tuple containing:
- *   - Eigen::VectorXd: the joint velocities [in rad/s];
- *   - Eigen::VectorXd: the joint positions [in rad].
- * - DynamicalSystem::StateDerivative is described by an std::tuple containing:
- *   - Eigen::VectorXd: the joint accelerations [in rad/s^2];
- *   - Eigen::VectorXd: the joint velocities [in rad/s].
- * - DynamicalSystem::Input is described by an std::tuple containing:
- *   - Eigen::VectorXd: the joint torques [in Nm];
+ * FixedBaseDynamics describes a the dynamics of a fixed base system
+ * The FixedBaseDynamics inherits from a generic DynamicalSystem where the State is
+ * described by a BipedalLocomotion::GenericContainer::named_tuple
+ * | Name |        Type       |         Description         |
+ * |:----:|:-----------------:|:---------------------------:|
+ * |  `s` | `Eigen::VectorXd` |  Joint positions [in rad]  |
+ * | `ds` | `Eigen::VectorXd` | Joint velocities [in rad/s] |
+ *
+ * The `StateDerivative` is described by a BipedalLocomotion::GenericContainer::named_tuple
+ * | Name |        Type       |            Description           |
+ * |:----:|:-----------------:|:--------------------------------:|
+ * | `ds` | `Eigen::VectorXd` |     Joint velocities [in rad]    |
+ * | dds` | `Eigen::VectorXd` | Joint accelerations [in rad/s^2] |
+ *
+ * The `Input` is described by a BipedalLocomotion::GenericContainer::named_tuple
+ * | Name |        Type       |            Description           |
+ * |:----:|:-----------------:|:--------------------------------:|
+ * |`tau` | `Eigen::VectorXd` |      Joint torque [in N/m]       |
  */
 class FixedBaseDynamics : public DynamicalSystem<FixedBaseDynamics>
 {
@@ -91,7 +101,7 @@ public:
      * |  `base_link`  | `string` |  Name of the link considered as fixed base in the model. If not defined the default link will be used. Please check [here](https://robotology.github.io/idyntree/master/classiDynTree_1_1Model.html#a1a8dc1c97b99ffc51dbf93ecff20e8c1)    |    No     |
      * @return true in case of success/false otherwise.
      */
-    bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
 
     /**
      * Set the model of the robot.

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseDynamicsWithCompliantContacts.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseDynamicsWithCompliantContacts.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_FLOATING_BASE_SYSTEM_DYNAMICS_WITH_COMPLIANT_CONTACTS_H
 #define BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_FLOATING_BASE_SYSTEM_DYNAMICS_WITH_COMPLIANT_CONTACTS_H
 
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -145,7 +146,7 @@ public:
      * @param stateDynamics tuple containing a reference to the element of the state derivative
      * @return true in case of success, false otherwise.
      */
-    bool dynamics(const double& time, StateDerivative& stateDerivative);
+    bool dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative);
 
     /**
      * Set the state of the dynamical system.

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseDynamicsWithCompliantContacts.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseDynamicsWithCompliantContacts.h
@@ -118,7 +118,7 @@ public:
      * |  `base_link`  | `string` |  Name of the link considered as fixed base in the model. If not defined the default link will be used. Please check [here](https://robotology.github.io/idyntree/master/classiDynTree_1_1Model.html#a1a8dc1c97b99ffc51dbf93ecff20e8c1)    |    No     |
      * @return true in case of success/false otherwise.
      */
-    bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
 
     /**
      * Set the model of the robot.

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseSystemKinematics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseSystemKinematics.h
@@ -116,7 +116,7 @@ public:
      * @param stateDynamics tuple containing a reference to the element of the state derivative
      * @return true in case of success, false otherwise.
      */
-    bool dynamics(const double& time, StateDerivative& stateDerivative);
+    bool dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative);
 };
 
 } // namespace ContinuousDynamicalSystem

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseSystemKinematics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseSystemKinematics.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h>
+#include <BipedalLocomotion/GenericContainer/NamedTuple.h>
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 
 #include <manif/SO3.h>
@@ -28,17 +29,22 @@ class FloatingBaseSystemKinematics;
 }
 }
 
-// Please read it as
-// BLF_DEFINE_CONTINUOUS_DYNAMICAL_SYSTEM_INTERAL_STRUCTURE(
-//     FloatingBaseSystemKinematics,
-//     (base position, base orientation, joint positions),
-//     (base linear velocity, base angular velocity, joint velocities),
-//     (base twist expressed in mixed representation, joint velocities))
-BLF_DEFINE_CONTINUOUS_DYNAMICAL_SYSTEM_INTERAL_STRUCTURE(
-    FloatingBaseSystemKinematics,
-    (Eigen::Vector3d, manif::SO3d, Eigen::VectorXd),
-    (Eigen::Vector3d, manif::SO3d::Tangent, Eigen::VectorXd),
-    (Eigen::Matrix<double, 6, 1>, Eigen::VectorXd));
+namespace BipedalLocomotion::ContinuousDynamicalSystem::internal
+{
+template <> struct traits<FloatingBaseSystemKinematics>
+{
+    using Twist = Eigen::Matrix<double, 6, 1>;
+    using State = GenericContainer::named_tuple<BLF_NAMED_PARAM(p, Eigen::Vector3d),
+                                      BLF_NAMED_PARAM(R, manif::SO3d),
+                                      BLF_NAMED_PARAM(s, Eigen::VectorXd)>;
+    using StateDerivative = GenericContainer::named_tuple<BLF_NAMED_PARAM(dp, Eigen::Vector3d),
+                                                BLF_NAMED_PARAM(omega, manif::SO3d::Tangent),
+                                                BLF_NAMED_PARAM(ds, Eigen::VectorXd)>;
+    using Input = GenericContainer::named_tuple<BLF_NAMED_PARAM(twist, Twist),
+                                      BLF_NAMED_PARAM(ds, Eigen::VectorXd)>;
+    using DynamicalSystem = FloatingBaseSystemKinematics;
+};
+} // namespace BipedalLocomotion::ContinuousDynamicalSystem::internal
 
 namespace BipedalLocomotion
 {
@@ -47,20 +53,26 @@ namespace ContinuousDynamicalSystem
 
 /**
  * FloatingBaseSystemKinematics describes a floating base system kinematics.
- * The FloatingBaseSystemKinematics inherits from a generic DynamicalSystem where:
- * - DynamicalSystem::State is described by an std::tuple containing:
- *   - Eigen::Vector3d: position of the base w.r.t. the inertial frame
- *   - manif::SO3d: rotation matrix \f${} ^ I R _ {b}\f$. Matrix that transform a vector
- * whose coordinates are expressed in the base frame in the inertial frame;
- *   - Eigen::VectorXd: the joint positions [in rad].
- * - DynamicalSystem::StateDerivative is described by an std::tuple containing:
- *   - Eigen::Vector3d: base linear velocity w.r.t. the inertial frame;
- *   - manif::SO3d::Tangent: base angular velocity w.r.t. the inertial frame; (Left trivialized)
- * whose coordinates are expressed in the base frame in the inertial frame;
- *   - Eigen::VectorXd: the joint velocities [in rad/s].
- * - DynamicalSystem::Input is described by an std::tuple containing:
- *   - Eigen::Vector6d: base twist w.r.t. the inertial frame;
- *   - Eigen::VectorXd: the joint velocities [in rad/s].
+ * The FloatingBaseSystemKinematics inherits from a generic DynamicalSystem where the State is
+ * described by a BipedalLocomotion::GenericContainer::named_tuple
+ * | Name |        Type       |                                                                  Description                                                                 |
+ * |:----:|:-----------------:|:--------------------------------------------------------------------------------------------------------------------------------------------:|
+ * |  `p` | `Eigen::Vector3d` |                                                Position of the base w.r.t. the inertial frame                                                |
+ * |  `R` |   `manif::SO3d`   | Rotation matrix \f${} ^ I R _ {b}\f$. Matrix that transform a vector whose coordinates are expressed in the base frame in the inertial frame |
+ * |  `s` | `Eigen::VectorXd` |                                                           Joint positions [in rad]                                                           |
+ *
+ * The `StateDerivative` is described by a BipedalLocomotion::GenericContainer::named_tuple
+ * |   Name  |          Type          |                                                         Description                                                         |
+ * |:-------:|:----------------------:|:---------------------------------------------------------------------------------------------------------------------------:|
+ * |  `dp`   |    `Eigen::Vector3d`   | Linear velocity of the origin of the base link whose coordinates are expressed in the Inertial frame (MIXED RERPESENTATION) |
+ * | `omega` | `manif::SO3d::Tangent` |                base angular velocity whose coordinates are expressed in the inertial frame (Left trivialized)               |
+ * |   `ds`  |    `Eigen::VectorXd`   |                                                 Joint velocities [in rad/s]                                                 |
+ *
+ * The `Input` is described by a BipedalLocomotion::GenericContainer::named_tuple
+ * |   Name  |              Type             |                  Description                 |
+ * |:-------:|:-----------------------------:|:--------------------------------------------:|
+ * | `twist` | `Eigen::Matrix<double, 6, 1>` | Base twist expressed in mixed representation |
+ * |   `ds`  |       `Eigen::VectorXd`       |          Joint velocities [in rad/s]         |
  */
 class FloatingBaseSystemKinematics : public DynamicalSystem<FloatingBaseSystemKinematics>
 {
@@ -74,7 +86,7 @@ public:
      * @return true in case of success/false otherwise.
      * @note This function does nothing but it is required for CRTP.
      */
-    bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
 
     /**
      * Set the state of the dynamical system.

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/ForwardEuler.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/ForwardEuler.h
@@ -14,6 +14,7 @@
 #include <iDynTree/Core/EigenHelpers.h>
 
 #include <BipedalLocomotion/ContinuousDynamicalSystem/FixedStepIntegrator.h>
+#include <BipedalLocomotion/GenericContainer/NamedTuple.h>
 
 namespace BipedalLocomotion
 {
@@ -60,21 +61,22 @@ private:
     /** Temporary buffer usefully to avoid continuous memory allocation */
     State m_computationalBufferState;
 
-    template <std::size_t I = 0, typename... Tp, typename... Td>
-    inline typename std::enable_if<I == sizeof...(Tp), void>::type
-    addArea(const std::tuple<Tp...>& dx, const double& dT, std::tuple<Td...>& x)
+    template <std::size_t I = 0>
+    inline typename std::enable_if<I == std::tuple_size<State>::value, void>::type
+    addArea(const StateDerivative& dx, const double& dT, State& x)
     {
-        static_assert(sizeof...(Tp) == sizeof...(Td));
+        static_assert(std::tuple_size<State>::value == std::tuple_size<StateDerivative>::value);
     }
 
-    template <std::size_t I = 0, typename... Tp, typename... Td>
-    inline typename std::enable_if < I<sizeof...(Tp), void>::type
-    addArea(const std::tuple<Tp...>& dx, const double& dT, std::tuple<Td...>& x)
+    template <std::size_t I = 0>
+    inline typename std::enable_if<(I < std::tuple_size<State>::value), void>::type
+    addArea(const StateDerivative& dx, const double& dT, State& x)
     {
-        static_assert(sizeof...(Tp) == sizeof...(Td));
+        static_assert(std::tuple_size<State>::value == std::tuple_size<StateDerivative>::value);
 
         // the order matters since we assume that all the velocities are left trivialized.
-        std::get<I>(x) = (std::get<I>(dx) * dT) + std::get<I>(x);
+        using std::get;
+        get<I>(x) = (get<I>(dx) * dT) + get<I>(x);
         addArea<I + 1>(dx, dT, x);
     }
 

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/Integrator.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/Integrator.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_INTEGRATOR_H
 #define BIPEDAL_LOCOMOTION_CONTINUOUS_DYNAMICAL_SYSTEM_INTEGRATOR_H
 
+#include <chrono>
 #include <memory>
 
 #include <BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h>
@@ -81,7 +82,8 @@ public:
      * @param finalTime final time of the integration.
      * @return true in case of success, false otherwise.
      */
-    bool integrate(double initialTime, double finalTime);
+    bool integrate(const std::chrono::nanoseconds& initialTime,
+                   const std::chrono::nanoseconds& finalTime);
 };
 
 template <class _Derived>
@@ -119,7 +121,9 @@ const typename Integrator<_Derived>::State& Integrator<_Derived>::getSolution() 
     return m_dynamicalSystem->getState();
 }
 
-template <class _Derived> bool Integrator<_Derived>::integrate(double initialTime, double finalTime)
+template <class _Derived>
+bool Integrator<_Derived>::integrate(const std::chrono::nanoseconds& initialTime,
+                                     const std::chrono::nanoseconds& finalTime)
 {
     return static_cast<_Derived*>(this)->integrate(initialTime, finalTime);
 }

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h
@@ -13,6 +13,7 @@
 
 #include <BipedalLocomotion/ContinuousDynamicalSystem/DynamicalSystem.h>
 #include <BipedalLocomotion/ContinuousDynamicalSystem/impl/traits.h>
+#include <BipedalLocomotion/GenericContainer/NamedTuple.h>
 
 #include <Eigen/Dense>
 
@@ -27,11 +28,16 @@ class LinearTimeInvariantSystem;
 }
 }
 
-// Define the internal structure of the System
-BLF_DEFINE_CONTINUOUS_DYNAMICAL_SYSTEM_INTERAL_STRUCTURE(LinearTimeInvariantSystem,
-                                                         (Eigen::VectorXd),
-                                                         (Eigen::VectorXd),
-                                                         (Eigen::VectorXd));
+namespace BipedalLocomotion::ContinuousDynamicalSystem::internal
+{
+template <> struct traits<LinearTimeInvariantSystem>
+{
+    using State = GenericContainer::named_tuple<BLF_NAMED_PARAM(x, Eigen::VectorXd)>;
+    using StateDerivative = GenericContainer::named_tuple<BLF_NAMED_PARAM(dx, Eigen::VectorXd)>;
+    using Input = GenericContainer::named_tuple<BLF_NAMED_PARAM(u, Eigen::VectorXd)>;
+    using DynamicalSystem = LinearTimeInvariantSystem;
+};
+} // namespace BipedalLocomotion::ContinuousDynamicalSystem::internal
 
 namespace BipedalLocomotion
 {
@@ -42,13 +48,21 @@ namespace ContinuousDynamicalSystem
  * LinearTimeInvariantSystem describes a MIMO linear time invariant system of the form \f$\dot{x} =
  * Ax + Bu\f$ where \a x is the state and \a u the control input. The state, its derivative and the
  * control input are described by vectors
- * The LinearTimeInvariantSystem inherits from a generic DynamicalSystem where:
- * - DynamicalSystem::State is described by an std::tuple containing:
- *   - Eigen::VectorXd: a generic state.
- * - DynamicalSystem::StateDerivative is described by an std::tuple containing:
- *   - Eigen::VectorXd: a generic state derivative.
- * - DynamicalSystem::Input is described by an std::tuple containing:
- *   - Eigen::VectorXd: a generic control input.
+ * The LinearTimeInvariantSystem inherits from a generic DynamicalSystem where the State is
+ * described by a BipedalLocomotion::GenericContainer::named_tuple
+ * | Name |        Type       |                     Description                   |
+ * |:----:|:-----------------:|:-------------------------------------------------:|
+ * |  `x` | `Eigen::VectorXd` | A generic vector belonging to \f$\mathbb{R}^n\f$  |
+ *
+ * The `StateDerivative` is described by a BipedalLocomotion::GenericContainer::named_tuple
+ * | Name |        Type       |                         Description                        |
+ * |:----:|:-----------------:|:----------------------------------------------------------:|
+ * | `dx` | `Eigen::VectorXd` | A state vector derivative belonging to \f$\mathbb{R}^n\f$  |
+ *
+ * The `Input` is described by a BipedalLocomotion::GenericContainer::named_tuple
+ * | Name |        Type       |                     Description                   |
+ * |:----:|:-----------------:|:-------------------------------------------------:|
+ * |  `u` | `Eigen::VectorXd` | A control vector belonging to \f$\mathbb{R}^m\f$  |
  */
 class LinearTimeInvariantSystem : public DynamicalSystem<LinearTimeInvariantSystem>
 {
@@ -75,7 +89,7 @@ public:
      * @param handler pointer to the parameter handler.
      * @return true in case of success/false otherwise.
      */
-    bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler);
 
     /**
      * Set the state of the dynamical system.

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h
@@ -121,7 +121,7 @@ public:
      * @param stateDynamics tuple containing a reference to the element of the state derivative
      * @return true in case of success, false otherwise.
      */
-    bool dynamics(const double& time, StateDerivative& stateDerivative);
+    bool dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative);
 };
 
 } // namespace ContinuousDynamicalSystem

--- a/src/ContinuousDynamicalSystem/src/CentroidalDynamics.cpp
+++ b/src/ContinuousDynamicalSystem/src/CentroidalDynamics.cpp
@@ -43,7 +43,7 @@ bool CentroidalDynamics::initialize(std::weak_ptr<const IParametersHandler> hand
     return true;
 }
 
-bool CentroidalDynamics::dynamics(const double& time, StateDerivative& stateDerivative)
+bool CentroidalDynamics::dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative)
 {
     using namespace BipedalLocomotion::GenericContainer::literals;
 

--- a/src/ContinuousDynamicalSystem/src/CentroidalDynamics.cpp
+++ b/src/ContinuousDynamicalSystem/src/CentroidalDynamics.cpp
@@ -1,0 +1,92 @@
+/**
+ * @file CentroidalDynamics.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h>
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+using namespace BipedalLocomotion;
+using namespace BipedalLocomotion::ContinuousDynamicalSystem;
+using namespace BipedalLocomotion::ParametersHandler;
+
+bool CentroidalDynamics::initialize(std::weak_ptr<const IParametersHandler> handler)
+{
+    constexpr auto logPrefix = "[CentroidalDynamics::initialize]";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is expired. Please call the function passing a "
+                     "pointer pointing an already allocated memory.",
+                     logPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("gravity", m_gravity))
+    {
+        log()->info("{} The gravity vector  not found. The default one will be used {}.",
+                    logPrefix,
+                    m_gravity.transpose());
+    }
+
+    if (!ptr->getParameter("mass", m_mass))
+    {
+        log()->info("{} The mass is not found. The default one will be used {} kg.",
+                    logPrefix,
+                    m_mass);
+    }
+
+    return true;
+}
+
+bool CentroidalDynamics::dynamics(const double& time, StateDerivative& stateDerivative)
+{
+    using namespace BipedalLocomotion::GenericContainer::literals;
+
+    const auto& [comPosition, comVelocity, angularMomentum] = m_state;
+    auto& [comVelocityOut, comAcceleration, angularMomentumRate] = stateDerivative;
+
+    comVelocityOut = comVelocity;
+    comAcceleration = m_gravity;
+    angularMomentumRate.setZero();
+
+    const auto& contacts = m_controlInput.get_from_hash<"contacts"_h>();
+    const auto& externalDisturbance = m_controlInput.get_from_hash<"external_force"_h>();
+    if (externalDisturbance)
+    {
+        comAcceleration += externalDisturbance.value();
+    }
+
+    for (const auto& [key, contact] : contacts)
+    {
+        for (const auto& corner : contact.corners)
+        {
+            comAcceleration.noalias() += 1 / m_mass * corner.force;
+            angularMomentumRate.noalias()
+                += (contact.pose.act(corner.position) - comPosition).cross(corner.force);
+        }
+    }
+
+    return true;
+}
+
+bool CentroidalDynamics::setState(const State& state)
+{
+    m_state = state;
+    return true;
+}
+
+const CentroidalDynamics::State& CentroidalDynamics::getState() const
+{
+    return m_state;
+}
+
+bool CentroidalDynamics::setControlInput(const Input& controlInput)
+{
+    m_controlInput = controlInput;
+    return true;
+}

--- a/src/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
+++ b/src/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
@@ -7,7 +7,10 @@
 
 #include <BipedalLocomotion/ContinuousDynamicalSystem/FirstOrderSmoother.h>
 #include <BipedalLocomotion/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h>
+#include <BipedalLocomotion/GenericContainer/NamedTuple.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
+
+#include <Eigen/Dense>
 
 using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 
@@ -54,6 +57,8 @@ bool FirstOrderSmoother::initialize(
 
 bool FirstOrderSmoother::reset(Eigen::Ref<const Eigen::VectorXd> initialPoint)
 {
+    using namespace BipedalLocomotion::GenericContainer::literals;
+
     constexpr auto logPrefix = "[FirstOrderSmoother::reset]";
     m_isInitialStateSet = false;
 
@@ -75,7 +80,8 @@ bool FirstOrderSmoother::reset(Eigen::Ref<const Eigen::VectorXd> initialPoint)
         log()->error("{} Unable to set the linear system matrices.", logPrefix);
         return false;
     }
-    if (!m_linearSystem->setState(initialPoint))
+
+    if (!m_linearSystem->setState({initialPoint}))
     {
         log()->error("{} Unable to initialize the system.", logPrefix);
         return false;
@@ -120,7 +126,7 @@ bool FirstOrderSmoother::setInput(const Eigen::VectorXd& input)
         return false;
     }
 
-    return m_linearSystem->setControlInput(input);
+    return m_linearSystem->setControlInput({input});
 }
 
 const Eigen::VectorXd& FirstOrderSmoother::getOutput() const

--- a/src/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
+++ b/src/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
@@ -11,6 +11,7 @@
 #include <BipedalLocomotion/TextLogging/Logger.h>
 
 #include <Eigen/Dense>
+#include <chrono>
 
 using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 
@@ -32,7 +33,7 @@ bool FirstOrderSmoother::initialize(
         return false;
     }
 
-    double samplingTime{-1};
+    std::chrono::nanoseconds samplingTime;
     if (!ptr->getParameter("sampling_time", samplingTime))
     {
         log()->error("{} Unable to get the 'sampling_time' parameter.", logPrefix);
@@ -105,7 +106,8 @@ bool FirstOrderSmoother::advance()
         return false;
     }
 
-    if (!m_integrator.integrate(0, m_integrator.getIntegrationStep()))
+    using namespace std::chrono_literals;
+    if (!m_integrator.integrate(0s, m_integrator.getIntegrationStep()))
     {
         log()->error("[FirstOrderSmoother::advance] Unable to propagate the dynamical system.");
         return false;

--- a/src/ContinuousDynamicalSystem/src/FixedBaseDynamics.cpp
+++ b/src/ContinuousDynamicalSystem/src/FixedBaseDynamics.cpp
@@ -129,7 +129,7 @@ bool FixedBaseDynamics::setMassMatrixRegularization(const Eigen::Ref<const Eigen
     return true;
 }
 
-bool FixedBaseDynamics::dynamics(const double& time, StateDerivative& stateDerivative)
+bool FixedBaseDynamics::dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative)
 {
     constexpr auto logPrefix = "[FixedBaseDynamics::dynamics]";
 

--- a/src/ContinuousDynamicalSystem/src/FixedBaseDynamics.cpp
+++ b/src/ContinuousDynamicalSystem/src/FixedBaseDynamics.cpp
@@ -17,7 +17,7 @@ using namespace BipedalLocomotion;
 using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 using namespace BipedalLocomotion::ParametersHandler;
 
-bool FixedBaseDynamics::initialize(std::weak_ptr<IParametersHandler> handler)
+bool FixedBaseDynamics::initialize(std::weak_ptr<const IParametersHandler> handler)
 {
     constexpr auto logPrefix = "[FixedBaseDynamics::initialize]";
 

--- a/src/ContinuousDynamicalSystem/src/FloatingBaseDynamicsWithCompliantContacts.cpp
+++ b/src/ContinuousDynamicalSystem/src/FloatingBaseDynamicsWithCompliantContacts.cpp
@@ -143,7 +143,7 @@ bool FloatingBaseDynamicsWithCompliantContacts::setMassMatrixRegularization(
     return true;
 }
 
-bool FloatingBaseDynamicsWithCompliantContacts::dynamics(const double& time,
+bool FloatingBaseDynamicsWithCompliantContacts::dynamics(const std::chrono::nanoseconds& time,
                                                          StateDerivative& stateDerivative)
 {
     constexpr auto logPrefix = "[FloatingBaseDynamicsWithCompliantContacts::dynamics]";

--- a/src/ContinuousDynamicalSystem/src/FloatingBaseDynamicsWithCompliantContacts.cpp
+++ b/src/ContinuousDynamicalSystem/src/FloatingBaseDynamicsWithCompliantContacts.cpp
@@ -18,7 +18,8 @@ using namespace BipedalLocomotion;
 using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 using namespace BipedalLocomotion::ParametersHandler;
 
-bool FloatingBaseDynamicsWithCompliantContacts::initialize(std::weak_ptr<IParametersHandler> handler)
+bool FloatingBaseDynamicsWithCompliantContacts::initialize(
+    std::weak_ptr<const IParametersHandler> handler)
 {
     constexpr auto logPrefix = "[FloatingBaseDynamicsWithCompliantContacts::initialize]";
 

--- a/src/ContinuousDynamicalSystem/src/FloatingBaseSystemKinematics.cpp
+++ b/src/ContinuousDynamicalSystem/src/FloatingBaseSystemKinematics.cpp
@@ -30,7 +30,7 @@ bool FloatingBaseSystemKinematics::initialize(std::weak_ptr<const IParametersHan
     return true;
 }
 
-bool FloatingBaseSystemKinematics::dynamics(const double& time,
+bool FloatingBaseSystemKinematics::dynamics(const std::chrono::nanoseconds& time,
                                             StateDerivative& stateDerivative)
 {
     using namespace BipedalLocomotion::GenericContainer::literals;

--- a/src/ContinuousDynamicalSystem/src/FloatingBaseSystemKinematics.cpp
+++ b/src/ContinuousDynamicalSystem/src/FloatingBaseSystemKinematics.cpp
@@ -11,7 +11,7 @@
 using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 using namespace BipedalLocomotion::ParametersHandler;
 
-bool FloatingBaseSystemKinematics::initialize(std::weak_ptr<IParametersHandler> handler)
+bool FloatingBaseSystemKinematics::initialize(std::weak_ptr<const IParametersHandler> handler)
 {
     constexpr auto logPrefix = "[FloatingBaseSystemKinematics::initialize]";
 
@@ -33,18 +33,20 @@ bool FloatingBaseSystemKinematics::initialize(std::weak_ptr<IParametersHandler> 
 bool FloatingBaseSystemKinematics::dynamics(const double& time,
                                             StateDerivative& stateDerivative)
 {
+    using namespace BipedalLocomotion::GenericContainer::literals;
+
     // get the state
-    const Eigen::Vector3d& basePosition = std::get<0>(m_state);
-    const manif::SO3d& baseRotation = std::get<1>(m_state);
-    const Eigen::VectorXd& jointPositions = std::get<2>(m_state);
+    const Eigen::Vector3d& basePosition = m_state.get_from_hash<"p"_h>();
+    const manif::SO3d& baseRotation = m_state.get_from_hash<"R"_h>();
+    const Eigen::VectorXd& jointPositions = m_state.get_from_hash<"s"_h>();
 
     // get the state derivative
-    Eigen::Vector3d& baseLinearVelocity = std::get<0>(stateDerivative);
-    manif::SO3d::Tangent& baseAngularVelocity = std::get<1>(stateDerivative);
-    Eigen::VectorXd& jointVelocityOutput = std::get<2>(stateDerivative);
+    Eigen::Vector3d& baseLinearVelocity = stateDerivative.get_from_hash<"dp"_h>();
+    manif::SO3d::Tangent& baseAngularVelocity = stateDerivative.get_from_hash<"omega"_h>();
+    Eigen::VectorXd& jointVelocityOutput = stateDerivative.get_from_hash<"ds"_h>();
 
-    const Eigen::Matrix<double, 6, 1>& baseTwist = std::get<0>(m_controlInput);
-    const Eigen::VectorXd& jointVelocity = std::get<1>(m_controlInput);
+    const Eigen::Matrix<double, 6, 1>& baseTwist = m_controlInput.get_from_hash<"twist"_h>();
+    const Eigen::VectorXd& jointVelocity = m_controlInput.get_from_hash<"ds"_h>();
 
     // check the size of the vectors
     if (jointVelocity.size() != jointPositions.size())

--- a/src/ContinuousDynamicalSystem/src/LinearTimeInvariantSystem.cpp
+++ b/src/ContinuousDynamicalSystem/src/LinearTimeInvariantSystem.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <BipedalLocomotion/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h>
+#include <BipedalLocomotion/GenericContainer/NamedTuple.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
 
 using namespace BipedalLocomotion::ContinuousDynamicalSystem;
@@ -43,9 +44,11 @@ bool LinearTimeInvariantSystem::dynamics(const double& time, StateDerivative& st
         return false;
     }
 
-    const auto& x = std::get<0>(m_state);
-    auto& dx = std::get<0>(stateDerivative);
-    const auto& u = std::get<0>(m_controlInput);
+    using namespace BipedalLocomotion::GenericContainer::literals;
+
+    const Eigen::VectorXd& x = m_state.get_from_hash<"x"_h>();
+    Eigen::VectorXd& dx = stateDerivative.get_from_hash<"dx"_h>();
+    const Eigen::VectorXd& u = m_controlInput.get_from_hash<"u"_h>();
 
     if (x.size() != m_A.rows())
     {
@@ -69,7 +72,7 @@ bool LinearTimeInvariantSystem::dynamics(const double& time, StateDerivative& st
 }
 
 bool LinearTimeInvariantSystem::initialize(
-    std::weak_ptr<ParametersHandler::IParametersHandler> handler)
+    std::weak_ptr<const ParametersHandler::IParametersHandler> handler)
 {
     return true;
 }

--- a/src/ContinuousDynamicalSystem/src/LinearTimeInvariantSystem.cpp
+++ b/src/ContinuousDynamicalSystem/src/LinearTimeInvariantSystem.cpp
@@ -34,7 +34,7 @@ bool LinearTimeInvariantSystem::setSystemMatrices(const Eigen::Ref<const Eigen::
     return true;
 }
 
-bool LinearTimeInvariantSystem::dynamics(const double& time, StateDerivative& stateDerivative)
+bool LinearTimeInvariantSystem::dynamics(const std::chrono::nanoseconds& time, StateDerivative& stateDerivative)
 {
     constexpr auto errorPrefix = "[LinearTimeInvariantSystem::dynamics]";
 

--- a/src/ContinuousDynamicalSystem/tests/FirstOrderSmoother.cpp
+++ b/src/ContinuousDynamicalSystem/tests/FirstOrderSmoother.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
 #include <limits>
 #include <memory>
 
@@ -20,7 +21,9 @@ using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 
 TEST_CASE("First order smoother")
 {
-    constexpr double dT = 0.0001;
+    using namespace std::chrono_literals;
+
+    constexpr std::chrono::nanoseconds dT = 100us;
     constexpr double settlingTime = 0.1;
     constexpr double tolerance = 1e-2;
 
@@ -56,13 +59,14 @@ TEST_CASE("First order smoother")
         const Eigen::Vector2d output = smoother.getOutput();
 
         // check if the solution is similar to the expected one
-        REQUIRE(output.isApprox(closeFormSolution(dT * i), tolerance));
+        REQUIRE(output.isApprox(closeFormSolution(std::chrono::duration<double>(dT * i).count()),
+                                tolerance));
 
         if (!settilingSubSystem1)
         {
             if ((output[0] > 0.95) && (output[0] < 1.05))
             {
-                settilingTimeSubSystem1 = i * dT;
+                settilingTimeSubSystem1 = std::chrono::duration<double>(dT * i).count();
                 settilingSubSystem1 = true;
             }
         } else if ((output[0] < 0.95) || (output[0] > 1.05))
@@ -75,7 +79,7 @@ TEST_CASE("First order smoother")
         {
             if ((output[1] > 0.95) && (output[1] < 1.05))
             {
-                settilingTimeSubSystem2 = i * dT;
+                settilingTimeSubSystem2 = std::chrono::duration<double>(dT * i).count();
                 settilingSubSystem2 = true;
             }
         } else if ((output[1] < 0.95) || (output[1] > 1.05))

--- a/src/ContinuousDynamicalSystem/tests/IntegratorFloatingBaseSystemKinematics.cpp
+++ b/src/ContinuousDynamicalSystem/tests/IntegratorFloatingBaseSystemKinematics.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
 #include <memory>
 
 // Catch2
@@ -21,9 +22,10 @@ using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 
 TEST_CASE("Integrator - Linear system")
 {
-    constexpr double dT = 0.0001;
+    using namespace std::chrono_literals;
+    constexpr std::chrono::nanoseconds dT = 100us;
     constexpr double tolerance = 1e-3;
-    constexpr double simulationTime = 0.5;
+    constexpr std::chrono::nanoseconds simulationTime = 500ms;
 
     auto system = std::make_shared<FloatingBaseSystemKinematics>();
 
@@ -65,12 +67,12 @@ TEST_CASE("Integrator - Linear system")
         const auto& [basePosition, baseRotation, jointPosition] = integrator.getSolution();
 
         const auto& [basePositionExact, baseRotationExact, jointPositionExact]
-            = closeFormSolution(dT * i);
+            = closeFormSolution(std::chrono::duration<double>(dT * i).count());
 
         REQUIRE(baseRotation.rotation().isApprox(baseRotationExact, tolerance));
         REQUIRE(basePosition.isApprox(basePositionExact, tolerance));
         REQUIRE(jointPosition.isApprox(jointPositionExact, tolerance));
 
-        REQUIRE(integrator.integrate(0, dT));
+        REQUIRE(integrator.integrate(0s, dT));
     }
 }

--- a/src/ContinuousDynamicalSystem/tests/IntegratorLinearSystem.cpp
+++ b/src/ContinuousDynamicalSystem/tests/IntegratorLinearSystem.cpp
@@ -5,6 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
 #include <memory>
 
 // Catch2
@@ -19,9 +20,11 @@ using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 
 TEST_CASE("Integrator - Linear system")
 {
-    constexpr double dT = 0.0001;
+    using namespace std::chrono_literals;
+
+    constexpr std::chrono::nanoseconds dT = 100us;
     constexpr double tolerance = 1e-3;
-    constexpr double simulationTime = 2;
+    constexpr std::chrono::nanoseconds simulationTime = 2s;
 
     // Create the linear system
     /**
@@ -67,7 +70,8 @@ TEST_CASE("Integrator - Linear system")
     {
         const auto& [solution] = integrator.getSolution();
 
-        REQUIRE(solution.isApprox(closeFormSolution(dT * i), tolerance));
-        REQUIRE(integrator.integrate(0, dT));
+        REQUIRE(solution.isApprox(closeFormSolution(std::chrono::duration<double>(dT * i).count()),
+                                  tolerance));
+        REQUIRE(integrator.integrate(0s, dT));
     }
 }

--- a/src/ContinuousDynamicalSystem/tests/MultiStateWeightProvider.cpp
+++ b/src/ContinuousDynamicalSystem/tests/MultiStateWeightProvider.cpp
@@ -5,6 +5,8 @@
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
  */
 
+#include <chrono>
+
 // Catch2
 #include <catch2/catch.hpp>
 
@@ -17,7 +19,8 @@ using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 
 TEST_CASE("Multistate weight provider")
 {
-    constexpr double dT = 0.01;
+    using namespace std::chrono_literals;
+    constexpr std::chrono::nanoseconds dT = 10ms;
     constexpr double settlingTime = 0.1;
     constexpr double tolerance = 1e-2;
 

--- a/src/GenericContainer/CMakeLists.txt
+++ b/src/GenericContainer/CMakeLists.txt
@@ -3,11 +3,14 @@
 # BSD-3-Clause license.
 
 # set target name
+
+set(H_PREFIX include/BipedalLocomotion/GenericContainer)
+
 add_bipedal_locomotion_library(
     NAME                   GenericContainer
-    PUBLIC_HEADERS         include/BipedalLocomotion/GenericContainer/Vector.h include/BipedalLocomotion/GenericContainer/TemplateHelpers.h
+    PUBLIC_HEADERS         ${H_PREFIX}/Vector.h ${H_PREFIX}/TemplateHelpers.h ${H_PREFIX}/NamedTuple.h
     PUBLIC_LINK_LIBRARIES  iDynTree::idyntree-core Eigen3::Eigen
-    SUBDIRECTORIES   tests
+    SUBDIRECTORIES         tests
     IS_INTERFACE)
 
 

--- a/src/GenericContainer/include/BipedalLocomotion/GenericContainer/NamedTuple.h
+++ b/src/GenericContainer/include/BipedalLocomotion/GenericContainer/NamedTuple.h
@@ -1,0 +1,399 @@
+/**
+ * @file NamedTuple.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+// the original version of the code can be found https://github.com/GiulioRomualdi/named_tuple
+
+#ifndef BIPEDAL_LOCOMOTION_GENERIC_CONTAINER_NAMED_TUPLE_H
+#define BIPEDAL_LOCOMOTION_GENERIC_CONTAINER_NAMED_TUPLE_H
+
+#include <cstdint>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace BipedalLocomotion
+{
+
+namespace GenericContainer
+{
+
+using hash_type = std::uint64_t;
+
+namespace detail
+{
+
+// The following code has been taken from https://gist.github.com/Manu343726/081512c43814d098fe4b
+// it allows to generate a compile time string hash
+constexpr hash_type fnv_basis = 14695981039346656037ull;
+constexpr hash_type fnv_prime = 109951162821ull;
+
+// FNV-1a 64 bit hash
+constexpr hash_type sid_hash(const char* str, hash_type hash = fnv_basis) noexcept
+{
+    return *str ? sid_hash(str + 1, (hash ^ *str) * fnv_prime) : hash;
+}
+
+} // namespace detail
+
+/**
+ * named_param is a struct that associate a compile time hash to a value.
+ * @note Type Ts must be default constructible.
+ */
+template <hash_type hash_, typename Type_> struct named_param
+{
+    static constexpr hash_type hash = hash_;
+    using Type = Type_;
+
+    Type param; /**< Parameter associated to the given hash */
+
+    named_param() = default;
+
+    template <typename OtherType>
+    named_param(const OtherType& param_)
+        : param(param_){};
+
+    template <typename OtherType> named_param& operator=(const OtherType& param_)
+    {
+        param = param_;
+        return *this;
+    }
+};
+
+/**
+ * named_tuple is a class that inherits from tuple. Its main purpose is to make more readable and
+ * less error prone code that uses `std::tuple`.
+ * \code{.cpp}
+ * using namespace BipedalLocomotion::GenericContainer::literals;
+ *
+ * auto foo =
+ * BipedalLocomotion::GenericContainer::make_named_tuple(BipedalLocomotion::GenericContainer::named_param<"name"_h, std::string>(),
+ *                                                       BipedalLocomotion::GenericContainer::named_param<"number"_h, int>());
+ *
+ * // it is still possible to access the elements of the named_tuple with structured binding
+ * // declaration
+ * auto& [a, b] = foo;
+ * b = 150;
+ *
+ * // moreover you can call std::get<> as usual
+ * int n = std::get<1>(foo);
+ *
+ * // Differently from a normal tuple it is possible to access to the element via the hash as
+ * // follows
+ * foo.get_from_hash<"name"_h>() = "Smith";
+ * const std::string& temp_string = foo.get_from_hash<"name"_h>();
+ * \endcode
+ */
+template <typename... Params> struct named_tuple : public std::tuple<Params...>
+{
+
+    /** Underlying tuple that can be generate from this named_tuple */
+    using underlying_tuple = std::tuple<typename Params::Type...>;
+
+    /**
+     * Constructor
+     */
+    constexpr named_tuple()
+        : std::tuple<Params...>()
+    {
+    }
+
+    /**
+     * Constructor
+     */
+    named_tuple(Params&&... args)
+        : std::tuple<Params...>(std::forward<Params>(args)...)
+    {
+    }
+
+    /**
+     * Construct from a tuple.
+     * @param t a tuple having the same number of elements of of named_tuple.
+     * @note This constructor requires the type of the elements of the tuple to be convertible into
+     * Params.
+     */
+    template <typename... Args>
+    named_tuple(const std::tuple<Args...>& t)
+        : std::tuple<Params...>(t)
+    {
+        static_assert(sizeof...(Params) == sizeof...(Args),
+                      "Invalid number of parameters in the std::tuple");
+    }
+
+    /**
+     * Construct from a tuple.
+     * @param t a tuple having the same number of elements of named_tuple.
+     * @note This constructor requires the type of the elements of the tuple to be convertible into
+     * Params.
+     */
+    template <typename... Args>
+    named_tuple(std::tuple<Args...>&& t)
+        : std::tuple<Params...>(std::forward<std::tuple<Args...>>(t))
+    {
+        static_assert(sizeof...(Params) == sizeof...(Args),
+                      "Invalid number of parameters in the std::tuple");
+    }
+
+    /**
+     * Copy from a tuple.
+     * @param t tuple
+     */
+    template <typename... Args> named_tuple& operator=(const std::tuple<Args...>& t)
+    {
+        static_assert(sizeof...(Params) == sizeof...(Args),
+                      "Invalid number of parameters in the std::tuple");
+        this->copy_from_tuple(t);
+        return *this;
+    }
+
+    /**
+     * Extracts the Ith element from the named_tuple. It must be an integer value in `[0,
+     * sizeof...(Types))`.
+     * @param t the named_tuple
+     * @return A reference to the selected element of t.
+     */
+    template <std::size_t I>
+    const typename std::tuple_element<I, underlying_tuple>::type& get() const noexcept
+    {
+        const auto& param = (std::get<I>(static_cast<const std::tuple<Params...>&>(*this)));
+        return param.param;
+    }
+
+    /**
+     * Extracts the Ith element from the named_tuple. I must be an integer value in `[0,
+     * sizeof...(Types))`.
+     * @param t the named_tuple
+     * @return A reference to the selected element of t.
+     */
+    template <std::size_t I> typename std::tuple_element<I, underlying_tuple>::type& get() noexcept
+    {
+        auto& param = (std::get<I>(static_cast<std::tuple<Params...>&>(*this)));
+        return param.param;
+    }
+
+    /**
+     * Extracts the  element from the named_tuple associated to the hash `Hash`. `Hash` must be
+     * among one of the hash values associated to the tuple when created.
+     * @@return A reference to the selected element of t.
+     */
+    template <hash_type Hash> const auto& get_from_hash() const noexcept
+    {
+        constexpr std::size_t index = get_element_index<Hash>();
+        static_assert((index != error), "Wrong named tuple key.");
+        return this->get<index>();
+    }
+
+    /**
+     * Extracts the  element from the named_tuple associated to the hash `Hash`. `Hash` must be
+     * among one of the hash values associated to the tuple when created.
+     * @@return A reference to the selected element of t.
+     */
+    template <hash_type Hash> auto& get_from_hash() noexcept
+    {
+        constexpr std::size_t index = get_element_index<Hash>();
+        static_assert((index != error), "Wrong named tuple key.");
+        return this->get<index>();
+    }
+
+    /**
+     * Return the associated std::tuple
+     * @return the tuple associated to the named_tuple
+     */
+    underlying_tuple to_tuple() const noexcept
+    {
+        underlying_tuple temp;
+        this->copy_to_tuple(temp);
+        return temp;
+    }
+
+private:
+    /**
+     * Copy an element of a named_tuple in tuple.
+     * @param t a tuple
+     * @note This ends the compile time recursive function
+     */
+    template <std::size_t I = 0, typename... Args>
+    inline typename std::enable_if<I == sizeof...(Params), void>::type
+    copy_to_tuple(underlying_tuple& t) const
+    {
+    }
+
+    /**
+     * Copy an element of a named_tuple in tuple.
+     * @param t a tuple
+     * @note This is a compile time recursive function
+     */
+    template <std::size_t I = 0, typename... Args>
+    inline typename std::enable_if<(I < sizeof...(Params)), void>::type
+    copy_to_tuple(underlying_tuple& t) const
+    {
+        // copy each element
+        std::get<I>(t) = this->get<I>();
+        this->copy_to_tuple<I + 1>(t);
+    }
+
+    /**
+     * Copy an element of a tuple in named_tuple.
+     * @param t a tuple
+     * @note This ends the compile time recursive function
+     */
+    template <std::size_t I = 0, typename... Args>
+    inline typename std::enable_if<I == sizeof...(Params), void>::type
+    copy_from_tuple(const std::tuple<Args...>& t)
+    {
+    }
+
+    /**
+     * Copy an element of a tuple in named_tuple.
+     * @param t a tuple
+     * @note This is a compile time recursive function
+     */
+    template <std::size_t I = 0, typename... Args>
+    inline typename std::enable_if<(I < sizeof...(Params)), void>::type
+    copy_from_tuple(const std::tuple<Args...>& t)
+    {
+        // copy each element
+        this->get<I>() = std::get<I>(t);
+        this->copy_from_tuple<I + 1>(t);
+    }
+
+    /**
+     * Get the index of the element given the hash.
+     * @return an error flag.
+     * @note In this function is returned means that the hash has not be found.
+     */
+    template <hash_type Hash, std::size_t I = 0>
+    constexpr typename std::enable_if<I == sizeof...(Params),
+                                      const std::size_t>::type static get_element_index() noexcept
+    {
+        return error;
+    }
+
+    /**
+     * Get the index of the element given the hash.
+     * @return The index of  the element associated to the given hash.
+     * @note This function is resolved at compile time. So if the hash is not found an error flag
+     * will be returned.
+     */
+    template <hash_type Hash, std::size_t I = 0>
+    constexpr typename std::enable_if<(I < sizeof...(Params)),
+                                      const std::size_t>::type static get_element_index() noexcept
+    {
+        using element_type = typename std::tuple_element<I, std::tuple<Params...>>::type;
+        if constexpr (Hash == element_type::hash)
+        {
+            return I;
+        }
+        return get_element_index<Hash, I + 1>();
+    }
+
+    static constexpr std::size_t error = -1;
+};
+
+/**
+ * Creates a named_tuple object, deducing the target type from the types of arguments.
+ * @params args zero or more arguments to construct the named_tuple from
+ * @return A named_tuple object containing the given values, created as if by
+ * `named_tuple<Args...>(std::forward<Args>(args)...).`
+ */
+template <typename... Args> constexpr auto make_named_tuple(Args&&... args)
+{
+    return named_tuple<Args...>(std::forward<Args>(args)...);
+}
+
+namespace literals
+{
+
+/**
+ * Forms a hash from a char*
+ * @note To use the literal operator please refer to the following code
+ * \code{.cpp}
+ * using namespace BipedalLocomotion::GenericContainer::literals;
+ *
+ * constexpr BipedalLocomotion::GenericContainer::hash_type hash = "foo"_h;
+ * \endcode
+ */
+constexpr hash_type operator"" _h(const char* tag, std::size_t s)
+{
+    return ::BipedalLocomotion::GenericContainer::detail::sid_hash(tag);
+}
+
+} // namespace literals
+} // namespace GenericContainer
+} // namespace BipedalLocomotion
+
+namespace std
+{
+
+/**
+ * Extracts the Ith element from the named_tuple. It must be an integer value in `[0,
+ * sizeof...(Types))`.
+ * @param t the named_tuple
+ * @return A reference to the selected element of t.
+ */
+template <std::size_t I, typename... Params>
+typename std::tuple_element<
+    I,
+    typename ::BipedalLocomotion::GenericContainer::named_tuple<Params...>::underlying_tuple>::type&
+get(::BipedalLocomotion::GenericContainer::named_tuple<Params...>& t) noexcept
+{
+    return t.template get<I>();
+}
+
+/**
+ * Extracts the Ith element from the named_tuple. It must be an integer value in `[0,
+ * sizeof...(Types))`.
+ * @param t the named_tuple
+ * @return A reference to the selected element of t.
+ */
+template <std::size_t I, typename... Params>
+const typename tuple_element<
+    I,
+    typename ::BipedalLocomotion::GenericContainer::named_tuple<Params...>::underlying_tuple>::type&
+get(const ::BipedalLocomotion::GenericContainer::named_tuple<Params...>& t) noexcept
+{
+    return t.template get<I>();
+}
+
+/**
+ * Template specialization to make the elements of the named_tuple accessible with the Structured
+ * binding declaration
+ */
+template <typename... Params>
+struct tuple_size<::BipedalLocomotion::GenericContainer::named_tuple<Params...>>
+    : integral_constant<size_t, sizeof...(Params)>
+{
+};
+
+/**
+ * Template specialization to make the elements of the named_tuple accessible with the Structured
+ * binding declaration
+ */
+template <size_t Index, typename... Params>
+struct tuple_element<Index, ::BipedalLocomotion::GenericContainer::named_tuple<Params...>>
+    : std::tuple_element<
+          Index,
+          typename ::BipedalLocomotion::GenericContainer::named_tuple<Params...>::underlying_tuple>
+{
+};
+
+} // namespace std
+
+/**
+ * Create the hash from a string
+ * @param x_ key
+ */
+#define BLF_STRING_TO_HASH(x_) ::BipedalLocomotion::GenericContainer::detail::sid_hash(#x_)
+
+/**
+ * Create a named parameter given type and key
+ * @param x_ key
+ * @param type_ type of the parameter
+ */
+#define BLF_NAMED_PARAM(x_, type_) \
+    ::BipedalLocomotion::GenericContainer::named_param<BLF_STRING_TO_HASH(x_), type_>
+
+#endif // BIPEDAL_LOCOMOTION_GENERIC_CONTAINER_NAMED_TUPLE_H

--- a/src/GenericContainer/tests/CMakeLists.txt
+++ b/src/GenericContainer/tests/CMakeLists.txt
@@ -7,6 +7,11 @@ add_bipedal_test(
   SOURCES GenericContainerTest.cpp
   LINKS BipedalLocomotion::GenericContainer iDynTree::idyntree-core)
 
+add_bipedal_test(
+  NAME NamedTuple
+  SOURCES NamedTupleTest.cpp
+  LINKS BipedalLocomotion::GenericContainer)
+
 if (FRAMEWORK_HAS_YARP)
     add_bipedal_test(
       NAME GenericContainerPlusYarp

--- a/src/GenericContainer/tests/NamedTupleTest.cpp
+++ b/src/GenericContainer/tests/NamedTupleTest.cpp
@@ -1,0 +1,125 @@
+/**
+ * @file NamedTupleTest.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <Eigen/Dense>
+#include <tuple>
+#include <iostream>
+
+// Catch2
+#include <Eigen/src/Core/Matrix.h>
+#include <catch2/catch.hpp>
+
+#include <BipedalLocomotion/GenericContainer/NamedTuple.h>
+
+using namespace BipedalLocomotion::GenericContainer;
+
+class DummyClass
+{
+public:
+    using State = named_tuple<named_param<detail::sid_hash("name"), std::string>,
+                              named_param<detail::sid_hash("number"), int>,
+                              named_param<detail::sid_hash("floating_number"), double>,
+                              named_param<detail::sid_hash("vector"), Eigen::VectorXd>>;
+
+    const State& getState() const
+    {
+        return m_state;
+    }
+
+    State& getState()
+    {
+        return m_state;
+    }
+
+    void setState(const State& state)
+    {
+        m_state = state;
+    }
+
+private:
+
+    State m_state;
+};
+
+TEST_CASE("Test Named Parameter")
+{
+    using namespace BipedalLocomotion::GenericContainer::literals;
+    named_param<"name"_h, std::string> param;
+
+    param = "Olivia";
+}
+
+TEST_CASE("Test Numed Tuple - tuple operator")
+{
+    using namespace BipedalLocomotion::GenericContainer::literals;
+    DummyClass dummyClass;
+
+    dummyClass.setState(
+        std::tuple<std::string, int, double, Eigen::VectorXd>{"Elisa", 12, 1.231, Eigen::Vector2d()});
+
+    REQUIRE(std::get<0>(dummyClass.getState()) == "Elisa");
+    REQUIRE(dummyClass.getState().get_from_hash<"name"_h>() == "Elisa");
+
+    const DummyClass& dummyClassRef = dummyClass;
+    REQUIRE(std::get<0>(dummyClassRef.getState()) == "Elisa");
+    REQUIRE(dummyClassRef.getState().get_from_hash<"name"_h>() == "Elisa");
+}
+
+TEST_CASE("Test NamedTuple")
+{
+    using namespace BipedalLocomotion::GenericContainer::literals;
+
+    auto foo = make_named_tuple(named_param<"name"_h, std::string>(),
+                                named_param<"number"_h, int>(),
+                                named_param<"floating_number"_h, double>(),
+                                named_param<"vector"_h, Eigen::VectorXd>());
+
+    SECTION("Get")
+    {
+        auto& [a, b, c, d] = foo;
+        a = "Smith";
+        b = 150;
+        c = 3.14;
+        d = Eigen::VectorXd::Ones(10);
+
+        REQUIRE(a == foo.get_from_hash<"name"_h>());
+        REQUIRE(std::get<0>(foo) == foo.get_from_hash<"name"_h>());
+
+        REQUIRE(b == foo.get_from_hash<"number"_h>());
+        REQUIRE(std::get<1>(foo) == foo.get_from_hash<"number"_h>());
+
+        REQUIRE(c == foo.get_from_hash<"floating_number"_h>());
+        REQUIRE(std::get<2>(foo) == foo.get_from_hash<"floating_number"_h>());
+
+        REQUIRE(d == foo.get_from_hash<"vector"_h>());
+        REQUIRE(std::get<3>(foo) == foo.get_from_hash<"vector"_h>());
+    }
+
+    SECTION("Set")
+    {
+        foo.get_from_hash<"name"_h>() = "Olivia";
+        REQUIRE(std::get<0>(foo) == foo.get_from_hash<"name"_h>());
+
+        foo.get_from_hash<"number"_h>() = 42;
+        REQUIRE(std::get<1>(foo) == foo.get_from_hash<"number"_h>());
+
+        foo.get_from_hash<"floating_number"_h>() = 8.15;
+        REQUIRE(std::get<2>(foo) == foo.get_from_hash<"floating_number"_h>());
+
+        foo.get_from_hash<"vector"_h>() = Eigen::Vector4d::Constant(3);
+        REQUIRE(std::get<3>(foo) == foo.get_from_hash<"vector"_h>());
+    }
+
+    SECTION("From and to tuple")
+    {
+        auto tempTuple = foo.to_tuple();
+        decltype(foo) newNamedTuple(tempTuple);
+
+        decltype(foo) newNamedTuple2;
+        newNamedTuple2 = tempTuple;
+    }
+}

--- a/src/IK/include/BipedalLocomotion/IK/JointLimitsTask.h
+++ b/src/IK/include/BipedalLocomotion/IK/JointLimitsTask.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_IK_JOINT_LIMITS_TASK_H
 #define BIPEDAL_LOCOMOTION_IK_JOINT_LIMITS_TASK_H
 
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -48,7 +49,7 @@ class JointLimitsTask : public IKLinearTask
 
     bool m_isLimitConsideredForAllJoints{false};
 
-    double m_samplingTime;
+    std::chrono::nanoseconds m_samplingTime;
 
     std::string m_robotVelocityVariableName;
 

--- a/src/IK/tests/CMakeLists.txt
+++ b/src/IK/tests/CMakeLists.txt
@@ -37,14 +37,18 @@ add_bipedal_test(
   SOURCES AngularMomentumTaskTest.cpp
   LINKS BipedalLocomotion::IK)
 
-add_bipedal_test(
-  NAME QPInverseKinematics
-  SOURCES QPInverseKinematicsTest.cpp
-  LINKS BipedalLocomotion::IK BipedalLocomotion::ManifConversions
-        BipedalLocomotion::ContinuousDynamicalSystem)
+if (FRAMEWORK_COMPILE_ContinuousDynamicalSystem)
 
-add_bipedal_test(
-  NAME QPFixedBaseInverseKinematics
-  SOURCES QPFixedBaseInverseKinematicsTest.cpp
-  LINKS BipedalLocomotion::IK BipedalLocomotion::ManifConversions
-        BipedalLocomotion::ContinuousDynamicalSystem)
+  add_bipedal_test(
+    NAME QPInverseKinematics
+    SOURCES QPInverseKinematicsTest.cpp
+    LINKS BipedalLocomotion::IK BipedalLocomotion::ManifConversions
+    BipedalLocomotion::ContinuousDynamicalSystem)
+
+  add_bipedal_test(
+    NAME QPFixedBaseInverseKinematics
+    SOURCES QPFixedBaseInverseKinematicsTest.cpp
+    LINKS BipedalLocomotion::IK BipedalLocomotion::ManifConversions
+    BipedalLocomotion::ContinuousDynamicalSystem)
+
+endif()

--- a/src/IK/tests/JointLimitsTaskTest.cpp
+++ b/src/IK/tests/JointLimitsTaskTest.cpp
@@ -5,6 +5,8 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <chrono>
+
 // Catch2
 #include <catch2/catch.hpp>
 
@@ -24,10 +26,11 @@ using namespace BipedalLocomotion::IK;
 
 TEST_CASE("Joint Regularization task")
 {
+    using namespace std::chrono_literals;
     const std::string robotVelocity = "robotVelocity";
 
     Eigen::VectorXd klim;
-    constexpr double dt = 0.01;
+    constexpr std::chrono::nanoseconds dt = 10ms;
 
     auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
     auto parameterHandler = std::make_shared<StdImplementation>();
@@ -126,10 +129,10 @@ TEST_CASE("Joint Regularization task")
 
             // check the vector b
             Eigen::VectorXd expectedB;
-            expectedB = klim.asDiagonal() * deltaLimit / dt;
+            expectedB = klim.asDiagonal() * deltaLimit / std::chrono::duration<double>(dt).count();
             REQUIRE(b.head(model.getNrOfDOFs()).isApprox(expectedB));
 
-            expectedB = klim.asDiagonal() * (deltaLimit) / dt;
+            expectedB = klim.asDiagonal() * (deltaLimit) / std::chrono::duration<double>(dt).count();
             REQUIRE(b.tail(model.getNrOfDOFs()).isApprox(expectedB));
 
         }

--- a/src/IK/tests/QPFixedBaseInverseKinematicsTest.cpp
+++ b/src/IK/tests/QPFixedBaseInverseKinematicsTest.cpp
@@ -36,9 +36,10 @@ using namespace BipedalLocomotion::System;
 using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 using namespace BipedalLocomotion::IK;
 using namespace BipedalLocomotion::Conversions;
+using namespace std::chrono_literals;
 
 constexpr auto robotVelocity = "robotVelocity";
-constexpr double dT = 0.005;
+constexpr std::chrono::nanoseconds dT = 5ms;
 
 struct InverseKinematicsAndTasks
 {
@@ -281,7 +282,7 @@ TEST_CASE("QP-IK")
 
                 // propagate the dynamical system
                 system.dynamics->setControlInput({baseVelocity, jointVelocity});
-                system.integrator->integrate(0, dT);
+                system.integrator->integrate(0s, dT);
             }
 
             // Check the end-effector pose error

--- a/src/IK/tests/QPInverseKinematicsTest.cpp
+++ b/src/IK/tests/QPInverseKinematicsTest.cpp
@@ -38,9 +38,10 @@ using namespace BipedalLocomotion::System;
 using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 using namespace BipedalLocomotion::IK;
 using namespace BipedalLocomotion::Conversions;
+using namespace std::chrono_literals;
 
 constexpr auto robotVelocity = "robotVelocity";
-constexpr double dT = 0.01;
+constexpr std::chrono::nanoseconds dT = 10ms;
 
 struct InverseKinematicsAndTasks
 {
@@ -348,7 +349,7 @@ TEST_CASE("QP-IK")
 
                 // propagate the dynamical system
                 system.dynamics->setControlInput({baseVelocity, jointVelocity});
-                system.integrator->integrate(0, dT);
+                system.integrator->integrate(0s, dT);
             }
 
             // check the CoM position
@@ -454,7 +455,7 @@ TEST_CASE("QP-IK [With strict limits]")
 
         // propagate the dynamical system
         system.dynamics->setControlInput({baseVelocity, jointVelocity});
-        system.integrator->integrate(0, dT);
+        system.integrator->integrate(0s, dT);
     }
 }
 
@@ -554,7 +555,7 @@ TEST_CASE("QP-IK [With builder]")
 
         // propagate the dynamical system
         system.dynamics->setControlInput({baseVelocity, jointVelocity});
-        system.integrator->integrate(0, dT);
+        system.integrator->integrate(0s, dT);
     }
 
     auto weightProvider

--- a/src/TSID/tests/QPFixedBaseTSIDTest.cpp
+++ b/src/TSID/tests/QPFixedBaseTSIDTest.cpp
@@ -6,25 +6,23 @@
  */
 
 // Catch2
-#include "BipedalLocomotion/System/ConstantWeightProvider.h"
 #include <catch2/catch.hpp>
 
 // std
+#include <chrono>
 #include <memory>
 #include <random>
 
 // BipedalLocomotion
-#include <BipedalLocomotion/Conversions/ManifConversions.h>
-#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
-#include <BipedalLocomotion/System/VariablesHandler.h>
-
-#include <BipedalLocomotion/TSID/JointTrackingTask.h>
-#include <BipedalLocomotion/TSID/SE3Task.h>
-
-#include <BipedalLocomotion/TSID/QPFixedBaseTSID.h>
-
 #include <BipedalLocomotion/ContinuousDynamicalSystem/FixedBaseDynamics.h>
 #include <BipedalLocomotion/ContinuousDynamicalSystem/ForwardEuler.h>
+#include <BipedalLocomotion/Conversions/ManifConversions.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/System/ConstantWeightProvider.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/TSID/JointTrackingTask.h>
+#include <BipedalLocomotion/TSID/QPFixedBaseTSID.h>
+#include <BipedalLocomotion/TSID/SE3Task.h>
 
 #include <iDynTree/Core/EigenHelpers.h>
 #include <iDynTree/Model/ModelTestUtils.h>
@@ -34,11 +32,12 @@ using namespace BipedalLocomotion::System;
 using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 using namespace BipedalLocomotion::Conversions;
 using namespace BipedalLocomotion::TSID;
+using namespace std::chrono_literals;
 
 constexpr auto robotAcceleration = "robotAccelration";
 constexpr auto jointTorques = "jointTorques";
 constexpr int maxNumOfContacts = 0;
-constexpr double dT = 0.01;
+constexpr std::chrono::nanoseconds dT = 10ms;
 
 struct TSIDAndTasks
 {
@@ -292,7 +291,7 @@ TEST_CASE("QP-TSID")
 
                 // propagate the dynamical system
                 system.dynamics->setControlInput({tsidAndTasks.tsid->getOutput().jointTorques});
-                system.integrator->integrate(0, dT);
+                system.integrator->integrate(0s, dT);
             }
 
             // Check the end-effector pose error


### PR DESCRIPTION
This PR implements the `NamedTuple` class in the System component. I took the implementation from here: https://github.com/GiulioRomualdi/named_tuple

The following classes have been modified to be compliant with `named_tuple`
- DynamicalSystem
- FixedBaseDynamics
- LinearTimeInvariantSystem
- FloatingBaseSystemKinematics
- ForwardEuler
- FirstOrderSmoother

Moreover, this PR implements the `CentroidalDynamics` class