### PR TITLE
Fix compilation when using CMake 3.26.1 and pybind11 2.4.3 (for example on Ubuntu 20.04 GitHub Actions image)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,15 +137,6 @@ jobs:
         mkdir -p /usr/share/librealsense2/presets
         sudo apt-get install librealsense2-dev
 
-    # Workaround for https://github.com/ami-iit/bipedal-locomotion-framework/issues/636
-    - name: Cmake 3.25.3 [Ubuntu]
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        curl -sL https://github.com/Kitware/CMake/releases/download/v3.25.3/cmake-3.25.3-linux-x86_64.sh -o cmakeinstall.sh \
-        && chmod +x cmakeinstall.sh \
-        && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \
-        && rm cmakeinstall.sh
-
     - name: Cache Source-based Dependencies
       id: cache-source-deps
       uses: actions/cache@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project are documented in this file.
 - Return an error if an invalid `KinDynComputations` object is passed to `QPInverseKinematics::build()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/622)
 - Fix `QPTSIF` documentation (https://github.com/ami-iit/bipedal-locomotion-framework/pull/634)
 - Fix error messages in `QPTSID` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/639)
+- Fix compilation failure when using CMake 3.26.1 and pybind11 2.4.3 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/643)
 
 ## [0.12.0] - 2023-03-07
 ### Added

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -5,6 +5,15 @@
 include(BipedalLocomotionFrameworkFindDependencies)
 include(BipedalLocomotionDependencyClassifier)
 
+# Workaround for issue that occurs with CMake 3.26.1 and pybind11 2.4.3
+# see https://github.com/ami-iit/bipedal-locomotion-framework/issues/636
+# This is done here as it needs to be done before any call (even transitive)
+# to find_package(pybind11)
+# It can be removed once pybind11 2.4.3 is not supported anymore
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 ################################################################################
 ########################## Mandatory dependencies ##############################
 


### PR DESCRIPTION
Fix https://github.com/ami-iit/bipedal-locomotion-framework/issues/636 .

This PR fixes an issue when using CMake 3.26.1 (so a quite recent CMake) with pybind11 2.4.3 (quite an old version). 

Basically, the problem is that the old version of pybind11 explicitly sets `-std=c++14` as compilation option, and this overrides the `-std=c++17` option that should be used instead (see https://github.com/pybind/pybind11/blob/v2.4.3/tools/pybind11Tools.cmake#L21 and https://github.com/pybind/pybind11/blob/v2.4.3/tools/pybind11Tools.cmake#L21). By explicitingly setting the `CMAKE_CXX_STANDARD` option, we make sure that pybind11 does not set any additional option.