### PR TITLE
Enable the possibility to send the PlannedContact, ContactList and ContactListMap as yarp msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Add the support of `std::chrono` in The text logging (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 - Add the possibility to retrieve and set duration from the `IParametersHandler` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/630)
 - Add the possibility to update the contact list in the swing foot trajectory planner (https://github.com/ami-iit/bipedal-locomotion-framework/pull/637)
+- Add the possibility to send the PlannedContact, ContactList and ContactListMap as yarp messages (https://github.com/ami-iit/bipedal-locomotion-framework/pull/644)
 
 ### Changed
 - Update the `IK tutorial` to use `QPInverseKinematics::build` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/621)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -40,6 +40,14 @@ else ()
 endif()
 mark_as_advanced(FRAMEWORK_COMPILE_BINDINGS_RosSystem)
 
+if (FRAMEWORK_COMPILE_Contact AND FRAMEWORK_COMPILE_YarpImplementation)
+  set(FRAMEWORK_COMPILE_BINDINGS_YarpContact ON)
+else ()
+  set(FRAMEWORK_COMPILE_BINDINGS_YarpContact OFF)
+endif()
+mark_as_advanced(FRAMEWORK_COMPILE_BINDINGS_YarpContact)
+
+
 configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/bipedal_locomotion_framework.cpp.in
   ${CMAKE_CURRENT_BINARY_DIR}/bipedal_locomotion_framework.cpp
   @ONLY)

--- a/bindings/python/Contacts/CMakeLists.txt
+++ b/bindings/python/Contacts/CMakeLists.txt
@@ -13,4 +13,14 @@ if(FRAMEWORK_COMPILE_Contact)
     LINK_LIBRARIES BipedalLocomotion::Contacts BipedalLocomotion::ContactDetectors
     TESTS tests/test_contact.py tests/test_schmitt_trigger_detector.py)
 
+  if(FRAMEWORK_COMPILE_YarpImplementation)
+
+    add_bipedal_locomotion_python_module(
+      NAME  ContactsYarpImplementationBindings
+      SOURCES src/ContactsYarpMsg.cpp src/YarpModule.cpp
+      HEADERS ${H_PREFIX}/ContactsYarpMsg.h ${H_PREFIX}/YarpModule.h
+      LINK_LIBRARIES BipedalLocomotion::ContactsYarpImplementation)
+
+  endif()
+
 endif()

--- a/bindings/python/Contacts/include/BipedalLocomotion/bindings/Contacts/ContactsYarpMsg.h
+++ b/bindings/python/Contacts/include/BipedalLocomotion/bindings/Contacts/ContactsYarpMsg.h
@@ -1,0 +1,28 @@
+/**
+ * @file ContactsYarpMsg.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_CONTACTS_CONTACTS_YARP_MSG_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_CONTACTS_CONTACTS_YARP_MSG_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace Contacts
+{
+
+void CreatePlannedContactYarpMsg(pybind11::module& module);
+void CreateContactListYarpMsg(pybind11::module& module);
+void CreateContactListMapYarpMsg(pybind11::module& module);
+
+} // namespace Contacts
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_CONTACTS_CONTACTS_YARP_MSG_H

--- a/bindings/python/Contacts/include/BipedalLocomotion/bindings/Contacts/YarpModule.h
+++ b/bindings/python/Contacts/include/BipedalLocomotion/bindings/Contacts/YarpModule.h
@@ -1,0 +1,26 @@
+/**
+ * @file YarpModule.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_CONTACTS_YARP_MODULE_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_CONTACTS_YARP_MODULE_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace Contacts
+{
+
+void CreateYarpModule(pybind11::module& module);
+
+} // namespace Contacts
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_CONTACTS_YARP_MODULE_H

--- a/bindings/python/Contacts/src/ContactsYarpMsg.cpp
+++ b/bindings/python/Contacts/src/ContactsYarpMsg.cpp
@@ -1,0 +1,80 @@
+/**
+ * @file ContactsYarpMsg.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/Contacts/Contact.h>
+#include <BipedalLocomotion/Contacts/ContactList.h>
+#include <BipedalLocomotion/Contacts/ContactListMapYarpMsg.h>
+#include <BipedalLocomotion/Contacts/ContactListYarpMsg.h>
+#include <BipedalLocomotion/Contacts/PlannedContactYarpMsg.h>
+
+#include <BipedalLocomotion/bindings/Contacts/ContactsYarpMsg.h>
+#include <BipedalLocomotion/bindings/YarpUtilities/BufferedPort.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace Contacts
+{
+void CreatePlannedContactYarpMsg(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    using namespace ::BipedalLocomotion::Contacts;
+
+    py::class_<PlannedContactYarpMsg, PlannedContact>(module, "PlannedContactYarpMsg")
+        .def(py::init<const PlannedContact&>())
+        .def("from_planned_contact",
+             &PlannedContactYarpMsg::fromPlannedContact,
+             py::arg("planned_contact"))
+        .def("__repr__", &PlannedContactYarpMsg::toString)
+        .def("to_string", &PlannedContactYarpMsg::toString);
+
+    using ::BipedalLocomotion::bindings::YarpUtilities::CreateBufferedPort;
+    CreateBufferedPort<PlannedContactYarpMsg>(module, "BufferedPlannedContact");
+}
+
+void CreateContactListYarpMsg(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    using namespace ::BipedalLocomotion::Contacts;
+
+    py::class_<ContactListYarpMsg, ContactList>(module, "ContactListYarpMsg")
+        .def(py::init<const ContactList&>())
+        .def("from_contact_list", &ContactListYarpMsg::fromContactList, py::arg("contact_list_"))
+        .def("__repr__", &ContactListYarpMsg::toString)
+        .def("to_string", &ContactListYarpMsg::toString);
+
+    using ::BipedalLocomotion::bindings::YarpUtilities::CreateBufferedPort;
+    CreateBufferedPort<ContactListYarpMsg>(module, "BufferedContactList");
+}
+
+void CreateContactListMapYarpMsg(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+
+    using namespace ::BipedalLocomotion::Contacts;
+
+    py::class_<ContactListMapYarpMsg>(module, "ContactListMapYarpMsg")
+        .def(py::init<const ContactListMap&>())
+        .def("from_contact_list_map",
+             &ContactListMapYarpMsg::fromContactListMap,
+             py::arg("contact_list_map"))
+        .def("__repr__", &ContactListMapYarpMsg::toString)
+        .def("to_string", &ContactListMapYarpMsg::toString);
+
+    using ::BipedalLocomotion::bindings::YarpUtilities::CreateBufferedPort;
+    CreateBufferedPort<ContactListMapYarpMsg>(module, "BufferedContactListMap");
+}
+
+} // namespace Contacts
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/Contacts/src/YarpModule.cpp
+++ b/bindings/python/Contacts/src/YarpModule.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file YarpModule.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include <BipedalLocomotion/bindings/Contacts/ContactsYarpMsg.h>
+#include <BipedalLocomotion/bindings/Contacts/YarpModule.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace Contacts
+{
+void CreateYarpModule(pybind11::module& module)
+{
+    CreatePlannedContactYarpMsg(module);
+    CreateContactListYarpMsg(module);
+    CreateContactListMapYarpMsg(module);
+}
+} // namespace Contacts
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/bipedal_locomotion_framework.cpp.in
+++ b/bindings/python/bipedal_locomotion_framework.cpp.in
@@ -46,6 +46,10 @@
 #include <BipedalLocomotion/bindings/Contacts/Module.h>
 @endcmakeif FRAMEWORK_COMPILE_Contact
 
+@cmakeif FRAMEWORK_COMPILE_BINDINGS_YarpContact
+#include <BipedalLocomotion/bindings/Contacts/YarpModule.h>
+@endcmakeif FRAMEWORK_COMPILE_BINDINGS_YarpContact
+
 @cmakeif FRAMEWORK_COMPILE_Planners
 #include <BipedalLocomotion/bindings/Planners/Module.h>
 @endcmakeif FRAMEWORK_COMPILE_Planners
@@ -138,6 +142,10 @@ PYBIND11_MODULE(bindings, m)
     py::module contactsModule = m.def_submodule("contacts");
     bindings::Contacts::CreateModule(contactsModule);
     @endcmakeif FRAMEWORK_COMPILE_Contact
+
+    @cmakeif FRAMEWORK_COMPILE_BINDINGS_YarpContact
+    bindings::Contacts::CreateYarpModule(contactsModule);
+    @endcmakeif FRAMEWORK_COMPILE_BINDINGS_YarpContact
 
     @cmakeif FRAMEWORK_COMPILE_Planners
     py::module plannersModule = m.def_submodule("planners");

--- a/src/Contacts/CMakeLists.txt
+++ b/src/Contacts/CMakeLists.txt
@@ -7,7 +7,7 @@ if (FRAMEWORK_COMPILE_Contact)
   set(H_PREFIX include/BipedalLocomotion/Contacts)
   add_bipedal_locomotion_library(
     NAME                  Contacts
-    SUBDIRECTORIES        tests/Contacts
+    SUBDIRECTORIES        YarpImplementation tests/Contacts tests/YarpImplementation
     PUBLIC_HEADERS        ${H_PREFIX}/Contact.h ${H_PREFIX}/ContactList.h ${H_PREFIX}/ContactPhase.h ${H_PREFIX}/ContactPhaseList.h ${H_PREFIX}/ContactListJsonParser.h
     SOURCES               src/Contact.cpp src/ContactList.cpp src/ContactPhase.cpp src/ContactPhaseList.cpp src/ContactListJsonParser.cpp
     PUBLIC_LINK_LIBRARIES MANIF::manif BipedalLocomotion::Math BipedalLocomotion::TextLogging
@@ -15,7 +15,7 @@ if (FRAMEWORK_COMPILE_Contact)
     INSTALLATION_FOLDER   Contacts)
 
   set(H_PREFIX include/BipedalLocomotion/ContactDetectors)
-    add_bipedal_locomotion_library(
+  add_bipedal_locomotion_library(
     NAME                   ContactDetectors
     SUBDIRECTORIES         tests/ContactDetectors
     SOURCES                src/ContactDetector.cpp src/SchmittTriggerDetector.cpp src/FixedFootDetector.cpp

--- a/src/Contacts/YarpImplementation/CMakeLists.txt
+++ b/src/Contacts/YarpImplementation/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (C) 2023 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license.
+
+
+if(FRAMEWORK_COMPILE_YarpImplementation)
+
+  set(H_PREFIX include/BipedalLocomotion/Contacts)
+
+  add_bipedal_locomotion_library(
+    NAME                   ContactsYarpImplementation
+    SOURCES                src/PlannedContactYarpMsg.cpp src/ContactListYarpMsg.cpp
+                           src/ContactListMapYarpMsg.cpp
+    PUBLIC_HEADERS         ${H_PREFIX}/PlannedContactYarpMsg.h
+                           ${H_PREFIX}/ContactListYarpMsg.h
+                           ${H_PREFIX}/ContactListMapYarpMsg.h
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::Contacts YARP::YARP_os
+    INSTALLATION_FOLDER    Contacts)
+
+endif()

--- a/src/Contacts/YarpImplementation/include/BipedalLocomotion/Contacts/ContactListMapYarpMsg.h
+++ b/src/Contacts/YarpImplementation/include/BipedalLocomotion/Contacts/ContactListMapYarpMsg.h
@@ -1,0 +1,63 @@
+/**
+ * @file ContactListMapYarpMsg.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_CONTACTS_CONTACT_LIST_MAP_YARP_MSG_H
+#define BIPEDAL_LOCOMOTION_CONTACTS_CONTACT_LIST_MAP_YARP_MSG_H
+
+#include <BipedalLocomotion/Contacts/ContactList.h>
+
+#include <yarp/os/Wire.h>
+#include <yarp/os/idl/WireTypes.h>
+
+namespace BipedalLocomotion::Contacts
+{
+
+class ContactListMapYarpMsg : public yarp::os::idl::WirePortable,
+                              public BipedalLocomotion::Contacts::ContactListMap
+{
+public:
+
+    using MsgType = BipedalLocomotion::Contacts::ContactListMap;
+
+    // Default constructor
+    ContactListMapYarpMsg() = default;
+
+    // Constructor with field values
+    ContactListMapYarpMsg(const ContactListMap& map);
+
+    // Build from an existing planned contact
+    void fromContactListMap(const ContactListMap& map);
+
+    // Read structure on a Wire
+    bool read(yarp::os::idl::WireReader& reader) override;
+
+    // Read structure on a Connection
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    // Write structure on a Wire
+    bool write(const yarp::os::idl::WireWriter& writer) const override;
+
+    // Write structure on a Connection
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+
+    // Convert to a printable string
+    std::string toString() const;
+
+    // If you want to serialize this class without nesting, use this helper
+    // typedef yarp::os::idl::Unwrapped<VectorsCollection> unwrapped;
+
+private:
+    // read/write vectors field
+    bool readContactListMap(yarp::os::idl::WireReader& reader);
+    bool writeContactListMap(const yarp::os::idl::WireWriter& writer) const;
+    // bool nested_read_vectors(yarp::os::idl::WireReader& reader);
+    // bool nested_write_vectors(const yarp::os::idl::WireWriter& writer) const;
+};
+
+} // namespace BipedalLocomotion::Contacts
+
+#endif // BIPEDAL_LOCOMOTION_CONTACTS_CONTACT_LIST_MAP_YARP_MSG_H

--- a/src/Contacts/YarpImplementation/include/BipedalLocomotion/Contacts/ContactListYarpMsg.h
+++ b/src/Contacts/YarpImplementation/include/BipedalLocomotion/Contacts/ContactListYarpMsg.h
@@ -1,0 +1,67 @@
+/**
+ * @file ContactListYarpMsg.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_CONTACTS_CONTACT_LIST_YARP_MSG_H
+#define BIPEDAL_LOCOMOTION_CONTACTS_CONTACT_LIST_YARP_MSG_H
+
+#include <BipedalLocomotion/Contacts/ContactList.h>
+
+#include <string>
+
+#include <yarp/os/Wire.h>
+#include <yarp/os/idl/WireTypes.h>
+
+namespace BipedalLocomotion::Contacts
+{
+
+class ContactListYarpMsg : public yarp::os::idl::WirePortable,
+                           public BipedalLocomotion::Contacts::ContactList
+{
+public:
+
+    using MsgType = BipedalLocomotion::Contacts::ContactList;
+
+    // Default constructor
+    ContactListYarpMsg() = default;
+
+    // Constructor with field values
+    ContactListYarpMsg(const ContactList&);
+
+    // Build from an existing planned contact
+    void fromContactList(const ContactList&);
+
+    // Read structure on a Wire
+    bool read(yarp::os::idl::WireReader& reader) override;
+
+    // Read structure on a Connection
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    // Write structure on a Wire
+    bool write(const yarp::os::idl::WireWriter& writer) const override;
+
+    // Write structure on a Connection
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+
+    // Convert to a printable string
+    std::string toString() const;
+
+    // If you want to serialize this class without nesting, use this helper
+    // typedef yarp::os::idl::Unwrapped<VectorsCollection> unwrapped;
+
+private:
+    // read/write vectors field
+    bool readContactList(yarp::os::idl::WireReader& reader);
+    bool writeContactList(const yarp::os::idl::WireWriter& writer) const;
+    bool readDefaultName(yarp::os::idl::WireReader& reader);
+    bool writeDefaultName(const yarp::os::idl::WireWriter& writer) const;
+    bool readDefaultIndex(yarp::os::idl::WireReader& reader);
+    bool writeDefaultIndex(const yarp::os::idl::WireWriter& writer) const;
+};
+
+} // namespace BipedalLocomotion::Contacts
+
+#endif // BIPEDAL_LOCOMOTION_CONTACTS_CONTACT_LIST_YARP_MSG_H

--- a/src/Contacts/YarpImplementation/include/BipedalLocomotion/Contacts/PlannedContactYarpMsg.h
+++ b/src/Contacts/YarpImplementation/include/BipedalLocomotion/Contacts/PlannedContactYarpMsg.h
@@ -1,0 +1,81 @@
+/**
+ * @file PlannedContactYarpMsg.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_CONTACTS_PLANNED_CONTACT_YARP_MSG_H
+#define BIPEDAL_LOCOMOTION_CONTACTS_PLANNED_CONTACT_YARP_MSG_H
+
+#include <BipedalLocomotion/Contacts/Contact.h>
+
+#include <yarp/os/Wire.h>
+#include <yarp/os/idl/WireTypes.h>
+
+namespace BipedalLocomotion::Contacts
+{
+
+class PlannedContactYarpMsg : public yarp::os::idl::WirePortable,
+                              public BipedalLocomotion::Contacts::PlannedContact
+{
+public:
+
+    using MsgType = BipedalLocomotion::Contacts::PlannedContact;
+
+    // Default constructor
+    PlannedContactYarpMsg() = default;
+
+    // Constructor with field values
+    PlannedContactYarpMsg(const PlannedContact& contact);
+
+    // Build from an existing planned contact
+    void fromPlannedContact(const PlannedContact& contact);
+
+    // Read structure on a Wire
+    bool read(yarp::os::idl::WireReader& reader) override;
+
+    // Read structure on a Connection
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    // Write structure on a Wire
+    bool write(const yarp::os::idl::WireWriter& writer) const override;
+
+    // Write structure on a Connection
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+
+    // Convert to a printable string
+    std::string toString() const;
+
+    // If you want to serialize this class without nesting, use this helper
+    typedef yarp::os::idl::Unwrapped<PlannedContact> unwrapped;
+
+private:
+    // read/write pose field
+    bool readPose(yarp::os::idl::WireReader& reader);
+    bool writePose(const yarp::os::idl::WireWriter& writer) const;
+    // bool nested_read_pose(yarp::os::idl::WireReader& reader);
+    // bool nested_write_pose(const yarp::os::idl::WireWriter& writer) const;
+
+    // read/write name field
+    bool readName(yarp::os::idl::WireReader& reader);
+    bool writeName(const yarp::os::idl::WireWriter& writer) const;
+    // bool nested_read_name(yarp::os::idl::WireReader& reader);
+    // bool nested_write_name(const yarp::os::idl::WireWriter& writer) const;
+
+    // read/write index field
+    bool readIndex(yarp::os::idl::WireReader& reader);
+    bool writeIndex(const yarp::os::idl::WireWriter& writer) const;
+    // bool nested_read_index(yarp::os::idl::WireReader& reader);
+    // bool nested_write_index(const yarp::os::idl::WireWriter& writer) const;
+
+    // read/write activationTime field
+    bool readTime(yarp::os::idl::WireReader& reader, std::chrono::nanoseconds& time);
+    bool writeTime(const yarp::os::idl::WireWriter& writer, const std::chrono::nanoseconds& time) const;
+    // bool nested_read_activationTime(yarp::os::idl::WireReader& reader);
+    // bool nested_write_activationTime(const yarp::os::idl::WireWriter& writer) const;
+};
+
+} // namespace BipedalLocomotion::Contacts
+
+#endif // BIPEDAL_LOCOMOTION_CONTACTS_PLANNED_CONTACT_YARP_MSG_H

--- a/src/Contacts/YarpImplementation/src/ContactListMapYarpMsg.cpp
+++ b/src/Contacts/YarpImplementation/src/ContactListMapYarpMsg.cpp
@@ -1,0 +1,174 @@
+/**
+ * @file ContactListMapYarpMsg.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/Contacts/Contact.h>
+#include <BipedalLocomotion/Contacts/ContactList.h>
+#include <BipedalLocomotion/Contacts/ContactListMapYarpMsg.h>
+#include <BipedalLocomotion/Contacts/ContactListYarpMsg.h>
+#include <BipedalLocomotion/Contacts/PlannedContactYarpMsg.h>
+
+#include <utility>
+
+using namespace BipedalLocomotion::Contacts;
+
+// Constructor with field values
+ContactListMapYarpMsg::ContactListMapYarpMsg(const ContactListMap& contactListMap)
+    : WirePortable()
+    , ContactListMap(contactListMap)
+{
+}
+
+void ContactListMapYarpMsg::fromContactListMap(const ContactListMap& map)
+{
+    ContactListMap* tmp = static_cast<ContactListMap*>(this);
+    if ((*tmp) != map)
+    {
+        (*tmp) = map;
+    }
+}
+
+// Read structure on a Wire
+bool ContactListMapYarpMsg::read(yarp::os::idl::WireReader& reader)
+{
+    if (!this->readContactListMap(reader))
+    {
+        return false;
+    }
+    return !reader.isError();
+}
+
+// Read structure on a Connection
+bool ContactListMapYarpMsg::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader(1))
+    {
+        return false;
+    }
+    return read(reader);
+}
+
+// Write structure on a Wire
+bool ContactListMapYarpMsg::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!this->writeContactListMap(writer))
+    {
+        return false;
+    }
+    return !writer.isError();
+}
+
+// Write structure on a Connection
+bool ContactListMapYarpMsg::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1))
+    {
+        return false;
+    }
+    return write(writer);
+}
+
+// Convert to a printable string
+std::string ContactListMapYarpMsg::toString() const
+{
+    yarp::os::Bottle b;
+    if (!yarp::os::Portable::copyPortable(*this, b))
+    {
+        return {};
+    }
+    return b.toString();
+}
+
+// read vectors field
+bool ContactListMapYarpMsg::readContactListMap(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore())
+    {
+        reader.fail();
+        return false;
+    }
+
+    size_t _csize;
+    yarp::os::idl::WireState _ktype;
+    yarp::os::idl::WireState _vtype;
+    reader.readMapBegin(_ktype, _vtype, _csize);
+    for (size_t _i = 0; _i < _csize; ++_i)
+    {
+        size_t _msize;
+        yarp::os::idl::WireState _lst;
+        reader.readListBegin(_lst, _msize);
+        std::string _key;
+        if (reader.noMore())
+        {
+            reader.fail();
+            return false;
+        }
+        if (!reader.readString(_key))
+        {
+            reader.fail();
+            return false;
+        }
+        ContactList& _val = this->operator[](_key);
+        if (reader.noMore())
+        {
+            reader.fail();
+            return false;
+        }
+
+        BipedalLocomotion::Contacts::ContactListYarpMsg tempContactList;
+        if (!reader.readNested(tempContactList))
+        {
+            reader.fail();
+            return false;
+        }
+        _val = tempContactList;
+
+        reader.readListEnd();
+    }
+    reader.readMapEnd();
+    return true;
+}
+
+// write vectors field
+bool ContactListMapYarpMsg::writeContactListMap(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeMapBegin(BOTTLE_TAG_STRING,
+                              BOTTLE_TAG_LIST | BOTTLE_TAG_LIST,
+                              static_cast<const ContactListMap*>(this)->size()))
+    {
+        return false;
+    }
+
+    for (const auto& _item : *static_cast<const ContactListMap*>(this))
+    {
+        if (!writer.writeListBegin(0, 2))
+        {
+            return false;
+        }
+        if (!writer.writeString(_item.first))
+        {
+            return false;
+        }
+
+        if (!writer.writeNested(ContactListYarpMsg(_item.second)))
+        {
+            return false;
+        }
+
+        if (!writer.writeListEnd())
+        {
+            return false;
+        }
+    }
+
+    if (!writer.writeMapEnd())
+    {
+        return false;
+    }
+    return true;
+}

--- a/src/Contacts/YarpImplementation/src/ContactListYarpMsg.cpp
+++ b/src/Contacts/YarpImplementation/src/ContactListYarpMsg.cpp
@@ -1,0 +1,205 @@
+/**
+ * @file ContactListYarpMsg.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/Contacts/Contact.h>
+#include <BipedalLocomotion/Contacts/ContactList.h>
+#include <BipedalLocomotion/Contacts/ContactListYarpMsg.h>
+#include <BipedalLocomotion/Contacts/PlannedContactYarpMsg.h>
+
+#include <utility>
+
+using namespace BipedalLocomotion::Contacts;
+
+// Constructor with field values
+ContactListYarpMsg::ContactListYarpMsg(const ContactList& contactList)
+    : WirePortable()
+    , ContactList(contactList)
+{
+}
+
+void ContactListYarpMsg::fromContactList(const ContactList& list)
+{
+    ContactList* tmp = static_cast<ContactList*>(this);
+    if ((*tmp) != list)
+    {
+        (*tmp) = list;
+    }
+}
+
+// Read structure on a Wire
+bool ContactListYarpMsg::read(yarp::os::idl::WireReader& reader)
+{
+    bool ok = this->readContactList(reader);
+    ok = ok && this->readDefaultName(reader);
+    ok = ok && this->readDefaultIndex(reader);
+    ok = ok && !reader.isError();
+
+    return ok;
+}
+
+// Read structure on a Connection
+bool ContactListYarpMsg::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader(3))
+    {
+        return false;
+    }
+    return read(reader);
+}
+
+// Write structure on a Wire
+bool ContactListYarpMsg::write(const yarp::os::idl::WireWriter& writer) const
+{
+    bool ok = this->writeContactList(writer);
+    ok = ok && this->writeDefaultName(writer);
+    ok = ok && this->writeDefaultIndex(writer);
+    ok = ok && !writer.isError();
+    return ok;
+}
+
+// Write structure on a Connection
+bool ContactListYarpMsg::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(3))
+    {
+        return false;
+    }
+    return write(writer);
+}
+
+// Convert to a printable string
+std::string ContactListYarpMsg::toString() const
+{
+    yarp::os::Bottle b;
+    if (!yarp::os::Portable::copyPortable(*this, b))
+    {
+        return {};
+    }
+    return b.toString();
+}
+
+// read vectors field
+bool ContactListYarpMsg::readContactList(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore())
+    {
+        reader.fail();
+        return false;
+    }
+
+    size_t _csize;
+    yarp::os::idl::WireState _etype;
+    reader.readListBegin(_etype, _csize);
+
+    // WireReader removes BOTTLE_TAG_LIST from the tag
+    constexpr int expected_tag = ((BOTTLE_TAG_LIST) & (~BOTTLE_TAG_LIST));
+    if constexpr (expected_tag != 0)
+    {
+        if (_csize != 0 && _etype.code != expected_tag)
+        {
+            return false;
+        }
+    }
+
+    BipedalLocomotion::Contacts::PlannedContactYarpMsg tempContact;
+    for (size_t _i = 0; _i < _csize; ++_i)
+    {
+        if (reader.noMore())
+        {
+            reader.fail();
+            return false;
+        }
+
+        if (!reader.readNested(tempContact))
+        {
+            reader.fail();
+            return false;
+        }
+
+        // TODO(Giulio) use MOVE if implemented
+        static_cast<ContactList*>(this)->addContact(tempContact);
+    }
+
+    reader.readListEnd();
+    return true;
+}
+
+// write vectors field
+bool ContactListYarpMsg::writeContactList(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeListBegin(BOTTLE_TAG_LIST, static_cast<const ContactList*>(this)->size()))
+    {
+        return false;
+    }
+
+    for (const auto& _item : *static_cast<const ContactList*>(this))
+    {
+        if (!writer.writeNested(PlannedContactYarpMsg(_item)))
+        {
+            return false;
+        }
+    }
+
+    if (!writer.writeListEnd())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+// read/write name field
+bool ContactListYarpMsg::readDefaultName(yarp::os::idl::WireReader& reader)
+{
+    std::string temp;
+    if (reader.noMore())
+    {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readString(temp))
+    {
+        reader.fail();
+        return false;
+    }
+
+    this->setDefaultName(temp);
+
+    return true;
+}
+
+bool ContactListYarpMsg::writeDefaultName(const yarp::os::idl::WireWriter& writer) const
+{
+    return writer.writeString(this->defaultName());
+}
+
+// read/write name field
+bool ContactListYarpMsg::readDefaultIndex(yarp::os::idl::WireReader& reader)
+{
+    std::int32_t temp;
+    if (reader.noMore())
+    {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readI32(temp))
+    {
+        reader.fail();
+        return false;
+    }
+
+    this->setDefaultIndex(temp);
+
+    return true;
+}
+
+bool ContactListYarpMsg::writeDefaultIndex(const yarp::os::idl::WireWriter& writer) const
+{
+    return writer.writeI32(this->defaultIndex());
+}

--- a/src/Contacts/YarpImplementation/src/PlannedContactYarpMsg.cpp
+++ b/src/Contacts/YarpImplementation/src/PlannedContactYarpMsg.cpp
@@ -1,0 +1,214 @@
+/**
+ * @file PlannedContactYarpMsg.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/Contacts/Contact.h>
+#include <BipedalLocomotion/Contacts/PlannedContactYarpMsg.h>
+
+#include <chrono>
+
+using namespace BipedalLocomotion::Contacts;
+
+PlannedContactYarpMsg::PlannedContactYarpMsg(const PlannedContact& contact)
+    : WirePortable()
+    , PlannedContact(contact)
+{
+}
+
+// Build from an existing planned contact
+void PlannedContactYarpMsg::fromPlannedContact(const PlannedContact& contact)
+{
+    PlannedContact* tmp = static_cast<PlannedContact*>(this);
+    if ((*tmp) != contact)
+    {
+        (*tmp) = contact;
+    }
+}
+
+// Read structure on a Wire
+bool PlannedContactYarpMsg::read(yarp::os::idl::WireReader& reader)
+{
+    bool ok = this->readPose(reader);
+    ok = ok && this->readName(reader);
+    ok = ok && this->readIndex(reader);
+    ok = ok && this->readTime(reader, this->activationTime);
+    ok = ok && this->readTime(reader, this->deactivationTime);
+    ok = ok && !reader.isError();
+    return ok;
+}
+
+bool PlannedContactYarpMsg::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader(5))
+    {
+        return false;
+    }
+    return read(reader);
+}
+
+// Write structure on a Wire
+bool PlannedContactYarpMsg::write(const yarp::os::idl::WireWriter& writer) const
+{
+    bool ok = this->writePose(writer);
+    ok = ok && this->writeName(writer);
+    ok = ok && this->writeIndex(writer);
+    ok = ok && this->writeTime(writer, this->activationTime);
+    ok = ok && this->writeTime(writer, this->deactivationTime);
+    ok = ok && !writer.isError();
+
+    return ok;
+}
+
+// Write structure on a Connection
+bool PlannedContactYarpMsg::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(5))
+    {
+        return false;
+    }
+    return write(writer);
+}
+
+std::string PlannedContactYarpMsg::toString() const
+{
+    yarp::os::Bottle b;
+    if (!yarp::os::Portable::copyPortable(*this, b))
+    {
+        return {};
+    }
+    return b.toString();
+}
+
+bool PlannedContactYarpMsg::readPose(yarp::os::idl::WireReader& reader)
+{
+    // the pose is stored as position plus quaternion
+    constexpr std::size_t poseDim = 7;
+
+    if (reader.noMore())
+    {
+        reader.fail();
+        return false;
+    }
+    size_t _csize;
+    yarp::os::idl::WireState _etype;
+    reader.readListBegin(_etype, _csize);
+    // WireReader removes BOTTLE_TAG_LIST from the tag
+    constexpr int expected_tag = ((BOTTLE_TAG_FLOAT64) & (~BOTTLE_TAG_LIST));
+    if constexpr (expected_tag != 0)
+    {
+        if (_csize != 0 && _etype.code != expected_tag)
+        {
+            return false;
+        }
+    }
+
+    // the pose is stored as position plus quaternion
+    if (_csize != poseDim)
+    {
+        return false;
+    }
+
+    if (_csize != 0
+        && !reader.readBlock(reinterpret_cast<char*>(this->pose.coeffs().data()),
+                             poseDim * sizeof(double)))
+    {
+        return false;
+    }
+    reader.readListEnd();
+    return true;
+}
+
+// write pose field
+bool PlannedContactYarpMsg::writePose(const yarp::os::idl::WireWriter& writer) const
+{
+    constexpr std::size_t poseDim = 7;
+
+    if (!writer.writeListBegin(BOTTLE_TAG_FLOAT64, poseDim))
+    {
+        return false;
+    }
+    if (!writer.writeBlock(reinterpret_cast<const char*>(this->pose.coeffs().data()),
+                           poseDim * sizeof(double)))
+    {
+        return false;
+    }
+
+    if (!writer.writeListEnd())
+    {
+        return false;
+    }
+    return true;
+}
+
+bool PlannedContactYarpMsg::readName(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore())
+    {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readString(this->name))
+    {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool PlannedContactYarpMsg::writeName(const yarp::os::idl::WireWriter& writer) const
+{
+    return writer.writeString(this->name);
+}
+
+// read index field
+bool PlannedContactYarpMsg::readIndex(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore())
+    {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readI32(this->index))
+    {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool PlannedContactYarpMsg::writeIndex(const yarp::os::idl::WireWriter& writer) const
+{
+    return writer.writeI32(this->index);
+}
+
+bool PlannedContactYarpMsg::readTime(yarp::os::idl::WireReader& reader,
+                                     std::chrono::nanoseconds& time)
+{
+    std::int64_t temp;
+
+    if (reader.noMore())
+    {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readI64(temp))
+    {
+        reader.fail();
+        return false;
+    }
+
+    time = std::chrono::nanoseconds(temp);
+
+    return true;
+}
+
+bool PlannedContactYarpMsg::writeTime(const yarp::os::idl::WireWriter& writer,
+                                      const std::chrono::nanoseconds& time) const
+{
+    return writer.writeI64(time.count());
+}

--- a/src/Contacts/include/BipedalLocomotion/Contacts/Contact.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/Contact.h
@@ -83,11 +83,17 @@ struct PlannedContact : ContactBase
 
     /**
      * @brief The equality operator.
-     *
      * @param other The other object used for the comparison.
      * @return True if the contacts are the same, false otherwise.
      */
-    bool operator==(const PlannedContact& other) const;
+    [[nodiscard]] bool operator==(const PlannedContact& other) const;
+
+    /**
+     * @brief The inequality operator.
+     * @param other The other object used for the comparison.
+     * @return True if the contacts are different, false otherwise.
+     */
+    [[nodiscard]] bool operator!=(const PlannedContact& other) const;
 
     /**
      * @brief Check if the contact is active at a give time instant

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactList.h
@@ -235,6 +235,20 @@ public:
      * @brief Remove only the last contact.
      */
     void removeLastContact();
+
+    /**
+     * @brief The equality operator.
+     * @param other The other object used for the comparison.
+     * @return True if the contact lists are the same, false otherwise.
+     */
+    [[nodiscard]] bool operator==(const ContactList& other) const;
+
+    /**
+     * @brief The inequality operator.
+     * @param other The other object used for the comparison.
+     * @return True if the contact lists are different, false otherwise.
+     */
+    [[nodiscard]] bool operator!=(const ContactList& other) const;
 };
 
 /**

--- a/src/Contacts/src/Contact.cpp
+++ b/src/Contacts/src/Contact.cpp
@@ -13,14 +13,18 @@ using namespace BipedalLocomotion::Contacts;
 
 bool PlannedContact::operator==(const PlannedContact& other) const
 {
-    bool eq = true;
-    eq = eq && this->activationTime == other.activationTime;
+    bool eq = this->activationTime == other.activationTime;
     eq = eq && this->name == other.name;
     eq = eq && this->type == other.type;
     eq = eq && this->pose.coeffs() == other.pose.coeffs();
     eq = eq && this->activationTime == other.activationTime;
     eq = eq && this->deactivationTime == other.deactivationTime;
     return eq;
+}
+
+bool PlannedContact::operator!=(const PlannedContact& other) const
+{
+    return !this->operator==(other);
 }
 
 bool PlannedContact::isContactActive(const std::chrono::nanoseconds& t) const

--- a/src/Contacts/src/ContactList.cpp
+++ b/src/Contacts/src/ContactList.cpp
@@ -259,3 +259,18 @@ void ContactList::removeLastContact()
 {
     erase(lastContact());
 }
+
+bool ContactList::operator==(const ContactList& other) const
+{
+    bool same = other.size() == this->size();
+    same = same && other.m_defaultName == this->m_defaultName;
+    same = same && other.m_defaultContactType == this->m_defaultContactType;
+    same = same && other.m_defaultIndex == this->m_defaultIndex;
+    same = same && other.m_contacts == this->m_contacts;
+    return same;
+}
+
+bool ContactList::operator!=(const ContactList& other) const
+{
+    return !this->operator==(other);
+}

--- a/src/Contacts/tests/YarpImplementation/CMakeLists.txt
+++ b/src/Contacts/tests/YarpImplementation/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (C) 2023 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license.
+
+
+if(FRAMEWORK_COMPILE_YarpImplementation)
+
+  add_bipedal_test(
+    NAME ContactsYarpMsg
+    SOURCES ContactsYarpMsgTest.cpp
+    LINKS BipedalLocomotion::ContactsYarpImplementation YARP::YARP_init)
+
+endif()

--- a/src/Contacts/tests/YarpImplementation/ContactsYarpMsgTest.cpp
+++ b/src/Contacts/tests/YarpImplementation/ContactsYarpMsgTest.cpp
@@ -1,0 +1,201 @@
+/**
+ * @file ContactsYarpMsgTest.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <algorithm>
+#include <memory>
+
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Thread.h>
+
+#include <manif/SE3.h>
+
+#include <catch2/catch.hpp>
+
+#include <BipedalLocomotion/Contacts/ContactListMapYarpMsg.h>
+#include <BipedalLocomotion/Contacts/ContactListYarpMsg.h>
+#include <BipedalLocomotion/Contacts/PlannedContactYarpMsg.h>
+
+using namespace BipedalLocomotion::Contacts;
+
+template <typename Msg> class Sender : public yarp::os::Thread
+{
+public:
+    Sender(std::shared_ptr<yarp::os::BufferedPort<Msg>> p, const typename Msg::MsgType& msg)
+    {
+        this->portOut = p;
+        this->msg = msg;
+    }
+
+    bool threadInit() override
+    {
+        this->success = false;
+        return true;
+    }
+
+    void run() override
+    {
+        int times = 10;
+
+        while (times--)
+        {
+            Msg& temp = portOut->prepare();
+            temp = this->msg;
+            this->portOut->write();
+        }
+
+        this->success = true;
+    }
+
+    std::shared_ptr<yarp::os::BufferedPort<Msg>> portOut;
+    bool success;
+    typename Msg::MsgType msg;
+};
+
+template <typename Msg> class Receiver : public yarp::os::Thread
+{
+public:
+    Receiver(std::shared_ptr<yarp::os::BufferedPort<Msg>> p,
+             const typename Msg::MsgType& expectedMsg)
+    {
+        this->portIn = p;
+        this->expectedMsg = expectedMsg;
+    }
+
+    bool threadInit() override
+    {
+        this->success = false;
+        return true;
+    }
+
+    void run() override
+    {
+        int times = 10;
+        Msg* temp = this->portIn->read(true);
+        if (temp != nullptr)
+        {
+            this->success = (*temp == this->expectedMsg);
+        }
+    }
+
+    std::shared_ptr<yarp::os::BufferedPort<Msg>> portIn;
+    bool success;
+    typename Msg::MsgType expectedMsg;
+};
+
+template <typename Msg> void test(const typename Msg::MsgType& msg)
+{
+    auto portIn = std::make_shared<yarp::os::BufferedPort<Msg>>();
+    auto portOut = std::make_shared<yarp::os::BufferedPort<Msg>>();
+
+    auto receiverThread = Receiver(portIn, msg);
+    auto senderThread = Sender(portOut, msg);
+
+    REQUIRE(portOut->open("/blf/test/contact:o"));
+    REQUIRE(portIn->open("/blf/test/contact:i"));
+
+    yarp::os::Network::connect("/blf/test/contact:o", "/blf/test/contact:i");
+
+    receiverThread.start();
+    senderThread.start();
+
+    receiverThread.stop();
+    senderThread.stop();
+
+    portOut->close();
+    portIn->close();
+
+    REQUIRE(senderThread.success); // Send test
+    REQUIRE(receiverThread.success); // Receive test
+}
+
+TEST_CASE("Planned Contact")
+{
+    using namespace std::chrono_literals;
+
+    yarp::os::NetworkBase::setLocalMode(true);
+    yarp::os::Network yarp;
+
+    PlannedContact p1;
+    p1.activationTime = 100ms;
+    p1.deactivationTime = 500ms;
+    p1.pose = manif::SE3d::Random();
+
+    test<PlannedContactYarpMsg>(p1);
+
+    yarp::os::NetworkBase::setLocalMode(false);
+}
+
+TEST_CASE("Contact list")
+{
+    using namespace std::chrono_literals;
+
+    yarp::os::NetworkBase::setLocalMode(true);
+    yarp::os::Network yarp;
+
+    ContactList list;
+    PlannedContact p1, p2;
+    p1.activationTime = 100ms;
+    p1.deactivationTime = 500ms;
+    p1.pose = manif::SE3d::Random();
+
+    p2.activationTime = 1s;
+    p2.deactivationTime = 1s + 500ms;
+    p2.pose = manif::SE3d::Random();
+
+    REQUIRE(list.addContact(p2));
+    REQUIRE(list.addContact(p1));
+
+    test<ContactListYarpMsg>(list);
+
+    yarp::os::NetworkBase::setLocalMode(false);
+}
+
+TEST_CASE("ContactList")
+{
+    using namespace std::chrono_literals;
+
+    yarp::os::NetworkBase::setLocalMode(true);
+    yarp::os::Network yarp;
+
+    ContactList list;
+    PlannedContact p1, p2;
+    p1.activationTime = 100ms;
+    p1.deactivationTime = 500ms;
+    p1.pose = manif::SE3d::Random();
+
+    p2.activationTime = 1s;
+    p2.deactivationTime = 1s + 500ms;
+    p2.pose = manif::SE3d::Random();
+
+    REQUIRE(list.addContact(p2));
+    REQUIRE(list.addContact(p1));
+
+    test<ContactListYarpMsg>(list);
+
+    yarp::os::NetworkBase::setLocalMode(false);
+}
+
+TEST_CASE("ContactListMap")
+{
+    using namespace std::chrono_literals;
+
+    yarp::os::NetworkBase::setLocalMode(true);
+    yarp::os::Network yarp;
+
+    ContactListMap contactListMap;
+    contactListMap["left"].setDefaultName("left_foot");
+    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Random(), 0s, 1s));
+    REQUIRE(contactListMap["left"].addContact(manif::SE3d::Random(), 2s, 5s));
+
+    contactListMap["right"].setDefaultName("right_foot");
+    REQUIRE(contactListMap["right"].addContact(manif::SE3d::Random(), 0s, 3s));
+
+    test<ContactListMapYarpMsg>(contactListMap);
+
+    yarp::os::NetworkBase::setLocalMode(false);
+}


### PR DESCRIPTION
Thanks to this PR it will be possible to send `PlannedContact`, `ContactList`, and `ContactListMap` via `yarp::port`. To enable this feature I implemented the associated msgs that inherit from the classes implemented in `Contacts` component. 

Differently from the usual [thrift IDL approach](https://yarp.it/latest/thrift_tutorial_simple.html)  I had to write a bunch of C++ code that allowed me to serialize custom objects such as that `manif` container. For instance the following code can be used to send a `PlannedContact`
```cpp
using namespace BipedalLocomotion::Contacts;
using namespace std::chrono_literals;

yarp::os::BufferedPort<PlannedContactYarpMsg> port;
port.open("/blf/test/contact:o");

PlannedContact p;
p.activationTime = 100ms;
p.deactivationTime = 500ms;
p.pose = manif::SE3d::Random();
auto& msg = port.prepare();
msg = p;
port.write();
```

Moreover, I also implemented the Python bindings that can be used by @paolo-viceconte
```python
import bipedal_locomotion_framework as blf
from datetime import timedelta
import manifpy as manif

p = blf.contacts.PlannedContact()
p.activation_time = timedelta(milliseconds=100)
p.deactivation_time = timedelta(milliseconds=100)
p.pose = manif.SE3.Random()

port = blf.contacts.BufferedPlannedContact()
msg = port.prepare()
msg.from_planned_contact(p)
port.write()
```
⚠️ Similarly to https://github.com/ami-iit/bipedal-locomotion-framework/pull/511 It is not possible to modify directly the content of `msg`(i.e., `msg.activation_time`). This is due to a well-known limitation in pybind11 https://github.com/pybind/pybind11/issues/175. A possible solution is to make opaque the std container has explained [here](https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html?highlight=opaque#making-opaque-types). However there seems that this choice will affect all the similar containers in the module and I would like to avoid this.
