### PR TITLE
Add the possibility to set vectorial gains in CoM IK and TSID tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project are documented in this file.
 - Update the code to be compatible with LieGroupControllers v0.2.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/653)
 - Allow use of vectors for task gains (https://github.com/ami-iit/bipedal-locomotion-framework/pull/654)
 - `Catch2` is now downloaded with `FetchContent` if `BUILD_TESTING` is set to `ON` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/655)
+- Add the possibility to set vectorial gains in CoM IK and TSID tasks (https://github.com/ami-iit/bipedal-locomotion-framework/pull/656)
 
 ### Fixed
 - Return an error if an invalid `KinDynComputations` object is passed to `QPInverseKinematics::build()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/622)

--- a/src/IK/include/BipedalLocomotion/IK/CoMTask.h
+++ b/src/IK/include/BipedalLocomotion/IK/CoMTask.h
@@ -74,11 +74,11 @@ public:
      * Initialize the task.
      * @param paramHandler pointer to the parameters handler.
      * @note the following parameters are required by the class
-     * |           Parameter Name           |   Type   |                                       Description                                      | Mandatory |
-     * |:----------------------------------:|:--------:|:--------------------------------------------------------------------------------------:|:---------:|
-     * |   `robot_velocity_variable_name`   | `string` |   Name of the variable contained in `VariablesHandler` describing the robot velocity   |    Yes    |
-     * |             `kp_linear`            | `double` |                             Gain of the position controller                            |    Yes    |
-     * |               `mask`               | `vector<bool>` |  Mask representing the DoFs controlled. E.g. [1,0,1] will enable the control on the x and z coordinates only. (Default value, [1,1,1])   |    No    |
+     * |           Parameter Name           |              Type            |                                                        Description                                                                       | Mandatory |
+     * |:----------------------------------:|:----------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------:|:---------:|
+     * |   `robot_velocity_variable_name`   |            `string`          |                            Name of the variable contained in `VariablesHandler` describing the robot velocity                            |    Yes    |
+     * |             `kp_linear`            | `double` or `vector<double>` |                                               Gain of the position controller                                                            |    Yes    |
+     * |               `mask`               |         `vector<bool>`       |  Mask representing the DoFs controlled. E.g. [1,0,1] will enable the control on the x and z coordinates only. (Default value, [1,1,1])   |    No     |
      * @return True in case of success, false otherwise.
      * Where the generalized robot velocity is a vector containing the base spatial-velocity
      * (expressed in mixed representation) and the joint velocities.

--- a/src/IK/src/CoMTask.cpp
+++ b/src/IK/src/CoMTask.cpp
@@ -114,14 +114,21 @@ bool CoMTask::initialize(std::weak_ptr<const ParametersHandler::IParametersHandl
     }
 
     // set the gains for the controllers
-    double kpLinear;
-    if (!ptr->getParameter("kp_linear", kpLinear))
+    double kpLinearScalar;
+    Eigen::Vector3d kpLinearVector;
+    if (ptr->getParameter("kp_linear", kpLinearScalar))
     {
-        log()->error("{} [{}] to get the proportional linear gain.", errorPrefix, m_description);
+        m_R3Controller.setGains(kpLinearScalar);
+    } else if (ptr->getParameter("kp_linear", kpLinearVector))
+    {
+        m_R3Controller.setGains(kpLinearVector);
+    } else
+    {
+        log()->error("{} [{}] Unable to get the proportional linear gain.",
+                     errorPrefix,
+                     m_description);
         return false;
     }
-
-    m_R3Controller.setGains(kpLinear);
 
     std::vector<bool> mask;
     if (!ptr->getParameter("mask", mask) || (mask.size() != m_linearVelocitySize))

--- a/src/TSID/include/BipedalLocomotion/TSID/CoMTask.h
+++ b/src/TSID/include/BipedalLocomotion/TSID/CoMTask.h
@@ -63,11 +63,11 @@ public:
      * Initialize the task.
      * @param paramHandler pointer to the parameters handler.
      * @note the following parameters are required by the class
-     * |           Parameter Name           |   Type   |                                       Description                                      | Mandatory |
-     * |:----------------------------------:|:--------:|:--------------------------------------------------------------------------------------:|:---------:|
-     * | `robot_acceleration_variable_name` | `string` | Name of the variable contained in `VariablesHandler` describing the robot acceleration |    Yes    |
-     * |             `kp_linear`            | `double` |                             Gain of the position controller                            |    Yes    |
-     * |             `kd_linear`            | `double` |                         Gain of the linear velocity controller                         |    Yes    |
+     * |           Parameter Name           |               Type           |                                       Description                                      | Mandatory |
+     * |:----------------------------------:|:----------------------------:|:--------------------------------------------------------------------------------------:|:---------:|
+     * | `robot_acceleration_variable_name` |            `string`          | Name of the variable contained in `VariablesHandler` describing the robot acceleration |    Yes    |
+     * |             `kp_linear`            | `double` or `vector<double>` |                             Gain of the position controller                            |    Yes    |
+     * |             `kd_linear`            | `double` or `vector<double>` |                         Gain of the linear velocity controller                         |    Yes    |
      * @return True in case of success, false otherwise.
      * Where the generalized robot velocity is a vector containing the base spatial-velocity
      * (expressed in mixed representation) and the joint velocities.

--- a/src/TSID/src/CoMTask.cpp
+++ b/src/TSID/src/CoMTask.cpp
@@ -105,17 +105,27 @@ bool CoMTask::initialize(std::weak_ptr<const ParametersHandler::IParametersHandl
         return false;
     }
 
-    double kpLinear, kdLinear;
-    if (!ptr->getParameter("kp_linear", kpLinear) || !ptr->getParameter("kd_linear", kdLinear))
+    double scalarBuffer;
+    Eigen::Vector3d kpLinear, kdLinear;
+    if (ptr->getParameter("kp_linear", scalarBuffer))
     {
-        log()->error("{} [{}] Unable to get the proportional and derivative linear gain.",
-                     errorPrefix,
-                     m_description);
+        kpLinear.setConstant(scalarBuffer);
+    } else if (!ptr->getParameter("kp_linear", kpLinear))
+    {
+        log()->error("{}, [{}] Unable to get the proportional gain.", errorPrefix, m_description);
         return false;
     }
 
-    m_R3Controller.setGains(kpLinear, kdLinear);
+    if (ptr->getParameter("kd_linear", scalarBuffer))
+    {
+        kdLinear.setConstant(scalarBuffer);
+    } else if (!ptr->getParameter("kd_linear", kdLinear))
+    {
+        log()->error("{}, [{}] Unable to get the derivative gain.", errorPrefix, m_description);
+        return false;
+    }
 
+    m_R3Controller.setGains(std::move(kpLinear), std::move(kdLinear));
     m_isInitialized = true;
 
     return true;


### PR DESCRIPTION
With this PR it will be possible to set vectorial gains in TSID and IK CoM Tasks.


After merging this PR, I will release a new version of the code so we can safely merge https://github.com/robotology/robotology-superbuild/pull/1384

---

@CarlottaSartore 