### PR TITLE
Implement robot dynamics estimator - PR2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 - Implement a class to perform inference with the [MANN network](https://github.com/ami-iit/mann-pytorch) (https://github.com/ami-iit/bipedal-locomotion-framework/pull/652)
 - Add some useful methods to the `SubModel` and `SubModelKinDynWrapper` classes (https://github.com/ami-iit/bipedal-locomotion-framework/pull/661)
+- Implement `Dynamics`, `ZeroVelocityDynamics`, and `JointVelocityStateDynamics` classes in `RobotDynamicsEstimator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/662)
 
 ### Changed
 
@@ -41,6 +42,7 @@ All notable changes to this project are documented in this file.
 - `Catch2` is now downloaded with `FetchContent` if `BUILD_TESTING` is set to `ON` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/655)
 - The tests now uses`Catch2 v3` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/655)
 - Add the possibility to set vectorial gains in CoM IK and TSID tasks (https://github.com/ami-iit/bipedal-locomotion-framework/pull/656)
+- Add some useful methods to the `SubModel` and `SubModelKinDynWrapper` classes (https://github.com/ami-iit/bipedal-locomotion-framework/pull/661)
 
 ### Fixed
 - Return an error if an invalid `KinDynComputations` object is passed to `QPInverseKinematics::build()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/622)

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -27,19 +27,13 @@ if(FRAMEWORK_COMPILE_RobotDynamicsEstimator)
   set(H_PREFIX include/BipedalLocomotion/RobotDynamicsEstimator)
   add_bipedal_locomotion_library(
     NAME                    RobotDynamicsEstimator
-    SOURCES                 src/SubModel.cpp
-                            src/SubModelKinDynWrapper.cpp
+    SOURCES                 src/SubModel.cpp src/SubModelKinDynWrapper.cpp src/Dynamics.cpp src/ZeroVelocityStateDynamics.cpp src/JointVelocityStateDynamics.cpp
+                            src/ConstantMeasurementModel.cpp
     SUBDIRECTORIES          tests/RobotDynamicsEstimator
-    PUBLIC_HEADERS          ${H_PREFIX}/SubModel.h
-                            ${H_PREFIX}/SubModelKinDynWrapper.h
-    PUBLIC_LINK_LIBRARIES   BipedalLocomotion::ParametersHandler
-                            BipedalLocomotion::TextLogging
-                            BipedalLocomotion::ManifConversions
-                            iDynTree::idyntree-high-level
-                            iDynTree::idyntree-core
-                            iDynTree::idyntree-model
-                            iDynTree::idyntree-modelio
-                            Eigen3::Eigen
-                            MANIF::manif
+    PUBLIC_HEADERS          ${H_PREFIX}/SubModel.h ${H_PREFIX}/SubModelKinDynWrapper.h ${H_PREFIX}/Dynamics.h ${H_PREFIX}/ZeroVelocityStateDynamics.h
+                            ${H_PREFIX}/JointVelocityStateDynamics.h ${H_PREFIX}/ConstantMeasurementModel.h
+    PUBLIC_LINK_LIBRARIES   BipedalLocomotion::ParametersHandler MANIF::manif BipedalLocomotion::System BipedalLocomotion::Math iDynTree::idyntree-high-level
+                                iDynTree::idyntree-core iDynTree::idyntree-model iDynTree::idyntree-modelio Eigen3::Eigen
+    PRIVATE_LINK_LIBRARIES  BipedalLocomotion::TextLogging BipedalLocomotion::ManifConversions
 )
 endif()

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/ConstantMeasurementModel.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/ConstantMeasurementModel.h
@@ -1,0 +1,107 @@
+/**
+ * @file ConstantMeasurementModel.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_CONSTANT_MEASUREMENT_MODEL_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_CONSTANT_MEASUREMENT_MODEL_H
+
+#include <memory>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The ConstantMeasurementModel class is a concrete implementation of the Dynamics.
+ * Please use this element if you do not know the specific dynamics of a state variable.
+ * The ConstantMeasurementModel represents the following equation in the continuous time:
+ * \f[
+ * \dot{x} = 0
+ * \f]
+ * In the discrete time the following dynamics assigns the current state to the next state:
+ * \f[
+ * x_{k+1} = x_{k}
+ * \f]
+ */
+class ConstantMeasurementModel : public Dynamics
+{
+    Eigen::VectorXd m_currentState; /**< Current state. */
+    bool m_useBias{false}; /**< If true the dynamics depends on a bias additively. */
+    Eigen::VectorXd m_bias; /**< The bias is initialized and used only if m_useBias is true. False if not specified. */
+    std::string m_biasVariableName; /**< Name of the variable containing the bias in the variable handler. */
+    std::string m_name; /**< Name of dynamics. */
+    std::vector<std::string> m_elements = {}; /**< Elements composing the variable vector. */
+    System::VariablesHandler m_stateVariableHandler; /**< Variable handler describing the variables and the sizes in the ukf state vector. */
+
+    /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    bool checkStateVariableHandler() override;
+
+public:
+    /**
+     * Initialize the state dynamics.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               | `string` |   Name of the state contained in the `VariablesHandler` describing the state associated to this dynamics|    Yes    |
+     * |            `covariance`            | `vector` |                                Process covariances                                                      |    Yes    |
+     * |           `dynamic_model`          | `string` |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
+     * |             `elements`             | `vector` |  Vector of strings describing the list of sub variables composing the state associated to this dynamics.|    No     |
+     * |             `use_bias`             |`boolean` |     Boolean saying if the dynamics depends on a bias. False if not specified.                           |    No     |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param stateVariableHandler object describing the variables in the state vector.
+     * @note You should call this method after you add ALL the state dynamics to the state variable handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& stateVariableHandler) override;
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param subModelList list of SubModel objects
+     * @param kinDynWrapperList list of pointers to SubModelKinDynWrapper objects.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+     * Update the content of the element.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics of the state/measurement variable associated to ths object.
+     * @param ukfState reference to the ukf state.
+     */
+     void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+     /**
+      * Set a `UKFInput` object.
+      * @param ukfInput reference to the UKFInput struct.
+      */
+      void setInput(const UKFInput & ukfInput) override;
+
+}; // class ConstantMeasurementModel
+
+BLF_REGISTER_UKF_DYNAMICS(ConstantMeasurementModel, ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_CONSTANT_MEASUREMENT_MODEL_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h
@@ -1,0 +1,205 @@
+/**
+ * @file Dynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_DYNAMICS_H
+
+#include <memory>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/System/Factory.h>
+#include <BipedalLocomotion/System/Advanceable.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+
+/**
+ * BLF_REGISTER_UKF_DYNAMICS is a macro that can be used to register a Dynamics. The key of
+ * the dynamics will be the stringified version of the Dynamics C++ Type
+ * @param _model the model of the dynamics
+ * @param _baseModel the base model from which the _model inherits.
+ */
+#define BLF_REGISTER_UKF_DYNAMICS(_model, _baseModel)               \
+    static std::shared_ptr<_baseModel> _model##FactoryBuilder() \
+{                                                               \
+    return std::make_shared<_model>();                          \
+    };                                                          \
+    static std::string _model##BuilderAutoRegHook               \
+    = ::BipedalLocomotion::Estimators::                         \
+    RobotDynamicsEstimator::DynamicsFactory::registerBuilder    \
+    (#_model, _model##FactoryBuilder);
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * @brief The UKFInput struct represents the input of the ukf needed to update the dynamics.
+ */
+struct UKFInput
+{
+    Eigen::VectorXd robotJointPositions; /**< Vector of joint positions. */
+    Eigen::VectorXd robotJointAccelerations; /**< Vector of joint accelerations. */
+    manif::SE3d robotBasePose; /**< Robot base position and orientation. */
+    manif::SE3d::Tangent robotBaseVelocity; /**< Robot base velocity. */
+    manif::SE3d::Tangent robotBaseAcceleration; /**< Robot base acceleration. */
+};
+
+/**
+ * UkfInputProvider describes the provider for the inputs of the ukf
+ */
+class UkfInputProvider : public System::Advanceable<UKFInput, UKFInput>
+{
+private:
+    UKFInput m_ukfInput;
+
+public:
+    /**
+     * Get the input
+     * @return A struct containing the inputs for the ukf
+     */
+    const UKFInput& getOutput() const override;
+
+    /**
+     * Set the state which represents the state of the provider.
+     * @param input is a struct containing the input of the ukf.
+     */
+    bool setInput(const UKFInput& input) override;
+
+    /**
+     * @brief Advance the internal state. This may change the value retrievable from getOutput().
+     * @return True if the advance is successfull.
+     */
+    bool advance() override;
+
+    /**
+     * @brief Determines the validity of the object retrieved with getOutput()
+     * @return True if the object is valid, false otherwise.
+     */
+    bool isOutputValid() const override;
+
+}; // class UkfProcessInputProvider
+
+/**
+ * The class Dynamics represents a base class describing a generic model composing the ukf process
+ * model or the ukf measurement model. The Dynamics object is created from a parameter handler which
+ * specifies the name of the variable described by the dynamics object, the covariances associated to the variable,
+ * the initial covariance, the Dynamics model which specifies which implementation of this class will be used.
+ * The model of the Dynamics object depends on the current state and an input object which need to be set
+ * before calling the update method.
+ */
+class Dynamics
+{
+protected:
+    int m_size; /**< Size of the variable associate to the Dynamics object. */
+    Eigen::VectorXd m_updatedVariable; /**< Updated variable computed using the dynamic model. */
+    std::string m_description{"Generic Dynamics Element"}; /**< String describing the type of the dynamics */
+    Eigen::VectorXd m_covariances; /**< Vector of covariances. */
+    bool m_isInitialized{false}; /**< True if the dynamics has been initialized. */
+    Eigen::VectorXd m_initialCovariances; /**< Vector of initial covariances. */
+
+    /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    virtual bool checkStateVariableHandler();
+
+public:
+    /**
+     * Initialize the task.
+     * @param paramHandler pointer to the parameters handler.
+     * @return True in case of success, false otherwise.
+     */
+    virtual bool
+    initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler);
+
+    /**
+     * Finalize the Dynamics.
+     * @param handler object describing the variables in the vector for which all the dynamics are defined.
+     * @note You should call this method after you add ALL the dynamics to the variable handler.
+     * @return true in case of success, false otherwise.
+     */
+    virtual bool finalize(const System::VariablesHandler& handler);
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param subModelList list of SubModel objects
+     * @param kinDynWrapperList list of pointers to SubModelKinDynWrapper objects.
+     * @return True in case of success, false otherwise.
+     */
+    virtual bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList);
+
+    /**
+     * Update the dynamics of the variable.
+     * @return True in case of success, false otherwise.
+     */
+    virtual bool update();
+
+    /**
+     * Get the next value m_updatedVariable.
+     * @return a const reference to the next variable value.
+     */
+    Eigen::Ref<const Eigen::VectorXd> getUpdatedVariable() const;
+
+    /**
+     * Get the size of the state.
+     * @return the size of the state.
+     */
+    int size() const;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics.
+     * @param ukfState reference to the ukf state.
+     */
+    virtual void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) = 0;
+
+    /**
+     * Set a `UKFInput` object.
+     * @param ukfInput reference to the UKFInput struct.
+     */
+    virtual void setInput(const UKFInput & ukfInput) = 0;
+
+    /**
+     * @brief getCovariance access the covariance `Eigen::VectorXd` associated to the variables described by this dynamics.
+     * @return the vector of covariances.
+     */
+    Eigen::Ref<const Eigen::VectorXd> getCovariance();
+
+    /**
+     * @brief getInitialStateCovariance access the covariance `Eigen::VectorXd` associated to the initial state.
+     * @return the vector of covariances.
+     */
+    Eigen::Ref<const Eigen::VectorXd> getInitialStateCovariance();
+
+    /**
+     * Destructor.
+     */
+    virtual ~Dynamics() = default;
+};
+
+/**
+ * DynamicsFactory implements the factory design patter for constructing a Dynamics given
+ * its model.
+ */
+class DynamicsFactory : public System::Factory<Dynamics>
+{
+
+public:
+    virtual ~DynamicsFactory() = default;
+};
+
+} // RobotDynamicsEstimator
+} // Estimators
+} // BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_DYNAMICS_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/JointVelocityStateDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/JointVelocityStateDynamics.h
@@ -1,0 +1,124 @@
+/**
+ * @file JointVelocityStateDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_JOINT_VELOCITY_STATE_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_JOINT_VELOCITY_STATE_DYNAMICS_H
+
+#include <memory>
+#include <map>
+#include <chrono>
+
+#include <BipedalLocomotion/Math/Wrench.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The JointVelocityDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element if you want to use the robot dynamic model to update the joint dynamics.
+ * The JointVelocityDynamics represents the following equation in the continuous time:
+ * \f[
+ * \ddot{s} = H^{-1} [\tau_{m} - \tau_{F} + (\sum J^T_{FT} f_{FT}) +
+ * + (\sum J^T_{ext} f_{ext})   - F^T {}^B \dot v  - h ]
+ * \f]
+ * where \ddot{s} is given as an input to this class.
+ * The discretized model becomes:
+ * \f[
+ * \dot{s}_{k+1} = \dot{s}_{k} + \Delta T \ddot{s}_{k}
+ * \f]
+ */
+class JointVelocityStateDynamics : public Dynamics
+{
+    std::chrono::nanoseconds m_dT{std::chrono::nanoseconds::zero()}; /**< Sampling time. */
+    Eigen::VectorXd m_jointVelocityFullModel; /**< Joint velocities of full-model. */
+    UKFInput m_ukfInput; /**< Input of the UKF used to update the dynamics. */
+    std::string m_name; /**< Name of dynamics. */
+    std::vector<std::string> m_elements = {}; /**< Elements composing the variable vector. */
+    System::VariablesHandler m_stateVariableHandler; /**< Variable handler describing the variables and the sizes in the ukf state vector. */
+
+public:
+    /*
+     * Constructor
+     */
+    JointVelocityStateDynamics();
+
+    /*
+     * Destructor
+     */
+    virtual ~JointVelocityStateDynamics();
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param subModelList list of SubModel objects
+     * @param kinDynWrapperList list of pointers to SubModelKinDynWrapper objects.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+     * Initialize the state dynamics.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |         Type          |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:---------------------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               |       `string`        |   Name of the state contained in the `VariablesHandler` describing the state associated to this dynamics|    Yes    |
+     * |            `covariance`            |       `vector`        |                                Process covariances                                                      |    Yes    |
+     * |         `initial_covariance`       |       `vector`        |                             Initial state covariances                                                   |    Yes    |
+     * |           `dynamic_model`          |       `string`        |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
+     * |             `elements`             |       `vector`        |  Vector of strings describing the list of sub variables composing the state associated to this dynamics.|    No     |
+     * |                `dT`                | `chrono::nanoseconds` |                                Sampling time.                                                           |    Yes    |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param stateVariableHandler object describing the variables in the state vector.
+     * @note You should call this method after you add ALL the state dynamics to the state variable handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& stateVariableHandler) override;
+
+    /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    bool checkStateVariableHandler() override;
+
+    /**
+     * Update the state.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics of the state variable associated to ths object.
+     * @param ukfState reference to the ukf state.
+     */
+     void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+     /**
+      * Set a `UKFInput` object.
+      * @param ukfInput reference to the UKFInput struct.
+      */
+      void setInput(const UKFInput & ukfInput) override;
+};
+
+BLF_REGISTER_UKF_DYNAMICS(JointVelocityStateDynamics, ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_JOINT_VELOCITY_STATE_DYNAMICS_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h
@@ -48,7 +48,6 @@ enum class UpdateMode {
  * SubModelKinDynWrapper is a concrete class and implements a wrapper of the KinDynComputation class
  * from iDynTree. The class is used to take updated the sub-model kinematics and dynamics
  */
-
 class SubModelKinDynWrapper
 {
     SubModel m_subModel; /**< SubModel struct containing all the information about the sub-model */

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityStateDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityStateDynamics.h
@@ -1,0 +1,104 @@
+/**
+ * @file ZeroVelocityStateDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_ZERO_VELOCITY_STATE_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_ZERO_VELOCITY_STATE_DYNAMICS_H
+
+#include <memory>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The ZeroVelocityStateDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element if you do not know the specific dynamics of a state variable.
+ * The ZeroVelocityStateDynamics represents the following equation in the continuous time:
+ * \f[
+ * \dot{x} = 0
+ * \f]
+ * In the discrete time the following dynamics assigns the current state to the next state:
+ * \f[
+ * x_{k+1} = x_{k}
+ * \f]
+ */
+class ZeroVelocityStateDynamics : public Dynamics
+{
+    Eigen::VectorXd m_currentState; /**< Current state. */
+    std::string m_name; /**< Name of dynamics. */
+    std::vector<std::string> m_elements = {}; /**< Elements composing the variable vector. */
+    System::VariablesHandler m_stateVariableHandler; /**< Variable handler describing the variables and the sizes in the ukf state vector. */
+
+    /**
+      * Controls whether the variable handler contains the variables on which the dynamics depend.
+      * @return True in case all the dependencies are contained in the variable handler, false otherwise.
+      */
+    bool checkStateVariableHandler() override;
+
+public:
+    /**
+     * Initialize the state dynamics.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               | `string` |   Name of the state contained in the `VariablesHandler` describing the state associated to this dynamics|    Yes    |
+     * |            `covariance`            | `vector` |                                Process covariances                                                      |    Yes    |
+     * |         `initial_covariance`       | `vector` |                             Initial state covariances                                                   |    Yes    |
+     * |           `dynamic_model`          | `string` |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
+     * |             `elements`             | `vector` |  Vector of strings describing the list of sub variables composing the state associated to this dynamics.|    No     |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param stateVariableHandler object describing the variables in the state vector.
+     * @note You should call this method after you add ALL the state dynamics to the state variable handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& stateVariableHandler) override;
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param subModelList list of SubModel objects
+     * @param kinDynWrapperList list of pointers to SubModelKinDynWrapper objects.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSubModels(const std::vector<SubModel>& subModelList, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+     * Update the content of the element.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics of the state/measurement variable associated to ths object.
+     * @param ukfState reference to the ukf state.
+     */
+     void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+     /**
+      * Set a `UKFInput` object.
+      * @param ukfInput reference to the UKFInput struct.
+      */
+      void setInput(const UKFInput & ukfInput) override;
+
+}; // class ZeroVelocityStateDynamics
+
+BLF_REGISTER_UKF_DYNAMICS(ZeroVelocityStateDynamics, ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_ZERO_VELOCITY_STATE_DYNAMICS_H

--- a/src/Estimators/src/ConstantMeasurementModel.cpp
+++ b/src/Estimators/src/ConstantMeasurementModel.cpp
@@ -1,0 +1,160 @@
+/**
+ * @file ConstantMeasurementModel.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/ConstantMeasurementModel.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+bool RDE::ConstantMeasurementModel::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[ConstantMeasurementModel::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covariances))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->debug("{} Variable elements not found.", errorPrefix);
+    }
+
+    // Set the bias related variables if use_bias is true
+    if (!ptr->getParameter("use_bias", m_useBias))
+    {
+        log()->debug("{} Variable use_bias not found. Set to false by default.", errorPrefix);
+    }
+    else
+    {
+        m_biasVariableName = m_name + "_bias";
+    }
+
+    m_description = "Zero velocity dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::ConstantMeasurementModel::finalize(const System::VariablesHandler &stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[ConstantMeasurementModel::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    m_size = m_covariances.size();
+
+    m_currentState.resize(m_size);
+    m_currentState.setZero();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    // Set the bias related variables if use_bias is true
+    if (m_useBias)
+    {
+        m_bias.resize(m_size);
+        m_bias.setZero();
+    }
+
+    return true;
+}
+
+bool RDE::ConstantMeasurementModel::setSubModels(const std::vector<RDE::SubModel>& /*subModelList*/, const std::vector<std::shared_ptr<RDE::SubModelKinDynWrapper>>& /*kinDynWrapperList*/)
+{
+    return true;
+}
+
+bool RDE::ConstantMeasurementModel::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[ConstantMeasurementModel::checkStateVariableHandler]";
+
+    // Check if the variable handler contains the variables used by this dynamics
+    if (!m_stateVariableHandler.getVariable(m_name).isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_name);
+        return false;
+    }
+
+    if (m_useBias)
+    {
+        if (!m_stateVariableHandler.getVariable(m_biasVariableName).isValid())
+        {
+            log()->error("{} The variable handler does not contain the expected state name {}.", errorPrefix, m_biasVariableName);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool RDE::ConstantMeasurementModel::update()
+{
+    if (m_useBias)
+    {
+        m_updatedVariable = m_currentState + m_bias;
+    }
+    else
+    {
+        m_updatedVariable = m_currentState;
+    }
+
+    return true;
+}
+
+void RDE::ConstantMeasurementModel::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_currentState = ukfState.segment(m_stateVariableHandler.getVariable(m_name).offset,
+                                      m_stateVariableHandler.getVariable(m_name).size);
+
+    if (m_useBias)
+    {
+        m_bias = ukfState.segment(m_stateVariableHandler.getVariable(m_biasVariableName).offset,
+                                  m_stateVariableHandler.getVariable(m_biasVariableName).size);
+    }
+}
+
+void RDE::ConstantMeasurementModel::setInput(const UKFInput& /*ukfInput*/)
+{
+    return;
+}

--- a/src/Estimators/src/Dynamics.cpp
+++ b/src/Estimators/src/Dynamics.cpp
@@ -1,0 +1,79 @@
+/**
+ * @file Dynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::System;
+using namespace BipedalLocomotion::ParametersHandler;
+
+const RDE::UKFInput& RDE::UkfInputProvider::getOutput() const
+{
+    return m_ukfInput;
+}
+
+bool RDE::UkfInputProvider::advance()
+{
+    return true;
+}
+
+bool RDE::UkfInputProvider::setInput(const UKFInput& input)
+{
+    m_ukfInput = input;
+
+    return true;
+}
+
+bool RDE::UkfInputProvider::isOutputValid() const
+{
+    return m_ukfInput.robotJointPositions.size() != 0;
+}
+
+bool RDE::Dynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> /*paramHandler*/)
+{
+    return true;
+}
+
+bool RDE::Dynamics::finalize(const System::VariablesHandler& /*stateVariableHandler*/)
+{
+    return true;
+}
+
+bool RDE::Dynamics::setSubModels(const std::vector<SubModel>& /*subModelList*/, const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& /*kinDynWrapperList*/)
+{
+    return true;
+}
+
+bool RDE::Dynamics::update()
+{
+    return true;
+}
+
+Eigen::Ref<const Eigen::VectorXd> RDE::Dynamics::getUpdatedVariable() const
+{
+    return m_updatedVariable;
+}
+
+int RDE::Dynamics::size() const
+{
+    return m_size;
+}
+
+Eigen::Ref<const Eigen::VectorXd> RDE::Dynamics::getCovariance()
+{
+    return m_covariances;
+}
+
+bool RDE::Dynamics::checkStateVariableHandler()
+{
+    return true;
+}
+
+Eigen::Ref<const Eigen::VectorXd> RDE::Dynamics::getInitialStateCovariance()
+{
+    return m_initialCovariances;
+}

--- a/src/Estimators/src/JointVelocityStateDynamics.cpp
+++ b/src/Estimators/src/JointVelocityStateDynamics.cpp
@@ -1,0 +1,125 @@
+/**
+ * @file JointVelocityStateDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <map>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/JointVelocityStateDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RDE::JointVelocityStateDynamics::JointVelocityStateDynamics() = default;
+
+RDE::JointVelocityStateDynamics::~JointVelocityStateDynamics() = default;
+
+bool RDE::JointVelocityStateDynamics::setSubModels(const std::vector<RDE::SubModel>& /*subModelList*/, const std::vector<std::shared_ptr<RDE::SubModelKinDynWrapper>>& /*kinDynWrapperList*/)
+{
+    return true;
+}
+
+bool RDE::JointVelocityStateDynamics::checkStateVariableHandler()
+{
+    return true;
+}
+
+bool RDE::JointVelocityStateDynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[JointVelocityStateDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covariances))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state initial covariance
+    if (!ptr->getParameter("initial_covariance", m_initialCovariances))
+    {
+        log()->error("{} Error while retrieving the initial_covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->info("{} Variable elements not found.", errorPrefix);
+    }
+
+    if (!ptr->getParameter("sampling_time", m_dT))
+    {
+        log()->error("{} Error while retrieving the sampling_time variable.", errorPrefix);
+        return false;
+    }
+
+    m_description = "Joint velocity state dynamics depending on the robot dynamic model";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::JointVelocityStateDynamics::finalize(const System::VariablesHandler &stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[JointVelocityStateDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    m_size = m_covariances.size();
+
+    m_jointVelocityFullModel.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_jointVelocityFullModel.setZero();
+
+    m_updatedVariable.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_updatedVariable.setZero();
+
+    return true;
+}
+
+
+bool RDE::JointVelocityStateDynamics::update()
+{
+    m_updatedVariable = m_jointVelocityFullModel + std::chrono::duration<double>(m_dT).count() * m_ukfInput.robotJointAccelerations;
+
+    return true;
+}
+
+void RDE::JointVelocityStateDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_jointVelocityFullModel = ukfState.segment(m_stateVariableHandler.getVariable("ds").offset,
+                                                m_stateVariableHandler.getVariable("ds").size);
+}
+
+void RDE::JointVelocityStateDynamics::setInput(const UKFInput& ukfInput)
+{
+    m_ukfInput = ukfInput;
+}

--- a/src/Estimators/src/ZeroVelocityStateDynamics.cpp
+++ b/src/Estimators/src/ZeroVelocityStateDynamics.cpp
@@ -1,0 +1,128 @@
+/**
+ * @file ZeroVelocityStateDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityStateDynamics.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+bool RDE::ZeroVelocityStateDynamics::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[ZeroVelocityStateDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covariances))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state initial covariance
+    if (!ptr->getParameter("initial_covariance", m_initialCovariances))
+    {
+        log()->error("{} Variable initial_covariance not found.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->debug("{} Variable elements not found.", errorPrefix);
+    }
+
+    m_description = "Zero velocity dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::ZeroVelocityStateDynamics::finalize(const System::VariablesHandler &stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[ZeroVelocityStateDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    m_size = m_covariances.size();
+
+    m_currentState.resize(m_size);
+    m_currentState.setZero();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    return true;
+}
+
+bool RDE::ZeroVelocityStateDynamics::setSubModels(const std::vector<RDE::SubModel>& /*subModelList*/, const std::vector<std::shared_ptr<RDE::SubModelKinDynWrapper>>& /*kinDynWrapperList*/)
+{
+    return true;
+}
+
+bool RDE::ZeroVelocityStateDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[ZeroVelocityStateDynamics::checkStateVariableHandler]";
+
+    // Check if the variable handler contains the variables used by this dynamics
+    if (!m_stateVariableHandler.getVariable(m_name).isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `{}`.", errorPrefix, m_name);
+        return false;
+    }
+
+    return true;
+}
+
+bool RDE::ZeroVelocityStateDynamics::update()
+{
+    m_updatedVariable = m_currentState;
+
+    return true;
+}
+
+void RDE::ZeroVelocityStateDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_currentState = ukfState.segment(m_stateVariableHandler.getVariable(m_name).offset,
+                                      m_stateVariableHandler.getVariable(m_name).size);
+}
+
+void RDE::ZeroVelocityStateDynamics::setInput(const UKFInput& /*ukfInput*/)
+{
+    return;
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
+++ b/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
@@ -5,23 +5,52 @@
 if(FRAMEWORK_USE_icub-models AND FRAMEWORK_COMPILE_YarpImplementation)
 
     add_bipedal_test(NAME SubModelCreator
-                     SOURCES SubModelCreatorTest.cpp
-                     LINKS BipedalLocomotion::RobotDynamicsEstimator
-                           BipedalLocomotion::ParametersHandler
-                           BipedalLocomotion::ParametersHandlerYarpImplementation
-                           icub-models::icub-models)
+        SOURCES SubModelCreatorTest.cpp
+        LINKS BipedalLocomotion::RobotDynamicsEstimator
+        BipedalLocomotion::ParametersHandler
+        BipedalLocomotion::ParametersHandlerYarpImplementation
+        icub-models::icub-models)
 
     add_bipedal_test(NAME SubModelKinDynWrapper
-                     SOURCES SubModelKinDynWrapperTest.cpp
-                     LINKS BipedalLocomotion::RobotDynamicsEstimator
-                           BipedalLocomotion::ParametersHandler
-                           BipedalLocomotion::ParametersHandlerYarpImplementation
-                           BipedalLocomotion::ManifConversions
-                           BipedalLocomotion::Math
-                           icub-models::icub-models
-                           Eigen3::Eigen
-                           MANIF::manif
-                           )
+        SOURCES SubModelKinDynWrapperTest.cpp
+        LINKS BipedalLocomotion::RobotDynamicsEstimator
+        BipedalLocomotion::ParametersHandler
+        BipedalLocomotion::ParametersHandlerYarpImplementation
+        BipedalLocomotion::ManifConversions
+        BipedalLocomotion::Math
+        icub-models::icub-models
+        Eigen3::Eigen
+        MANIF::manif
+        )
+
+    add_bipedal_test(NAME ZeroVelocityStateDynamics
+        SOURCES ZeroVelocityStateDynamicsTest.cpp
+        LINKS BipedalLocomotion::RobotDynamicsEstimator
+        BipedalLocomotion::ParametersHandler
+        BipedalLocomotion::ParametersHandlerYarpImplementation
+        icub-models::icub-models
+        Eigen3::Eigen
+        BipedalLocomotion::ManifConversions)
+
+    add_bipedal_test(NAME ConstantMeasurementModel
+        SOURCES ConstantMeasurementModelTest.cpp
+        LINKS BipedalLocomotion::RobotDynamicsEstimator
+        BipedalLocomotion::ParametersHandler
+        BipedalLocomotion::ParametersHandlerYarpImplementation
+        icub-models::icub-models
+        Eigen3::Eigen
+        BipedalLocomotion::ManifConversions)
+
+    add_bipedal_test(NAME JointVelocityStateDynamics
+        SOURCES JointVelocityStateDynamicsTest.cpp
+        LINKS BipedalLocomotion::RobotDynamicsEstimator
+        BipedalLocomotion::ParametersHandler
+        BipedalLocomotion::ParametersHandlerYarpImplementation
+        BipedalLocomotion::System
+        icub-models::icub-models
+        Eigen3::Eigen
+        MANIF::manif
+        BipedalLocomotion::ManifConversions)
 
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/ConfigFolderPath.h.in" "${CMAKE_CURRENT_BINARY_DIR}/ConfigFolderPath.h" @ONLY)

--- a/src/Estimators/tests/RobotDynamicsEstimator/ConstantMeasurementModelTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/ConstantMeasurementModelTest.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file ConstantMeasurementModelTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+
+#include <ConfigFolderPath.h>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/ConstantMeasurementModel.h>
+
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+
+TEST_CASE("Constant Measurement Model")
+{
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    // Create variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_sensor", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_sensor_bias", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_sensor", sizeVariable));
+
+    Eigen::VectorXd state;
+    state.resize(sizeVariable * variableHandler.getNumberOfVariables());
+    state.setZero();
+
+    const std::string name = "r_leg_ft_sensor";
+    Eigen::VectorXd covariance(6);
+    covariance << 1e-7, 1e-2, 5e0, 5e-3, 5e-1, 5e-10;
+    const std::string model = "ConstantMeasurementModel";
+    const bool useBias = true;
+
+    parameterHandler->clear();
+    parameterHandler->setParameter("name", name);
+    parameterHandler->setParameter("covariance", covariance);
+    parameterHandler->setParameter("initial_covariance", covariance);
+    parameterHandler->setParameter("dynamic_model", model);
+    parameterHandler->setParameter("sampling_time", 0.01);
+    parameterHandler->setParameter("use_bias", useBias);
+
+    ConstantMeasurementModel ft;
+
+    REQUIRE(ft.initialize(parameterHandler));
+    REQUIRE(ft.finalize(variableHandler));
+
+    Eigen::VectorXd bias(6);
+    for (int index = 0; index < 6; index++)
+    {
+        bias(index) = GENERATE(take(1, random(-100, 100)));
+    }
+
+    state.segment(variableHandler.getVariable("r_leg_ft_sensor_bias").offset, variableHandler.getVariable("r_leg_ft_sensor_bias").size) = bias;
+
+    ft.setState(state);
+    REQUIRE(ft.update());
+
+    Eigen::VectorXd updatedVariable = ft.getUpdatedVariable();
+    Eigen::VectorXd ftPre = state.segment(variableHandler.getVariable("r_leg_ft_sensor").offset, variableHandler.getVariable("r_leg_ft_sensor").size);
+
+    REQUIRE((ftPre+bias).isApprox(updatedVariable));
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/JointVelocityStateDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/JointVelocityStateDynamicsTest.cpp
@@ -1,0 +1,424 @@
+/**
+ * @file FrictionTorqueDynamicsTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+
+#include <ConfigFolderPath.h>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+
+// iDynTree
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+#include <BipedalLocomotion/Math/Constants.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModelKinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/JointVelocityStateDynamics.h>
+
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+
+IParametersHandler::shared_ptr loadParameterHandler()
+{
+    std::shared_ptr<YarpImplementation> originalHandler = std::make_shared<YarpImplementation>();
+    IParametersHandler::shared_ptr parameterHandler = originalHandler;
+
+    yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
+    rf.setDefaultConfigFile("/config/model.ini");
+
+    std::vector<std::string> arguments = {" ", "--from ", getConfigPath()};
+
+    std::vector<char*> argv;
+    for (const auto& arg : arguments)
+        argv.push_back((char*)arg.data());
+    argv.push_back(nullptr);
+
+    rf.configure(argv.size() - 1, argv.data());
+
+    REQUIRE_FALSE(rf.isNull());
+    parameterHandler->clear();
+    REQUIRE(parameterHandler->isEmpty());
+    originalHandler->set(rf);
+
+    auto group = parameterHandler->getGroup("MODEL").lock();
+    REQUIRE(group != nullptr);
+
+    return group;
+}
+
+void createModelLoader(IParametersHandler::shared_ptr group,
+                       iDynTree::ModelLoader& mdlLdr,
+                       bool useFT)
+{
+    // List of joints and fts to load the model
+    std::vector<SubModel> subModelList;
+
+    const std::string modelPath = iCubModels::getModelFile("iCubGenova09");
+
+    std::vector<std::string> jointList;
+    REQUIRE(group->getParameter("joint_list", jointList));
+
+    std::vector<std::string> jointsAndFTs;
+    jointsAndFTs.insert(jointsAndFTs.begin(), jointList.begin(), jointList.end());
+
+    if (useFT)
+    {
+        std::vector<std::string> ftFramesList;
+        auto ftGroup = group->getGroup("FT").lock();
+        REQUIRE(ftGroup->getParameter("associated_joints", ftFramesList));
+        jointsAndFTs.insert(jointsAndFTs.end(), ftFramesList.begin(), ftFramesList.end());
+    }
+
+    REQUIRE(mdlLdr.loadReducedModelFromFile(modelPath, jointsAndFTs));
+}
+
+void createSubModels(iDynTree::ModelLoader& mdlLdr,
+                     std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                     IParametersHandler::shared_ptr group,
+                     bool useFTSensors,
+                     SubModelCreator& subModelCreator)
+{
+    subModelCreator.setModelAndSensors(mdlLdr.model(), mdlLdr.sensors());
+    REQUIRE(subModelCreator.setKinDyn(kinDynFullModel));
+
+    if (useFTSensors)
+    {
+        REQUIRE(subModelCreator.createSubModels(group));
+    }
+    else
+    {
+        auto groupEmpty = group->clone();
+        groupEmpty->clear();
+
+        std::vector<std::string> jointList;
+        group->getParameter("joint_list", jointList);
+        groupEmpty->setParameter("joint_list", jointList);
+
+        std::shared_ptr<IParametersHandler> emptySubGroup = groupEmpty->clone();
+        emptySubGroup->clear();
+        std::vector<std::string> emptyVector;
+        emptySubGroup->setParameter("names", emptyVector);
+        emptySubGroup->setParameter("frames", emptyVector);
+        emptySubGroup->setParameter("associated_joints", emptyVector);
+        groupEmpty->setGroup("FT", emptySubGroup);
+        groupEmpty->setGroup("ACCELEROMETER", emptySubGroup);
+        groupEmpty->setGroup("GYROSCOPE", emptySubGroup);
+        groupEmpty->setGroup("EXTERNAL_CONTACT", emptySubGroup);
+
+        REQUIRE(subModelCreator.createSubModels(groupEmpty));
+    }
+}
+
+bool setStaticState(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    size_t dofs = kinDyn->getNrOfDegreesOfFreedom();
+    iDynTree::Transform worldTbase;
+    Eigen::VectorXd baseVel(6);
+    Eigen::Vector3d gravity;
+
+    Eigen::VectorXd qj(dofs), dqj(dofs), ddqj(dofs);
+
+    worldTbase = iDynTree::Transform(iDynTree::Rotation::Identity(), iDynTree::Position::Zero());
+
+    Eigen::Matrix4d transform = toEigen(worldTbase.asHomogeneousTransform());
+
+    gravity.setZero();
+    gravity(2) = -BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+
+    baseVel.setZero();
+
+    for (size_t dof = 0; dof < dofs; dof++)
+    {
+        qj(dof) = 0.0;
+        dqj(dof) = 0.0;
+        ddqj(dof) = 0.0;
+    }
+
+    return kinDyn->setRobotState(transform,
+                                 iDynTree::make_span(qj.data(), qj.size()),
+                                 iDynTree::make_span(baseVel.data(), baseVel.size()),
+                                 iDynTree::make_span(dqj.data(), dqj.size()),
+                                 iDynTree::make_span(gravity.data(), gravity.size()));
+}
+
+TEST_CASE("Joint Velocity Dynamics Without FT")
+{
+    using namespace std::chrono_literals;
+
+    // Create parameter handler
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    const std::string name = "ds";
+    Eigen::VectorXd covariance(6);
+    covariance << 1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3;
+    std::string model = "JointVelocityStateDynamics";
+    const std::vector<std::string> elements = {"r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll"};
+
+    parameterHandler->setParameter("name", name);
+    parameterHandler->setParameter("covariance", covariance);
+    parameterHandler->setParameter("initial_covariance", covariance);
+    parameterHandler->setParameter("dynamic_model", model);
+    parameterHandler->setParameter("elements", elements);
+    parameterHandler->setParameter("sampling_time", 10ms);
+
+    // Create variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_acc_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_acc_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft_acc_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_gyro_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_gyro_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft_gyro_bias", 3));
+
+    auto handlerFromConfig = loadParameterHandler();
+
+    bool useFT = false;
+
+    iDynTree::ModelLoader modelLoader;
+    createModelLoader(handlerFromConfig, modelLoader, useFT);
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    REQUIRE(kinDyn->loadRobotModel(modelLoader.model()));
+
+    REQUIRE(setStaticState(kinDyn));
+
+    SubModelCreator subModelCreatorWithFT;
+    createSubModels(modelLoader, kinDyn, handlerFromConfig, useFT, subModelCreatorWithFT);
+
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperList;
+    const auto & subModelListWithFT = subModelCreatorWithFT.getSubModelList();
+
+    for (int idx = 0; idx < subModelCreatorWithFT.getSubModelList().size(); idx++)
+    {
+        kinDynWrapperList.emplace_back(std::make_shared<SubModelKinDynWrapper>());
+        REQUIRE(kinDynWrapperList.at(idx)->setKinDyn(kinDyn));
+        REQUIRE(kinDynWrapperList.at(idx)->initialize(subModelListWithFT[idx]));
+    }
+
+    manif::SE3d::Tangent robotBaseAcceleration;
+    robotBaseAcceleration.setZero();
+
+    Eigen::VectorXd robotJointAcceleration(kinDyn->model().getNrOfDOFs());
+    robotJointAcceleration.setZero();
+
+    iDynTree::LinkNetExternalWrenches extWrench(kinDyn->model());
+    extWrench.zero();
+
+    // Compute joint torques in static configuration from inverse dynamics on the full model
+    iDynTree::FreeFloatingGeneralizedTorques jointTorques(kinDyn->model());
+
+    kinDyn->inverseDynamics(iDynTree::make_span(robotBaseAcceleration.data(),
+                                                manif::SE3d::Tangent::DoF),
+                            robotJointAcceleration,
+                            extWrench,
+                            jointTorques);
+
+    JointVelocityStateDynamics ds;
+    model = "JointVelocityStateDynamics";
+    parameterHandler->setParameter("dynamic_model", model);
+    REQUIRE(ds.setSubModels(subModelListWithFT, kinDynWrapperList));
+    REQUIRE(ds.initialize(parameterHandler));
+    REQUIRE(ds.finalize(variableHandler));
+
+    Eigen::VectorXd state;
+    state.resize(variableHandler.getNumberOfVariables());
+    state.setZero();
+
+    int offset = variableHandler.getVariable("tau_m").offset;
+    int size = variableHandler.getVariable("tau_m").size;
+    for (int jointIndex = 0; jointIndex < size; jointIndex++)
+    {
+        state[offset+jointIndex] = jointTorques.jointTorques()[jointIndex];
+    }
+
+    // Create an input for the ukf state
+    UKFInput input;
+
+    // Define joint positions
+    Eigen::VectorXd jointPos;
+    jointPos.resize(kinDyn->model().getNrOfDOFs());
+    jointPos.setZero();
+    input.robotJointPositions = jointPos;
+
+    // Define base pose
+    manif::SE3d basePose;
+    basePose.setIdentity();
+    input.robotBasePose = basePose;
+
+    // Define base velocity and acceleration
+    manif::SE3d::Tangent baseVelocity, baseAcceleration;
+    baseVelocity.setZero();
+    baseAcceleration.setZero();
+    input.robotBaseVelocity = baseVelocity;
+    input.robotBaseAcceleration = baseAcceleration;
+    input.robotJointAccelerations = Eigen::VectorXd(kinDyn->model().getNrOfDOFs()).setZero();
+
+    for (int idx = 0; idx < subModelCreatorWithFT.getSubModelList().size(); idx++)
+    {
+        REQUIRE(kinDynWrapperList.at(idx)->updateState(baseAcceleration,
+                                                       input.robotJointAccelerations,
+                                                       BipedalLocomotion::Estimators::RobotDynamicsEstimator::UpdateMode::Full));
+    }
+
+    ds.setInput(input);
+
+    ds.setState(state);
+
+    REQUIRE(ds.update());
+}
+
+TEST_CASE("Joint Velocity Dynamics With FT")
+{
+    using namespace std::chrono_literals;
+
+    // Create parameter handler
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    const std::string name = "ds";
+    Eigen::VectorXd covariance(6);
+    covariance << 1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3;
+    std::string model = "JointVelocityStateDynamics";
+    const std::vector<std::string> elements = {"r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll"};
+
+    parameterHandler->setParameter("name", name);
+    parameterHandler->setParameter("covariance", covariance);
+    parameterHandler->setParameter("initial_covariance", covariance);
+    parameterHandler->setParameter("dynamic_model", model);
+    parameterHandler->setParameter("elements", elements);
+    parameterHandler->setParameter("sampling_time", 10ms);
+
+    // Create variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft", 6));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft", 6));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft", 6));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_bias", 6));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_bias", 6));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft_bias", 6));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_acc_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_acc_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft_acc_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_gyro_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_gyro_bias", 3));
+    REQUIRE(variableHandler.addVariable("r_foot_rear_ft_gyro_bias", 3));
+
+    auto handlerFromConfig = loadParameterHandler();
+
+    iDynTree::ModelLoader modelLoader;
+    createModelLoader(handlerFromConfig, modelLoader, true);
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    REQUIRE(kinDyn->loadRobotModel(modelLoader.model()));
+
+    REQUIRE(setStaticState(kinDyn));
+
+    bool useFT = true;
+
+    SubModelCreator subModelCreatorWithFT;
+    createSubModels(modelLoader, kinDyn, handlerFromConfig, useFT, subModelCreatorWithFT);
+
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperListWithFT;
+    const auto & subModelListWithFT = subModelCreatorWithFT.getSubModelList();
+
+    for (int idx = 0; idx < subModelCreatorWithFT.getSubModelList().size(); idx++)
+    {
+        kinDynWrapperListWithFT.emplace_back(std::make_shared<SubModelKinDynWrapper>());
+        REQUIRE(kinDynWrapperListWithFT.at(idx)->setKinDyn(kinDyn));
+        REQUIRE(kinDynWrapperListWithFT.at(idx)->initialize(subModelListWithFT[idx]));
+    }
+
+    manif::SE3d::Tangent robotBaseAcceleration;
+    robotBaseAcceleration.setZero();
+
+    Eigen::VectorXd robotJointAcceleration(kinDyn->model().getNrOfDOFs());
+    robotJointAcceleration.setZero();
+
+    iDynTree::LinkNetExternalWrenches extWrench(kinDyn->model());
+    extWrench.zero();
+
+    // Compute joint torques in static configuration from inverse dynamics on the full model
+    iDynTree::FreeFloatingGeneralizedTorques jointTorques(kinDyn->model());
+
+    kinDyn->inverseDynamics(iDynTree::make_span(robotBaseAcceleration.data(),
+                                                robotBaseAcceleration.coeffs().size()),
+                            robotJointAcceleration,
+                            extWrench,
+                            jointTorques);
+
+    JointVelocityStateDynamics dsSplit;
+    model = "JointVelocityStateDynamics";
+    parameterHandler->setParameter("dynamic_model", model);
+    REQUIRE(dsSplit.setSubModels(subModelListWithFT, kinDynWrapperListWithFT));
+    REQUIRE(dsSplit.initialize(parameterHandler));
+    REQUIRE(dsSplit.finalize(variableHandler));
+
+    Eigen::VectorXd state;
+    state.resize(variableHandler.getNumberOfVariables());
+    state.setZero();
+
+    int offset = variableHandler.getVariable("tau_m").offset;
+    int size = variableHandler.getVariable("tau_m").size;
+    for (int jointIndex = 0; jointIndex < size; jointIndex++)
+    {
+        state[offset+jointIndex] = jointTorques.jointTorques()[jointIndex];
+    }
+
+    auto massSecondSubModel = subModelListWithFT.at(1).getModel().getTotalMass();
+    state(variableHandler.getVariable("r_leg_ft").offset+2) = massSecondSubModel * BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+
+    // Create an input for the ukf state
+    UKFInput input;
+
+    // Define joint positions
+    Eigen::VectorXd jointPos;
+    jointPos.resize(kinDyn->model().getNrOfDOFs());
+    jointPos.setZero();
+    input.robotJointPositions = jointPos;
+
+    // Define base pose
+    manif::SE3d basePose;
+    basePose.setIdentity();
+    input.robotBasePose = basePose;
+
+    // Define base velocity and acceleration
+    manif::SE3d::Tangent baseVelocity, baseAcceleration;
+    baseVelocity.setZero();
+    baseAcceleration.setZero();
+    input.robotBaseVelocity = baseVelocity;
+    input.robotBaseAcceleration = baseAcceleration;
+
+    for (int idx = 0; idx < subModelCreatorWithFT.getSubModelList().size(); idx++)
+    {
+        REQUIRE(kinDynWrapperListWithFT.at(idx)->updateState(baseAcceleration,
+                                                             Eigen::VectorXd(kinDyn->model().getNrOfDOFs()).setZero(),
+                                                             BipedalLocomotion::Estimators::RobotDynamicsEstimator::UpdateMode::RobotDynamicsOnly));
+    }
+
+    input.robotJointAccelerations = Eigen::VectorXd(kinDyn->model().getNrOfDOFs()).setZero();
+
+    dsSplit.setInput(input);
+
+    dsSplit.setState(state);
+
+    REQUIRE(dsSplit.update());
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/ZeroVelocityStateDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/ZeroVelocityStateDynamicsTest.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file ZeroVelocityStateDynamicsTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+
+#include <ConfigFolderPath.h>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/ZeroVelocityStateDynamics.h>
+
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+
+TEST_CASE("Zero Velocity Dynamics")
+{
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    // Test without bias
+    const std::string name = "tau_m";
+    Eigen::VectorXd covariance(6);
+    covariance << 1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3;
+    const std::string model = "ZeroVelocityStateDynamics";
+
+    parameterHandler->setParameter("name", name);
+    parameterHandler->setParameter("covariance", covariance);
+    parameterHandler->setParameter("initial_covariance", covariance);
+    parameterHandler->setParameter("dynamic_model", model);
+    parameterHandler->setParameter("sampling_time", 0.01);
+
+    // Create variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_sensor", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_sensor_bias", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_foot_front_ft_sensor", sizeVariable));
+
+    ZeroVelocityStateDynamics tau_m;
+
+    REQUIRE(tau_m.initialize(parameterHandler));
+    REQUIRE(tau_m.finalize(variableHandler));
+
+    Eigen::VectorXd currentState(sizeVariable);
+    for (int index = 0; index < sizeVariable; index++)
+    {
+        currentState(index) = GENERATE(take(1, random(-100, 100)));
+    }
+
+    Eigen::VectorXd state;
+    state.resize(sizeVariable * variableHandler.getNumberOfVariables());
+    state.setZero();
+    state.segment(variableHandler.getVariable("tau_m").offset, variableHandler.getVariable("tau_m").size) = currentState;
+
+    tau_m.setState(state);
+
+    REQUIRE(tau_m.update());
+
+    Eigen::VectorXd nextState(covariance.size());
+    nextState = tau_m.getUpdatedVariable();
+
+    REQUIRE(currentState == nextState);
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_measurement.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_measurement.ini
@@ -3,13 +3,13 @@ dynamics_list ("JOINT_VELOCITY", "MOTOR_CURRENT",
                "RIGHT_LEG_ACC", "RIGHT_FOOT_FRONT_ACC", "RIGHT_FOOT_REAR_ACC",
                "RIGHT_LEG_GYRO", "RIGHT_FOOT_FRONT_GYRO", "RIGHT_FOOT_REAR_GYRO")
 
-# Available dynamics = ["ZeroVelocityDynamics", "AccelerometerMeasurementDynamics", "GyroscopeMeasurementDynamics", "MotorCurrentMeasurementDynamics"]
+# Available dynamics = ["ConstantMeasurementModel", "AccelerometerMeasurementDynamics", "GyroscopeMeasurementDynamics", "MotorCurrentMeasurementDynamics"]
 
 [JOINT_VELOCITY]
 name "ds"
 elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
 covariance (1e-4, 1e-4, 1e-4, 1e-4, 1e-4, 1e-4)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ConstantMeasurementModel"
 
 [MOTOR_CURRENT]
 name "i_m"
@@ -24,21 +24,21 @@ name "r_leg_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-2, 1e-2, 1e-2, 1e-3, 1e-3, 1e-3)
 use_bias 1
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ConstantMeasurementModel"
 
 [RIGHT_FOOT_FRONT_FT]
 name "r_foot_front_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-2, 1e-2, 1e-2, 1e-5, 1e-5, 1e-5)
 use_bias 1
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ConstantMeasurementModel"
 
 [RIGHT_FOOT_REAR_FT]
 name "r_foot_rear_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-2, 1e-2, 1e-2, 1e-5, 1e-5, 1e-5)
 use_bias 1
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ConstantMeasurementModel"
 
 [RIGHT_LEG_ACC]
 name "r_leg_ft_acc"

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_state.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_state.ini
@@ -3,7 +3,7 @@ dynamics_list ("JOINT_VELOCITY", "MOTOR_TORQUE", "FRICTION_TORQUE", "RIGHT_LEG_F
                "RIGHT_LEG_ACC_BIAS", "RIGHT_FOOT_FRONT_ACC_BIAS", "RIGHT_FOOT_REAR_ACC_BIAS",
                "RIGHT_LEG_GYRO_BIAS", "RIGHT_FOOT_FRONT_GYRO_BIAS", "RIGHT_FOOT_REAR_GYRO_BIAS")
 
-# Available dynamics = ["ZeroVelocityDynamics", "JointVelocityStateDynamics", "FrictionTorqueStateDynamics"]
+# Available dynamics = ["ZeroVelocityStateDynamics", "JointVelocityStateDynamics", "FrictionTorqueStateDynamics"]
 
 [JOINT_VELOCITY]
 name "ds"
@@ -17,13 +17,13 @@ name "tau_m"
 elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
 covariance (1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3)
 initial_covariance (0.01, 0.01, 0.01, 0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [FRICTION_TORQUE]
 name "tau_F"
 elements ("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")
 covariance (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-1)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 friction_k0 (9.106, 5.03, 4.93, 12.88, 14.34, 1.12)
 friction_k1 (200.0, 6.9, 200.0, 59.87, 200.0, 200.0)
 friction_k2 (1.767, 5.64, 0.27, 2.0, 3.0, 0.0)
@@ -34,82 +34,82 @@ name "r_leg_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-3, 1e-3, 1e-3, 1e-4, 1e-4, 1e-4)
 initial_covariance (0.01, 0.01, 0.01, 0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_FOOT_FRONT_FT]
 name "r_foot_front_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-3, 1e-3, 1e-3, 1e-6, 1e-6, 1e-6)
 initial_covariance (0.01, 0.01, 0.01, 0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_FOOT_REAR_FT]
 name "r_foot_rear_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-3, 1e-3, 1e-3, 1e-6, 1e-6, 1e-6)
 initial_covariance (0.01, 0.01, 0.01, 0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_LEG_FT_BIAS]
 name "r_leg_ft_bias"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-6, 1e-6, 1e-6, 1e-6, 1e-6, 1e-6)
 initial_covariance (0.01, 0.01, 0.01, 0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_FOOT_FRONT_FT_BIAS]
 name "r_foot_front_ft_bias"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-6, 1e-6, 1e-6, 1e-6, 1e-6, 1e-6)
 initial_covariance (0.01, 0.01, 0.01, 0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_FOOT_REAR_FT_BIAS]
 name "r_foot_rear_ft_bias"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-6, 1e-6, 1e-6, 1e-6, 1e-6, 1e-6)
 initial_covariance (0.01, 0.01, 0.01, 0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_LEG_ACC_BIAS]
 name "r_leg_ft_acc_bias"
 elements ("x", "y", "z")
 covariance (7.9e-5, 1.9e-5, 4.4e-5)
 initial_covariance (0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_FOOT_FRONT_ACC_BIAS]
 name "r_foot_front_ft_acc_bias"
 elements ("x", "y", "z")
 covariance (7.4e-5, 1.2e-5, 4.4e-5)
 initial_covariance (0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_FOOT_REAR_ACC_BIAS]
 name "r_foot_rear_ft_acc_bias"
 elements ("x", "y", "z")
 covariance (5.5e-5, 1.1e-5, 1.7e-5)
 initial_covariance (0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_LEG_GYRO_BIAS]
 name "r_leg_ft_gyro_bias"
 elements ("x", "y", "z")
 covariance (4e-4, 4.7e-4, 4.7e-4)
 initial_covariance (0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_FOOT_FRONT_GYRO_BIAS]
 name "r_foot_front_ft_gyro_bias"
 elements ("x", "y", "z")
 covariance (1.3e-2, 9.9e-3, 9e-3)
 initial_covariance (0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 
 [RIGHT_FOOT_REAR_GYRO_BIAS]
 name "r_foot_rear_ft_gyro_bias"
 elements ("x", "y", "z")
 covariance (8.2e-8, 1e-2, 9.3e-3)
 initial_covariance (0.01, 0.01, 0.01)
-dynamic_model "ZeroVelocityDynamics"
+dynamic_model "ZeroVelocityStateDynamics"
 


### PR DESCRIPTION
This PR implements the base class `Dynamics` which can be extended to implement specific dynamics describing the process model and the measurement model. Together with this base class I already added two specific models:
- the `ZeroVelocityDynamics` defines a dynamic model having a null first derivative
- the `JointVelocityStateDynamics` describes the dynamic model of the robot joints.