### PR TITLE
Add accelerometer and gyroscope dynamic models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Implement a class to perform inference with the [MANN network](https://github.com/ami-iit/mann-pytorch) (https://github.com/ami-iit/bipedal-locomotion-framework/pull/652)
 - Add some useful methods to the `SubModel` and `SubModelKinDynWrapper` classes (https://github.com/ami-iit/bipedal-locomotion-framework/pull/661)
 - Implement `Dynamics`, `ZeroVelocityDynamics`, and `JointVelocityStateDynamics` classes in `RobotDynamicsEstimator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/662)
+- Implement `AccelerometerMeasurementDynamics` and `GyroscopeMeasurementDynamics` classes in `RobotDynamicsEstimator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/666)
 
 ### Changed
 

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -28,10 +28,11 @@ if(FRAMEWORK_COMPILE_RobotDynamicsEstimator)
   add_bipedal_locomotion_library(
     NAME                    RobotDynamicsEstimator
     SOURCES                 src/SubModel.cpp src/SubModelKinDynWrapper.cpp src/Dynamics.cpp src/ZeroVelocityStateDynamics.cpp src/JointVelocityStateDynamics.cpp
-                            src/ConstantMeasurementModel.cpp
+                            src/ConstantMeasurementModel.cpp src/AccelerometerMeasurementDynamics.cpp src/GyroscopeMeasurementDynamics.cpp
     SUBDIRECTORIES          tests/RobotDynamicsEstimator
     PUBLIC_HEADERS          ${H_PREFIX}/SubModel.h ${H_PREFIX}/SubModelKinDynWrapper.h ${H_PREFIX}/Dynamics.h ${H_PREFIX}/ZeroVelocityStateDynamics.h
-                            ${H_PREFIX}/JointVelocityStateDynamics.h ${H_PREFIX}/ConstantMeasurementModel.h
+                            ${H_PREFIX}/JointVelocityStateDynamics.h ${H_PREFIX}/ConstantMeasurementModel.h ${H_PREFIX}/AccelerometerMeasurementDynamics.h
+                            ${H_PREFIX}/GyroscopeMeasurementDynamics.h
     PUBLIC_LINK_LIBRARIES   BipedalLocomotion::ParametersHandler MANIF::manif BipedalLocomotion::System BipedalLocomotion::Math iDynTree::idyntree-high-level
                                 iDynTree::idyntree-core iDynTree::idyntree-model iDynTree::idyntree-modelio Eigen3::Eigen
     PRIVATE_LINK_LIBRARIES  BipedalLocomotion::TextLogging BipedalLocomotion::ManifConversions

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/AccelerometerMeasurementDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/AccelerometerMeasurementDynamics.h
@@ -1,0 +1,147 @@
+/**
+ * @file AccelerometerMeasurementDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_ACCELEROMETER_MEASUREMENT_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_ACCELEROMETER_MEASUREMENT_DYNAMICS_H
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+#include <memory>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The AccelerometerMeasurementDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element if you want to use the model dynamics of an accelerometer defined,
+ * using the kinematics, as the time derivative of the frame linear velocity:
+ * \f[
+ * v = J \nu
+ * \f]
+ * The AccelerometerMeasurementDynamics represents the following equation in the continuous time:
+ * \f[
+ * \dot{v}^{accelerometer} = \dot{J} \nu + J \dot{\nu} = \dot{J} \nu + J^{base} \dot{v}^{base} +
+ * J^{joints} \ddot{s} \f] where the joint acceleration is given by the forward dynamics equation.
+ */
+class AccelerometerMeasurementDynamics : public Dynamics
+{
+    bool m_useBias{false}; /**< If true the dynamics depends on a bias additively. */
+    Eigen::VectorXd m_bias; /**< The bias is initialized and used only if m_useBias is true. False
+                               if not specified. */
+    std::string m_biasVariableName; /**< Name of the variable containing the bias in the variable
+                                       handler. */
+    std::vector<SubModel> m_subModelList; /** List of SubModel objects. */
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> m_kinDynWrapperList; /**< List of pointers
+                                                                                to
+                                                                                SubModelKinDynWrapper
+                                                                                objects. */
+    bool m_isSubModelListSet{false}; /**< Boolean flag saying if the sub-model list has been set. */
+    std::vector<Eigen::VectorXd> m_subModelJointAcc; /**< Updated joint acceleration of each
+                                                        sub-model. */
+    Eigen::Vector3d m_gravity; /**< Gravitational acceleration. */
+    std::vector<std::size_t> m_subModelsWithAccelerometer; /**< List of indeces saying which
+                                                              sub-model in the m_subDynamics list
+                                                              containa the accelerometer. */
+    UKFInput m_ukfInput; /**< Input of the UKF used to update the dynamics. */
+    std::string m_name; /**< Name of dynamics. */
+    System::VariablesHandler m_stateVariableHandler; /**< Variable handler describing the variables
+                                                        and the sizes in the ukf state vector. */
+    Eigen::VectorXd m_covSingleVar; /**< Covariance of the accelerometer measurement from
+                                       configuration. */
+    Eigen::VectorXd m_JdotNu; /**< Jdot nu. */
+    Eigen::VectorXd m_JvdotBase; /**< Jacobian times the base acceleration. */
+    Eigen::VectorXd m_Jsdotdot; /**< Jacobian times the joint acceleration. */
+    Eigen::Vector3d m_accRg; /**< Gravity rotated in the accelerometer frame. */
+    Eigen::Vector3d m_vCrossW; /**< Accelerometer linear velocity cross accelerometer angular
+                                  velocity. */
+    Eigen::Vector3d m_linVel; /**< Accelerometer linear velocity. */
+    Eigen::Vector3d m_angVel; /**< Accelerometer angular velocity. */
+
+public:
+    /*
+     * Constructor
+     */
+    AccelerometerMeasurementDynamics();
+
+    /*
+     * Destructor
+     */
+    virtual ~AccelerometerMeasurementDynamics();
+
+    /**
+     * Initialize the state dynamics.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               | `string` |   Name of the state contained in the `VariablesHandler` describing the state associated to this dynamics|    Yes    |
+     * |            `covariance`            | `vector` |                                Process covariances                                                      |    Yes    |
+     * |           `dynamic_model`          | `string` |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
+     * |             `use_bias`             |`boolean` |     Boolean saying if the dynamics depends on a bias. False if not specified.                           |    No     |
+     * @return True in case of success, false otherwise.
+     */
+    bool
+    initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param stateVariableHandler object describing the variables in the state vector.
+     * @note You should call this method after you add ALL the state dynamics to the state variable
+     * handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& stateVariableHandler) override;
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param subModelList list of SubModel objects
+     * @param kinDynWrapperList list of pointers to SubModelKinDynWrapper objects.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSubModels(
+        const std::vector<SubModel>& subModelList,
+        const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+     * Controls whether the variable handler contains the variables on which the dynamics depend.
+     * @return True in case all the dependencies are contained in the variable handler, false
+     * otherwise.
+     */
+    bool checkStateVariableHandler() override;
+
+    /**
+     * Update the content of the element.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics of the measurement variable associated
+     * to ths object.
+     * @param ukfState reference to the ukf state.
+     */
+    void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+    /**
+     * Set a `UKFInput` object.
+     * @param ukfInput reference to the UKFInput struct.
+     */
+    void setInput(const UKFInput& ukfInput) override;
+
+}; // class AccelerometerMeasurementDynamics
+
+BLF_REGISTER_UKF_DYNAMICS(AccelerometerMeasurementDynamics,
+                          ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_ACCELEROMETER_MEASUREMENT_DYNAMICS_H

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/GyroscopeMeasurementDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/GyroscopeMeasurementDynamics.h
@@ -1,0 +1,140 @@
+/**
+ * @file GyroscopeMeasurementDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_ACCELEROMETER_MEASUREMENT_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_ACCELEROMETER_MEASUREMENT_DYNAMICS_H
+
+#include <memory>
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The GyroscopeMeasurementDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element if you want to use the model dynamics of a gyroscope.
+ * The GyroscopeMeasurementDynamics represents the following equation in the continuous time:
+ * \f[
+ * \omega^{gyroscope} = J \nu = J^{base} v^{base} + J^{joints} \dot{s}
+ * \f]
+ * where the joint velocity is estimated by the ukf.
+ */
+class GyroscopeMeasurementDynamics : public Dynamics
+{
+    bool m_useBias{false}; /**< If true the dynamics depends on a bias additively. */
+    Eigen::VectorXd m_bias; /**< The bias is initialized and used only if m_useBias is true. False
+                               if not specified. */
+    std::string m_biasVariableName; /**< Name of the variable containing the bias in the variable
+                                       handler. */
+    bool m_isSubModelListSet{false}; /**< Boolean flag saying if the sub-model list has been set. */
+    int m_nrOfSubDynamics; /**< Number of sub-dynamics which corresponds to the number of
+                              sub-models. */
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> m_subModelKinDynList; /**< Vector of
+                                                                                 SubModelKinDynWrapper
+                                                                                 objects. */
+    std::vector<SubModel> m_subModelList; /**< Vector of SubModel objects. */
+    std::vector<Eigen::VectorXd> m_subModelJointVel; /**< Updated joint velocities of each
+                                                        sub-model. */
+    std::vector<std::size_t> m_subModelWithGyro; /**< List of indeces saying which sub-model in the
+                                                    m_subDynamics list containa the gyroscope. */
+    Eigen::VectorXd m_jointVelocityFullModel; /**< Vector of joint velocities. */
+    UKFInput m_ukfInput; /**< Input of the UKF used to update the dynamics. */
+    std::string m_name; /**< Name of dynamics. */
+    std::vector<std::string> m_elements = {}; /**< Elements composing the variable vector. */
+    System::VariablesHandler m_stateVariableHandler; /**< Variable handler describing the variables
+                                                        and the sizes in the ukf state vector. */
+    Eigen::VectorXd m_covSingleVar; /**< Covariance of the gyroscope measurement from configuration.
+                                     */
+    manif::SE3d::Tangent m_subModelBaseVel; /**< Submodel base velocity. */
+    Eigen::VectorXd m_JvBase; /**< Jacobian times base velocity. */
+    Eigen::VectorXd m_Jsdot; /**< Jacobian times joint velocity. */
+
+public:
+    /*
+     * Constructor
+     */
+    GyroscopeMeasurementDynamics();
+
+    /*
+     * Destructor
+     */
+    virtual ~GyroscopeMeasurementDynamics();
+
+    /**
+     * Initialize the state dynamics.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               | `string` |   Name of the state contained in the `VariablesHandler` describing the state associated to this dynamics|    Yes    |
+     * |            `covariance`            | `vector` |                                Process covariances                                                      |    Yes    |
+     * |           `dynamic_model`          | `string` |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
+     * |             `use_bias`             |`boolean` |     Boolean saying if the dynamics depends on a bias. False if not specified.                           |    No     |
+     * @return True in case of success, false otherwise.
+     */
+    bool
+    initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param stateVariableHandler object describing the variables in the state vector.
+     * @note You should call this method after you add ALL the state dynamics to the state variable
+     * handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& stateVariableHandler) override;
+
+    /**
+     * Set the SubModelKinDynWrapper object.
+     * @param subModelList list of SubModel objects
+     * @param kinDynWrapperList list of pointers to SubModelKinDynWrapper objects.
+     * @return True in case of success, false otherwise.
+     */
+    bool setSubModels(
+        const std::vector<SubModel>& subModelList,
+        const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+     * Controls whether the variable handler contains the variables on which the dynamics depend.
+     * @return True in case all the dependencies are contained in the variable handler, false
+     * otherwise.
+     */
+    bool checkStateVariableHandler() override;
+
+    /**
+     * Update the content of the element.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics of the measurement variable associated
+     * to ths object.
+     * @param ukfState reference to the ukf state.
+     */
+    void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+    /**
+     * Set a `UKFInput` object.
+     * @param ukfInput reference to the UKFInput struct.
+     */
+    void setInput(const UKFInput& ukfInput) override;
+
+}; // class GyroscopeMeasurementDynamics
+
+BLF_REGISTER_UKF_DYNAMICS(GyroscopeMeasurementDynamics,
+                          ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_ACCELEROMETER_MEASUREMENT_DYNAMICS_H

--- a/src/Estimators/src/AccelerometerMeasurementDynamics.cpp
+++ b/src/Estimators/src/AccelerometerMeasurementDynamics.cpp
@@ -1,0 +1,253 @@
+/**
+ * @file AccelerometerMeasurementDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/AccelerometerMeasurementDynamics.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RDE::AccelerometerMeasurementDynamics::AccelerometerMeasurementDynamics() = default;
+
+RDE::AccelerometerMeasurementDynamics::~AccelerometerMeasurementDynamics() = default;
+
+bool RDE::AccelerometerMeasurementDynamics::initialize(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[AccelerometerMeasurementDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covSingleVar))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the bias related variables if use_bias is true
+    if (!ptr->getParameter("use_bias", m_useBias))
+    {
+        log()->info("{} Variable use_bias not found. Set to false by default.", errorPrefix);
+    } else
+    {
+        m_biasVariableName = m_name + "_bias";
+    }
+
+    m_gravity.setZero();
+    m_gravity[2] = -BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+
+    m_JdotNu.resize(6);
+    m_JvdotBase.resize(6);
+    m_Jsdotdot.resize(6);
+
+    m_description = "Accelerometer measurement dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::AccelerometerMeasurementDynamics::finalize(
+    const System::VariablesHandler& stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[AccelerometerMeasurementDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (!m_isSubModelListSet)
+    {
+        log()->error("{} Please call `setSubModels` before finalizing.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Search and save all the submodels containing the sensor
+    for (int submodelIndex = 0; submodelIndex < m_subModelList.size(); submodelIndex++)
+    {
+        if (m_subModelList[submodelIndex].hasAccelerometer(m_name))
+        {
+            m_subModelsWithAccelerometer.push_back(submodelIndex);
+        }
+    }
+
+    m_covariances.resize(m_covSingleVar.size() * m_subModelsWithAccelerometer.size());
+    for (int index = 0; index < m_subModelsWithAccelerometer.size(); index++)
+    {
+        m_covariances.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
+            = m_covSingleVar;
+    }
+
+    m_size = m_covariances.size();
+
+    m_subModelJointAcc.resize(m_subModelList.size());
+
+    for (int idx = 0; idx < m_subModelList.size(); idx++)
+    {
+        m_subModelJointAcc[idx].resize(m_subModelList[idx].getJointMapping().size());
+        m_subModelJointAcc[idx].setZero();
+    }
+
+    m_bias.resize(m_covSingleVar.size());
+    m_bias.setZero();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    m_linVel.setZero();
+    m_angVel.setZero();
+
+    return true;
+}
+
+bool RDE::AccelerometerMeasurementDynamics::setSubModels(
+    const std::vector<SubModel>& subModelList,
+    const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    m_subModelList = subModelList;
+    m_kinDynWrapperList = kinDynWrapperList;
+    m_isSubModelListSet = true;
+
+    return true;
+}
+
+bool RDE::AccelerometerMeasurementDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[AccelerometerMeasurementDynamics::checkStateVariableHandler]";
+
+    if (!m_useBias)
+    {
+        return true;
+    }
+    if (!m_stateVariableHandler.getVariable(m_biasVariableName).isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `{}`.",
+                     errorPrefix,
+                     m_biasVariableName);
+        return false;
+    }
+
+    return true;
+}
+
+bool RDE::AccelerometerMeasurementDynamics::update()
+{
+    // compute joint acceleration per each sub-model containing the accelerometer
+    for (int arrayIdx = 0; arrayIdx < m_subModelsWithAccelerometer.size(); arrayIdx++)
+    {
+        if (m_subModelList[m_subModelsWithAccelerometer[arrayIdx]].getModel().getNrOfDOFs() > 0)
+        {
+            for (int jointIdx = 0;
+                 jointIdx
+                 < m_subModelList[m_subModelsWithAccelerometer[arrayIdx]].getJointMapping().size();
+                 jointIdx++)
+            {
+                m_subModelJointAcc[m_subModelsWithAccelerometer[arrayIdx]][jointIdx]
+                    = m_ukfInput.robotJointAccelerations
+                          [m_subModelList[m_subModelsWithAccelerometer[arrayIdx]]
+                               .getJointMapping()[jointIdx]];
+            }
+        }
+    }
+
+    // J_dot nu + base_J v_dot_base + joint_J s_dotdot - acc_Rot_world gravity + bias
+    for (int index = 0; index < m_subModelsWithAccelerometer.size(); index++)
+    {
+        m_JdotNu = m_kinDynWrapperList[m_subModelsWithAccelerometer[index]]
+                       ->getAccelerometerBiasAcceleration(m_name);
+
+        m_JvdotBase = m_kinDynWrapperList[m_subModelsWithAccelerometer[index]]
+                          ->getAccelerometerJacobian(m_name)
+                          .leftCols<6>()
+                      * m_kinDynWrapperList[m_subModelsWithAccelerometer[index]]
+                            ->getBaseAcceleration()
+                            .coeffs();
+
+        m_accRg = m_kinDynWrapperList[m_subModelsWithAccelerometer[index]]
+                      ->getAccelerometerRotation(m_name)
+                      .act(m_gravity);
+
+        m_linVel = m_kinDynWrapperList[m_subModelsWithAccelerometer[index]]
+                       ->getAccelerometerVelocity(m_name)
+                       .lin();
+        m_angVel = m_kinDynWrapperList[m_subModelsWithAccelerometer[index]]
+                       ->getAccelerometerVelocity(m_name)
+                       .ang();
+
+        m_vCrossW = m_linVel.cross(m_angVel);
+
+        m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
+            = m_JdotNu.segment(0, 3) + m_JvdotBase.segment(0, 3) - m_vCrossW - m_accRg;
+
+        if (m_useBias)
+        {
+            m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
+                = m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
+                  + m_bias;
+        }
+
+        if (m_subModelList[m_subModelsWithAccelerometer[index]].getJointMapping().size() > 0)
+        {
+            m_Jsdotdot
+                = m_kinDynWrapperList[m_subModelsWithAccelerometer[index]]
+                      ->getAccelerometerJacobian(m_name)
+                      .rightCols(m_subModelJointAcc[m_subModelsWithAccelerometer[index]].size())
+                  * m_subModelJointAcc[m_subModelsWithAccelerometer[index]];
+
+            m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
+                += m_Jsdotdot.segment(0, 3);
+        }
+    }
+
+    return true;
+}
+
+void RDE::AccelerometerMeasurementDynamics::setState(
+    const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    if (m_useBias)
+    {
+        m_bias = ukfState.segment(m_stateVariableHandler.getVariable(m_biasVariableName).offset,
+                                  m_stateVariableHandler.getVariable(m_biasVariableName).size);
+    }
+}
+
+void RDE::AccelerometerMeasurementDynamics::setInput(const UKFInput& ukfInput)
+{
+    m_ukfInput = ukfInput;
+}

--- a/src/Estimators/src/GyroscopeMeasurementDynamics.cpp
+++ b/src/Estimators/src/GyroscopeMeasurementDynamics.cpp
@@ -1,0 +1,234 @@
+﻿/**
+ * @file GyroscopeMeasurementDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/GyroscopeMeasurementDynamics.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RDE::GyroscopeMeasurementDynamics::GyroscopeMeasurementDynamics() = default;
+
+RDE::GyroscopeMeasurementDynamics::~GyroscopeMeasurementDynamics() = default;
+
+bool RDE::GyroscopeMeasurementDynamics::initialize(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[GyroscopeMeasurementDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covSingleVar))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the bias related variables if use_bias is true
+    if (!ptr->getParameter("use_bias", m_useBias))
+    {
+        log()->info("{} Variable use_bias not found. Set to false by default.", errorPrefix);
+    } else
+    {
+        m_biasVariableName = m_name + "_bias";
+    }
+
+    m_description = "Gyroscope measurement dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::GyroscopeMeasurementDynamics::finalize(
+    const System::VariablesHandler& stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[GyroscopeMeasurementDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Search and save all the submodels containing the sensor
+    for (int submodelIndex = 0; submodelIndex < m_nrOfSubDynamics; submodelIndex++)
+    {
+        if (m_subModelList[submodelIndex].hasGyroscope(m_name))
+        {
+            m_subModelWithGyro.push_back(submodelIndex);
+        }
+    }
+
+    m_covariances.resize(m_covSingleVar.size() * m_subModelWithGyro.size());
+    for (int index = 0; index < m_subModelWithGyro.size(); index++)
+    {
+        m_covariances.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
+            = m_covSingleVar;
+    }
+
+    m_size = m_covariances.size();
+
+    m_jointVelocityFullModel.resize(m_stateVariableHandler.getVariable("ds").size);
+    m_jointVelocityFullModel.setZero();
+
+    m_subModelJointVel.resize(m_nrOfSubDynamics);
+
+    for (int idx = 0; idx < m_nrOfSubDynamics; idx++)
+    {
+        m_subModelJointVel[idx].resize(m_subModelList[idx].getJointMapping().size());
+        m_subModelJointVel[idx].setZero();
+    }
+
+    m_bias.resize(m_covSingleVar.size());
+    m_bias.setZero();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    return true;
+}
+
+bool RDE::GyroscopeMeasurementDynamics::setSubModels(
+    const std::vector<SubModel>& subModelList,
+    const std::vector<std::shared_ptr<SubModelKinDynWrapper>>& kinDynWrapperList)
+{
+    constexpr auto errorPrefix = "[GyroscopeMeasurementDynamics::setSubModels]";
+
+    m_subModelList = subModelList;
+    m_subModelKinDynList = kinDynWrapperList;
+
+    if (m_subModelList.size() == 0 || m_subModelKinDynList.size() == 0
+        || m_subModelList.size() != m_subModelKinDynList.size())
+    {
+        log()->error("{} Wrong size of input parameters", errorPrefix);
+        return false;
+    }
+
+    m_nrOfSubDynamics = m_subModelList.size();
+
+    m_isSubModelListSet = true;
+
+    return true;
+}
+
+bool RDE::GyroscopeMeasurementDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[GyroscopeMeasurementDynamics::checkStateVariableHandler]";
+
+    if (!m_stateVariableHandler.getVariable("ds").isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `ds`.",
+                     errorPrefix);
+        return false;
+    }
+
+    if (!m_useBias)
+    {
+        return true;
+    }
+    if (!m_stateVariableHandler.getVariable(m_biasVariableName).isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `{}`.",
+                     errorPrefix,
+                     m_biasVariableName);
+        return false;
+    }
+
+    return true;
+}
+
+bool RDE::GyroscopeMeasurementDynamics::update()
+{
+    // base_J v_base + joint_J s_dot + bias
+    for (int index = 0; index < m_subModelWithGyro.size(); index++)
+    {
+        m_subModelBaseVel = m_subModelKinDynList[m_subModelWithGyro[index]]->getBaseVelocity();
+
+        m_JvBase
+            = m_subModelKinDynList[m_subModelWithGyro[index]]->getGyroscopeJacobian(m_name).leftCols<6>()
+              * m_subModelBaseVel.coeffs();
+
+        m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
+            = m_JvBase.segment(3, 3);
+
+        if (m_useBias)
+        {
+            m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
+                += m_bias;
+        }
+
+        if (m_subModelList[m_subModelWithGyro[index]].getJointMapping().size() > 0)
+        {
+            m_Jsdot = m_subModelKinDynList[m_subModelWithGyro[index]]
+                          ->getGyroscopeJacobian(m_name)
+                          .rightCols(m_subModelList[m_subModelWithGyro[index]].getModel().getNrOfDOFs())
+                      * m_subModelJointVel[m_subModelWithGyro[index]];
+
+            m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
+                += m_Jsdot.segment(3, 3);
+        }
+    }
+
+    return true;
+}
+
+void RDE::GyroscopeMeasurementDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_jointVelocityFullModel = ukfState.segment(m_stateVariableHandler.getVariable("ds").offset,
+                                                m_stateVariableHandler.getVariable("ds").size);
+
+    for (int smIndex = 0; smIndex < m_subModelList.size(); smIndex++)
+    {
+        for (int jntIndex = 0; jntIndex < m_subModelList[smIndex].getModel().getNrOfDOFs();
+             jntIndex++)
+        {
+            m_subModelJointVel[smIndex][jntIndex]
+                = m_jointVelocityFullModel[m_subModelList[smIndex].getJointMapping()[jntIndex]];
+        }
+    }
+
+    if (m_useBias)
+    {
+        m_bias = ukfState.segment(m_stateVariableHandler.getVariable(m_biasVariableName).offset,
+                                  m_stateVariableHandler.getVariable(m_biasVariableName).size);
+    }
+}
+
+void RDE::GyroscopeMeasurementDynamics::setInput(const UKFInput& ukfInput)
+{
+    m_ukfInput = ukfInput;
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/AccelerometerMeasurementDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/AccelerometerMeasurementDynamicsTest.cpp
@@ -1,0 +1,234 @@
+/**
+ * @file AccelerometerMeasurementDynamicsTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <ConfigFolderPath.h>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/AccelerometerMeasurementDynamics.h>
+
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+
+void createModelLoader(IParametersHandler::shared_ptr group, iDynTree::ModelLoader& mdlLdr)
+{
+    // List of joints and fts to load the model
+    std::vector<SubModel> subModelList;
+
+    const std::string modelPath = iCubModels::getModelFile("iCubGenova09");
+
+    std::vector<std::string> jointList;
+    REQUIRE(group->getParameter("joint_list", jointList));
+
+    std::vector<std::string> ftFramesList;
+    auto ftGroup = group->getGroup("FT").lock();
+    REQUIRE(ftGroup->getParameter("associated_joints", ftFramesList));
+
+    std::vector<std::string> jointsAndFTs;
+    jointsAndFTs.insert(jointsAndFTs.begin(), jointList.begin(), jointList.end());
+
+    REQUIRE(mdlLdr.loadReducedModelFromFile(modelPath, jointsAndFTs));
+}
+
+void createSubModels(iDynTree::ModelLoader& mdlLdr,
+                     std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                     IParametersHandler::shared_ptr group,
+                     SubModelCreator& subModelCreator)
+{
+    subModelCreator.setModelAndSensors(mdlLdr.model(), mdlLdr.sensors());
+    REQUIRE(subModelCreator.setKinDyn(kinDynFullModel));
+
+    REQUIRE(subModelCreator.createSubModels(group));
+}
+
+bool setStaticState(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    size_t dofs = kinDyn->getNrOfDegreesOfFreedom();
+    iDynTree::Transform worldTbase;
+    Eigen::VectorXd baseVel(6);
+    Eigen::Vector3d gravity;
+
+    Eigen::VectorXd qj(dofs), dqj(dofs), ddqj(dofs);
+
+    worldTbase = iDynTree::Transform(iDynTree::Rotation::Identity(), iDynTree::Position::Zero());
+
+    Eigen::Matrix4d transform = toEigen(worldTbase.asHomogeneousTransform());
+
+    gravity.setZero();
+    gravity(2) = -BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+
+    baseVel.setZero();
+
+    for (size_t dof = 0; dof < dofs; dof++)
+    {
+        qj(dof) = 0.0;
+        dqj(dof) = 0.0;
+        ddqj(dof) = 0.0;
+    }
+
+    return kinDyn->setRobotState(transform,
+                                 iDynTree::make_span(qj.data(), qj.size()),
+                                 iDynTree::make_span(baseVel.data(), baseVel.size()),
+                                 iDynTree::make_span(dqj.data(), dqj.size()),
+                                 iDynTree::make_span(gravity.data(), gravity.size()));
+}
+
+TEST_CASE("Friction Torque Dynamics")
+{
+    // Create parameter handler
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    const std::string name = "r_leg_ft_acc";
+    Eigen::VectorXd covariance(3);
+    covariance << 2.3e-3, 1.9e-3, 3.1e-3;
+    const std::string model = "AccelerometerMeasurementDynamics";
+    const bool useBias = true;
+
+    const std::vector<std::string> jointList
+        = {"r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll"};
+
+    parameterHandler->setParameter("name", name);
+    parameterHandler->setParameter("covariance", covariance);
+    parameterHandler->setParameter("dynamic_model", model);
+    parameterHandler->setParameter("use_bias", useBias);
+
+    // Create state variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_acc_bias", 3));
+
+    // Create model variable handler to load the robot model
+    auto modelParamHandler = std::make_shared<StdImplementation>();
+    auto emptyGroupNamesFrames = std::make_shared<StdImplementation>();
+    std::vector<std::string> emptyVectorString;
+    emptyGroupNamesFrames->setParameter("names", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("frames", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("associated_joints", emptyVectorString);
+    REQUIRE(modelParamHandler->setGroup("FT", emptyGroupNamesFrames));
+    REQUIRE(modelParamHandler->setGroup("GYROSCOPE", emptyGroupNamesFrames));
+
+    auto accGroup = std::make_shared<StdImplementation>();
+    std::vector<std::string> accNameList = {"r_leg_ft_acc"};
+    std::vector<std::string> accFrameList = {"r_leg_ft"};
+    accGroup->setParameter("names", accNameList);
+    accGroup->setParameter("frames", accFrameList);
+    REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", accGroup));
+
+    auto emptyGroupFrames = std::make_shared<StdImplementation>();
+    emptyGroupFrames->setParameter("frames", emptyVectorString);
+    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupFrames));
+
+    modelParamHandler->setParameter("joint_list", jointList);
+
+    // Load model
+    iDynTree::ModelLoader modelLoader;
+    createModelLoader(modelParamHandler, modelLoader);
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    REQUIRE(kinDyn->loadRobotModel(modelLoader.model()));
+    REQUIRE(kinDyn->setFrameVelocityRepresentation(iDynTree::BODY_FIXED_REPRESENTATION));
+
+    REQUIRE(setStaticState(kinDyn));
+
+    SubModelCreator subModelCreator;
+    createSubModels(modelLoader, kinDyn, modelParamHandler, subModelCreator);
+
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperList;
+    const auto& subModelList = subModelCreator.getSubModelList();
+
+    for (int idx = 0; idx < subModelCreator.getSubModelList().size(); idx++)
+    {
+        kinDynWrapperList.emplace_back(std::make_shared<SubModelKinDynWrapper>());
+        REQUIRE(kinDynWrapperList.at(idx)->setKinDyn(kinDyn));
+        REQUIRE(kinDynWrapperList.at(idx)->initialize(subModelList[idx]));
+    }
+
+    AccelerometerMeasurementDynamics accDynamics;
+    REQUIRE(accDynamics.setSubModels(subModelList, kinDynWrapperList));
+    REQUIRE(accDynamics.initialize(parameterHandler));
+    REQUIRE(accDynamics.finalize(variableHandler));
+
+    manif::SE3d::Tangent robotBaseAcceleration;
+    robotBaseAcceleration.setZero();
+
+    Eigen::VectorXd robotJointAcceleration(kinDyn->model().getNrOfDOFs());
+    robotJointAcceleration.setZero();
+
+    iDynTree::LinkNetExternalWrenches extWrench(kinDyn->model());
+    extWrench.zero();
+
+    // Compute joint torques in static configuration from inverse dynamics on the full model
+    iDynTree::FreeFloatingGeneralizedTorques jointTorques(kinDyn->model());
+
+    kinDyn->inverseDynamics(iDynTree::make_span(robotBaseAcceleration.data(),
+                                                manif::SE3d::Tangent::DoF),
+                            robotJointAcceleration,
+                            extWrench,
+                            jointTorques);
+
+    Eigen::VectorXd state;
+    state.resize(variableHandler.getNumberOfVariables());
+    state.setZero();
+
+    int offset = variableHandler.getVariable("tau_m").offset;
+    int size = variableHandler.getVariable("tau_m").size;
+    for (int jointIndex = 0; jointIndex < size; jointIndex++)
+    {
+        state[offset + jointIndex] = jointTorques.jointTorques()[jointIndex];
+    }
+
+    // Create an input for the ukf state
+    UKFInput input;
+
+    // Define joint positions
+    Eigen::VectorXd jointPos;
+    jointPos.resize(kinDyn->model().getNrOfDOFs());
+    jointPos.setZero();
+    input.robotJointPositions = jointPos;
+
+    // Define base pose
+    manif::SE3d basePose;
+    basePose.setIdentity();
+    input.robotBasePose = basePose;
+
+    // Define base velocity and acceleration
+    manif::SE3d::Tangent baseVelocity, baseAcceleration;
+    baseVelocity.setZero();
+    baseAcceleration.setZero();
+    input.robotBaseVelocity = baseVelocity;
+    input.robotBaseAcceleration = baseAcceleration;
+
+    input.robotJointAccelerations = Eigen::VectorXd(kinDyn->model().getNrOfDOFs()).setZero();
+
+    for (int idx = 0; idx < subModelCreator.getSubModelList().size(); idx++)
+    {
+        REQUIRE(kinDynWrapperList.at(idx)->updateState(baseAcceleration,
+                                                       input.robotJointAccelerations,
+                                                       UpdateMode::Full));
+    }
+
+    accDynamics.setInput(input);
+    accDynamics.setState(state);
+
+    REQUIRE(accDynamics.update());
+    for (int idx = 0; idx < accDynamics.getUpdatedVariable().size(); idx++)
+    {
+        REQUIRE(std::abs(accDynamics.getUpdatedVariable()(idx)) < 10);
+    }
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
+++ b/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
@@ -52,6 +52,28 @@ if(FRAMEWORK_USE_icub-models AND FRAMEWORK_COMPILE_YarpImplementation)
         MANIF::manif
         BipedalLocomotion::ManifConversions)
 
+    add_bipedal_test(NAME AccelerometerMeasurementDynamics
+        SOURCES AccelerometerMeasurementDynamicsTest.cpp
+        LINKS   BipedalLocomotion::RobotDynamicsEstimator
+        BipedalLocomotion::ParametersHandler
+        BipedalLocomotion::ParametersHandlerYarpImplementation
+        BipedalLocomotion::System
+        icub-models::icub-models
+        Eigen3::Eigen
+        MANIF::manif
+        BipedalLocomotion::ManifConversions)
+
+    add_bipedal_test(NAME GyroscopeMeasurementDynamics
+        SOURCES GyroscopeMeasurementDynamicsTest.cpp
+        LINKS   BipedalLocomotion::RobotDynamicsEstimator
+        BipedalLocomotion::ParametersHandler
+        BipedalLocomotion::ParametersHandlerYarpImplementation
+        BipedalLocomotion::System
+        icub-models::icub-models
+        Eigen3::Eigen
+        MANIF::manif
+        BipedalLocomotion::ManifConversions)
+
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/ConfigFolderPath.h.in" "${CMAKE_CURRENT_BINARY_DIR}/ConfigFolderPath.h" @ONLY)
 

--- a/src/Estimators/tests/RobotDynamicsEstimator/GyroscopeMeasurementDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/GyroscopeMeasurementDynamicsTest.cpp
@@ -1,0 +1,238 @@
+/**
+ * @file GyroscopeMeasurementDynamicsTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <ConfigFolderPath.h>
+#include <iCubModels/iCubModels.h>
+#include <yarp/os/ResourceFinder.h>
+
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/System/VariablesHandler.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/GyroscopeMeasurementDynamics.h>
+
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+
+void createModelLoader(IParametersHandler::shared_ptr group, iDynTree::ModelLoader& mdlLdr)
+{
+    // List of joints and fts to load the model
+    std::vector<SubModel> subModelList;
+
+    const std::string modelPath = iCubModels::getModelFile("iCubGenova09");
+
+    std::vector<std::string> jointList;
+    REQUIRE(group->getParameter("joint_list", jointList));
+
+    std::vector<std::string> ftFramesList;
+    auto ftGroup = group->getGroup("FT").lock();
+    REQUIRE(ftGroup->getParameter("associated_joints", ftFramesList));
+
+    std::vector<std::string> jointsAndFTs;
+    jointsAndFTs.insert(jointsAndFTs.begin(), jointList.begin(), jointList.end());
+    //    jointsAndFTs.insert(jointsAndFTs.end(), ftFramesList.begin(), ftFramesList.end());
+
+    REQUIRE(mdlLdr.loadReducedModelFromFile(modelPath, jointsAndFTs));
+}
+
+void createSubModels(iDynTree::ModelLoader& mdlLdr,
+                     std::shared_ptr<iDynTree::KinDynComputations> kinDynFullModel,
+                     IParametersHandler::shared_ptr group,
+                     SubModelCreator& subModelCreator)
+{
+    subModelCreator.setModelAndSensors(mdlLdr.model(), mdlLdr.sensors());
+    REQUIRE(subModelCreator.setKinDyn(kinDynFullModel));
+
+    REQUIRE(subModelCreator.createSubModels(group));
+}
+
+bool setStaticState(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+{
+    size_t dofs = kinDyn->getNrOfDegreesOfFreedom();
+    iDynTree::Transform worldTbase;
+    Eigen::VectorXd baseVel(6);
+    Eigen::Vector3d gravity;
+
+    Eigen::VectorXd qj(dofs), dqj(dofs), ddqj(dofs);
+
+    worldTbase = iDynTree::Transform(iDynTree::Rotation::Identity(), iDynTree::Position::Zero());
+
+    Eigen::Matrix4d transform = toEigen(worldTbase.asHomogeneousTransform());
+
+    gravity.setZero();
+    gravity(2) = -BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+
+    baseVel.setZero();
+
+    for (size_t dof = 0; dof < dofs; dof++)
+    {
+        qj(dof) = 0.0;
+        dqj(dof) = 0.0;
+        ddqj(dof) = 0.0;
+    }
+
+    return kinDyn->setRobotState(transform,
+                                 iDynTree::make_span(qj.data(), qj.size()),
+                                 iDynTree::make_span(baseVel.data(), baseVel.size()),
+                                 iDynTree::make_span(dqj.data(), dqj.size()),
+                                 iDynTree::make_span(gravity.data(), gravity.size()));
+}
+
+TEST_CASE("Gyroscope Measurement Dynamics")
+{
+    // Create parameter handler
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    const std::string name = "r_leg_ft_gyro";
+    Eigen::VectorXd covariance(3);
+    covariance << 2.3e-3, 1.9e-3, 3.1e-3;
+    const std::string model = "GyroscopeMeasurementDynamics";
+    const bool useBias = true;
+
+    double dT = 0.01;
+
+    const std::vector<std::string> jointList
+        = {"r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll"};
+
+    parameterHandler->setParameter("name", name);
+    parameterHandler->setParameter("covariance", covariance);
+    parameterHandler->setParameter("dynamic_model", model);
+    parameterHandler->setParameter("use_bias", useBias);
+
+    // Create state variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_leg_ft_gyro_bias", 3));
+
+    // Create model variable handler to load the robot model
+    auto modelParamHandler = std::make_shared<StdImplementation>();
+    auto emptyGroupNamesFrames = std::make_shared<StdImplementation>();
+    std::vector<std::string> emptyVectorString;
+    emptyGroupNamesFrames->setParameter("names", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("frames", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("associated_joints", emptyVectorString);
+    REQUIRE(modelParamHandler->setGroup("FT", emptyGroupNamesFrames));
+    REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", emptyGroupNamesFrames));
+
+    auto accGroup = std::make_shared<StdImplementation>();
+    std::vector<std::string> accNameList = {"r_leg_ft_gyro"};
+    std::vector<std::string> accFrameList = {"r_leg_ft_sensor"};
+    accGroup->setParameter("names", accNameList);
+    accGroup->setParameter("frames", accFrameList);
+    REQUIRE(modelParamHandler->setGroup("GYROSCOPE", accGroup));
+
+    auto emptyGroupFrames = std::make_shared<StdImplementation>();
+    emptyGroupFrames->setParameter("frames", emptyVectorString);
+    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupFrames));
+
+    modelParamHandler->setParameter("joint_list", jointList);
+
+    // Load model
+    iDynTree::ModelLoader modelLoader;
+    createModelLoader(modelParamHandler, modelLoader);
+
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    REQUIRE(kinDyn->loadRobotModel(modelLoader.model()));
+    REQUIRE(kinDyn->setFrameVelocityRepresentation(iDynTree::BODY_FIXED_REPRESENTATION));
+
+    REQUIRE(setStaticState(kinDyn));
+
+    SubModelCreator subModelCreator;
+    createSubModels(modelLoader, kinDyn, modelParamHandler, subModelCreator);
+
+    std::vector<std::shared_ptr<SubModelKinDynWrapper>> kinDynWrapperList;
+    const auto& subModelList = subModelCreator.getSubModelList();
+
+    for (int idx = 0; idx < subModelCreator.getSubModelList().size(); idx++)
+    {
+        kinDynWrapperList.emplace_back(std::make_shared<SubModelKinDynWrapper>());
+        REQUIRE(kinDynWrapperList.at(idx)->setKinDyn(kinDyn));
+        REQUIRE(kinDynWrapperList.at(idx)->initialize(subModelList[idx]));
+    }
+
+    GyroscopeMeasurementDynamics gyroDynamics;
+    REQUIRE(gyroDynamics.setSubModels(subModelList, kinDynWrapperList));
+    REQUIRE(gyroDynamics.initialize(parameterHandler));
+    REQUIRE(gyroDynamics.finalize(variableHandler));
+
+    manif::SE3d::Tangent robotBaseAcceleration;
+    robotBaseAcceleration.setZero();
+
+    Eigen::VectorXd robotJointAcceleration(kinDyn->model().getNrOfDOFs());
+    robotJointAcceleration.setZero();
+
+    iDynTree::LinkNetExternalWrenches extWrench(kinDyn->model());
+    extWrench.zero();
+
+    // Compute joint torques in static configuration from inverse dynamics on the full model
+    iDynTree::FreeFloatingGeneralizedTorques jointTorques(kinDyn->model());
+
+    kinDyn->inverseDynamics(iDynTree::make_span(robotBaseAcceleration.data(),
+                                                manif::SE3d::Tangent::DoF),
+                            robotJointAcceleration,
+                            extWrench,
+                            jointTorques);
+
+    Eigen::VectorXd state;
+    state.resize(variableHandler.getNumberOfVariables());
+    state.setZero();
+
+    int offset = variableHandler.getVariable("tau_m").offset;
+    int size = variableHandler.getVariable("tau_m").size;
+    for (int jointIndex = 0; jointIndex < size; jointIndex++)
+    {
+        state[offset + jointIndex] = jointTorques.jointTorques()[jointIndex];
+    }
+
+    // Create an input for the ukf state
+    UKFInput input;
+
+    // Define joint positions
+    Eigen::VectorXd jointPos;
+    jointPos.resize(kinDyn->model().getNrOfDOFs());
+    jointPos.setZero();
+    input.robotJointPositions = jointPos;
+
+    // Define base pose
+    manif::SE3d basePose;
+    basePose.setIdentity();
+    input.robotBasePose = basePose;
+
+    // Define base velocity and acceleration
+    manif::SE3d::Tangent baseVelocity, baseAcceleration;
+    baseVelocity.setZero();
+    baseAcceleration.setZero();
+    input.robotBaseVelocity = baseVelocity;
+    input.robotBaseAcceleration = baseAcceleration;
+
+    for (int idx = 0; idx < subModelCreator.getSubModelList().size(); idx++)
+    {
+        REQUIRE(
+            kinDynWrapperList.at(idx)
+                ->updateState(baseAcceleration,
+                              Eigen::VectorXd(subModelList[idx].getModel().getNrOfDOFs()).setZero(),
+                              UpdateMode::Full));
+    }
+
+    gyroDynamics.setInput(input);
+
+    gyroDynamics.setState(state);
+
+    REQUIRE(gyroDynamics.update());
+    for (int idx = 0; idx < gyroDynamics.getUpdatedVariable().size(); idx++)
+    {
+        REQUIRE(std::abs(gyroDynamics.getUpdatedVariable()(idx)) < 0.1);
+    }
+}


### PR DESCRIPTION
The PR implements two classes `AccelerometerMeasurementDynamics` and `GyroscopeMeasurementDynamics` describing the measurement models for the accelerometer and the gyroscope sensors.