### PR TITLE
Implement MANNTrajectoryGenerator in ML component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - Implement `Conversions::toiDynTreePose()` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/659)
 - Implement `MANNAutoregressive` class in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/659)
 - Implement`UkfState` class in `RobotDynamicsEstimator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/669)
+- Implement `MANNTrajectoryGenerator` class in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/668)
 
 ### Changed
 - Restructure application folders of `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/670)

--- a/bindings/python/ML/CMakeLists.txt
+++ b/bindings/python/ML/CMakeLists.txt
@@ -8,8 +8,8 @@ if(FRAMEWORK_COMPILE_ML)
 
   add_bipedal_locomotion_python_module(
     NAME MLBindings
-    SOURCES src/Module.cpp src/MANN.cpp src/MANNAutoregressive.cpp
-    HEADERS ${H_PREFIX}/Module.h ${H_PREFIX}/MANN.h ${H_PREFIX}/MANNAutoregressive.h
+    SOURCES src/Module.cpp src/MANN.cpp src/MANNAutoregressive.cpp src/MANNTrajectoryGenerator.cpp
+    HEADERS ${H_PREFIX}/Module.h ${H_PREFIX}/MANN.h ${H_PREFIX}/MANNAutoregressive.h ${H_PREFIX}/MANNTrajectoryGenerator.h
     LINK_LIBRARIES BipedalLocomotion::ML
     )
 

--- a/bindings/python/ML/include/BipedalLocomotion/bindings/ML/MANNTrajectoryGenerator.h
+++ b/bindings/python/ML/include/BipedalLocomotion/bindings/ML/MANNTrajectoryGenerator.h
@@ -1,0 +1,26 @@
+/*
+ * @file MANNTrajectoryGenerator.h
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_ML_MANN_TRAJECTORY_GENERATOR_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_ML_MANN_TRAJECTORY_GENERATOR_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ML
+{
+
+void CreateMANNTrajectoryGenerator(pybind11::module& module);
+
+} // namespace ML
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_ML_MANN_TRAJECTORY_GENERATOR_H

--- a/bindings/python/ML/src/MANNAutoregressive.cpp
+++ b/bindings/python/ML/src/MANNAutoregressive.cpp
@@ -49,13 +49,19 @@ void CreateMANNAutoregressive(pybind11::module& module)
         (module, "MANNAutoregressive");
     py::class_<ML::MANNAutoregressive,
                System::Advanceable<ML::MANNAutoregressiveInput, //
-                                   ML::MANNAutoregressiveOutput>>(module,
-                                                                        "MANNAutoregressive")
+                                   ML::MANNAutoregressiveOutput>>(module, "MANNAutoregressive")
         .def(py::init())
-        .def("reset", py::overload_cast<const ML::MANNInput&, const Contacts::EstimatedContact&,
-               const Contacts::EstimatedContact&,
-               const manif::SE3d&,
-               const manif::SE3Tangentd&>(&ML::MANNAutoregressive::reset))
+        .def("reset",
+             py::overload_cast<const ML::MANNInput&,
+                               const Contacts::EstimatedContact&,
+                               const Contacts::EstimatedContact&,
+                               const manif::SE3d&,
+                               const manif::SE3Tangentd&>(&ML::MANNAutoregressive::reset),
+             py::arg("input"),
+             py::arg("left_foot"),
+             py::arg("right_foot"),
+             py::arg("base_pose"),
+             py::arg("base_velocity"))
         .def("set_robot_model", [](ML::MANNAutoregressive& impl, ::pybind11::object& obj) {
             iDynTree::Model* cls = py::detail::swig_wrapped_pointer_to_pybind<iDynTree::Model>(obj);
 

--- a/bindings/python/ML/src/MANNTrajectoryGenerator.cpp
+++ b/bindings/python/ML/src/MANNTrajectoryGenerator.cpp
@@ -1,0 +1,73 @@
+/**
+ * @file MANNTrajectoryGenerator.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <iDynTree/Model/Model.h>
+#include <pybind11/chrono.h>
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/ML/MANNTrajectoryGenerator.h>
+#include <BipedalLocomotion/bindings/ML/MANNTrajectoryGenerator.h>
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
+#include <BipedalLocomotion/bindings/type_caster/swig.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ML
+{
+
+void CreateMANNTrajectoryGenerator(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+    namespace ML = BipedalLocomotion::ML;
+    namespace System = BipedalLocomotion::System;
+
+    py::class_<ML::MANNTrajectoryGeneratorInput, ML::MANNAutoregressiveInput>(module,
+                                                                              "MANNTrajectoryGenera"
+                                                                              "torInput")
+        .def(py::init())
+        .def_readwrite("merge_point_index", &ML::MANNTrajectoryGeneratorInput::mergePointIndex);
+
+    py::class_<ML::MANNTrajectoryGeneratorOutput>(module, "MANNTrajectoryGeneratorOutput")
+        .def(py::init())
+        .def_readwrite("joint_positions", &ML::MANNTrajectoryGeneratorOutput::jointPositions)
+        .def_readwrite("base_pose", &ML::MANNTrajectoryGeneratorOutput::basePoses)
+        .def_readwrite("phase_list", &ML::MANNTrajectoryGeneratorOutput::phaseList);
+
+    BipedalLocomotion::bindings::System::CreateAdvanceable<ML::MANNTrajectoryGeneratorInput, //
+                                                           ML::MANNTrajectoryGeneratorOutput> //
+        (module, "MANNTrajectoryGenerator");
+    py::class_<ML::MANNTrajectoryGenerator,
+               System::Advanceable<ML::MANNTrajectoryGeneratorInput, //
+                                   ML::MANNTrajectoryGeneratorOutput>>(module,
+                                                                       "MANNTrajectoryGenerator")
+        .def(py::init())
+        .def("set_initial_state",
+             &ML::MANNTrajectoryGenerator::setInitialState,
+             py::arg("joint_positions"),
+             py::arg("left_foot"),
+             py::arg("right_foot"),
+             py::arg("base_pose"),
+             py::arg("time"))
+        .def("set_robot_model", [](ML::MANNTrajectoryGenerator& impl, ::pybind11::object& obj) {
+            iDynTree::Model* cls = py::detail::swig_wrapped_pointer_to_pybind<iDynTree::Model>(obj);
+
+            if (cls == nullptr)
+            {
+                throw ::pybind11::value_error("Invalid input for the function. Please provide "
+                                              "an iDynTree::Model object.");
+            }
+            return impl.setRobotModel(*cls);
+        });
+}
+
+} // namespace ML
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/ML/src/Module.cpp
+++ b/bindings/python/ML/src/Module.cpp
@@ -9,6 +9,7 @@
 
 #include <BipedalLocomotion/bindings/ML/MANN.h>
 #include <BipedalLocomotion/bindings/ML/MANNAutoregressive.h>
+#include <BipedalLocomotion/bindings/ML/MANNTrajectoryGenerator.h>
 
 namespace BipedalLocomotion
 {
@@ -22,6 +23,7 @@ void CreateModule(pybind11::module& module)
 
     CreateMANN(module);
     CreateMANNAutoregressive(module);
+    CreateMANNTrajectoryGenerator(module);
 }
 } // namespace ML
 } // namespace bindings

--- a/src/ML/CMakeLists.txt
+++ b/src/ML/CMakeLists.txt
@@ -8,8 +8,8 @@ if (FRAMEWORK_COMPILE_ML)
 
   add_bipedal_locomotion_library(
     NAME ML
-    PUBLIC_HEADERS ${H_PREFIX}/MANN.h ${H_PREFIX}/MANNAutoregressive.h
-    SOURCES        src/MANN.cpp src/MANNAutoregressive.cpp
+    PUBLIC_HEADERS ${H_PREFIX}/MANN.h ${H_PREFIX}/MANNAutoregressive.h ${H_PREFIX}/MANNTrajectoryGenerator.h
+    SOURCES        src/MANN.cpp src/MANNAutoregressive.cpp src/MANNTrajectoryGenerator.cpp
     PUBLIC_LINK_LIBRARIES Eigen3::Eigen BipedalLocomotion::ParametersHandler BipedalLocomotion::System
                           BipedalLocomotion::ContinuousDynamicalSystem BipedalLocomotion::Contacts
     PRIVATE_LINK_LIBRARIES BipedalLocomotion::TextLogging onnxruntime::onnxruntime BipedalLocomotion::ManifConversions

--- a/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
@@ -59,6 +59,8 @@ struct MANNAutoregressiveOutput
     Eigen::VectorXd jointsPosition; /**< Joint positions in radians */
     manif::SE3d basePose; /**< Base pose with respect to the inertial frame, i.e., \f${}^I H_B\f$ */
     manif::SE3d::Tangent baseVelocity; /**< Base velocity in mixed representation */
+    Eigen::Vector3d comPosition;
+    Eigen::Vector3d angularMomentum;
     Contacts::EstimatedContact leftFoot; /**< Left foot contact */
     Contacts::EstimatedContact rightFoot; /**< Right foot contact */
     std::chrono::nanoseconds currentTime; /**< Current time stored in the advanceable */

--- a/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
@@ -58,6 +58,7 @@ struct MANNAutoregressiveOutput
 {
     Eigen::VectorXd jointsPosition; /**< Joint positions in radians */
     manif::SE3d basePose; /**< Base pose with respect to the inertial frame, i.e., \f${}^I H_B\f$ */
+    manif::SE3d::Tangent baseVelocity; /**< Base velocity in mixed representation */
     Contacts::EstimatedContact leftFoot; /**< Left foot contact */
     Contacts::EstimatedContact rightFoot; /**< Right foot contact */
     std::chrono::nanoseconds currentTime; /**< Current time stored in the advanceable */
@@ -178,7 +179,7 @@ public:
     bool reset(const MANNInput& input,
                const Contacts::EstimatedContact& leftFoot,
                const Contacts::EstimatedContact& rightFoot,
-               const manif::SE3d& basePosition,
+               const manif::SE3d& basePose,
                const manif::SE3Tangentd& baseVelocity);
 
     /**
@@ -213,6 +214,18 @@ public:
      * @return the output of the system.
      */
     const Output& getOutput() const override;
+
+    /**
+     * Get the structure that has been used as input for MANN.
+     * @return the MANNInput
+     */
+    const MANNInput& getMANNInput() const;
+
+    /**
+     * Get the autoregressive state required to rest MANNAutoregressive.
+     * @return the AutoregressiveState
+     */
+    const AutoregressiveState& getAutoregressiveState() const;
 
 private:
     struct Impl;

--- a/src/ML/include/BipedalLocomotion/ML/MANNTrajectoryGenerator.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANNTrajectoryGenerator.h
@@ -1,0 +1,175 @@
+/**
+ * @file MANNTrajectoryGenerator.h
+ * @authors Paolo Maria Viceconte, Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ML_MANN_TRAJECTORY_GENERATOR_H
+#define BIPEDAL_LOCOMOTION_ML_MANN_TRAJECTORY_GENERATOR_H
+
+#include <memory>
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/Contacts/ContactPhaseList.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ML/MANNAutoregressive.h>
+#include <BipedalLocomotion/System/Advanceable.h>
+
+namespace BipedalLocomotion
+{
+namespace ML
+{
+
+/**
+ * Input of the planner.
+ */
+struct MANNTrajectoryGeneratorInput : public MANNAutoregressiveInput
+{
+    /** Index to the merge point considered to attach the new trajectory */
+    std::size_t mergePointIndex;
+};
+
+/**
+ * Output of the trajectory planner
+ */
+struct MANNTrajectoryGeneratorOutput
+{
+    Eigen::Matrix3Xd comTrajectory; /**< CoM trajectory expressed in the inertial frame. */
+    Eigen::Matrix3Xd angularMomentumTrajectory; /**< Centroidal angular momentum trajectory
+                                                   expressed in the mixed representation. */
+    std::vector<Eigen::VectorXd> jointPositions; /**< Vector cointaining the joint positions for
+                                                    each instant. The order is the one associated to
+                                                    the model provided with
+                                                    MANNTrajectoryGenerator::setRobotModel. */
+    std::vector<manif::SE3d> basePoses; /**< Vector cointaining the base pose for each instant. */
+    Contacts::ContactPhaseList phaseList; /**< List of the contact phases */
+};
+
+/**
+ * MANNTrajectoryGenerator is a class that uses MANNAutoregressive to generate a kinematically
+ * feasible trajectory for humanoid robots. The planner will generate a trajectory which duration is
+ * equal to `slow_down_factor * time_horizon` seconds.
+ * @subsection mann_trajectory_generator MANN trajectory generator
+ * The diagram illustrates the utilization of the MANNAutoregressive within the
+ * MANNTrajectoryGenerator class.
+ * <img src="https://user-images.githubusercontent.com/16744101/239922103-1f23e08b-0091-475a-8879-61af66399c62.png" alt="mann_trajectory_generator">
+ * To initialize the generator, the user needs to set the initial
+ * state using the MANNTrajectoryGenerator::setInitialState method. The
+ * MANNTrajectoryGeneratorInput, provided by the user, serves as the input for the
+ * MANNAutoregressiveInput, along with the 'mergePointIndex.' The MANNAutoregressiveInput is assumed
+ * to remain constant within the trajectory horizon. The 'mergePointIndex' indicates the index at
+ * which the new trajectory will be attached. For example, when the MANNTrajectoryGenerator
+ * generates a trajectory consisting of 'N' points, if the 'mergePointIndex' is set to 3, the first
+ * three elements of the new trajectory will be derived from the previously computed trajectory by
+ * MANNTrajectoryGeneratorOutput, utilizing the previous MANNAutoregressiveInput. Subsequently, all
+ * points from 3 to N will be evaluated using the current MANNAutoregressiveInput. This behavior is
+ * facilitated by a mechanism that stores the autoregressive state required for resetting the
+ * MANNAutoregressive at the designated merge point. Every time the MANNAutoregressive::advance()
+ * function is invoked by the MANNTrajectoryGenerator, the autoregressive state is stored for future
+ * reference.
+ * @note The implementation of the class follows the work presented in "P. M. Viceconte et al.,
+ * ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots,
+ * in IEEE Robotics and Automation Letters, vol. 7, no. 2, pp. 2779-2786, April 2022,
+ * doi: 10.1109/LRA.2022.3141658." https://doi.org/10.1109/LRA.2022.3141658
+ */
+class MANNTrajectoryGenerator
+    : public System::Advanceable<MANNTrajectoryGeneratorInput, MANNTrajectoryGeneratorOutput>
+{
+public:
+
+    /**
+     * Constructor
+     */
+    MANNTrajectoryGenerator();
+
+    /**
+     * Destructor
+     */
+    ~MANNTrajectoryGenerator();
+
+    /**
+     * Set the robot model.
+     * @param model model of the robot considered by the network. Please load the very same model
+     * with the same joint serialization used to train the MANN network.
+     * @return true in case of success, false otherwise.
+     */
+    bool setRobotModel(const iDynTree::Model& model);
+
+    /**
+     * Initialize the trajectory planner.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |      Parameter Name      |   Type   |                                                  Description                                                  | Mandatory |
+     * |:------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------------:|:---------:|
+     * |      `time_horizon`      | `double` |                                           Horizon of the planner.                                             |    Yes    |
+     * |     `sampling_time`      | `double` |                                    Sampling considered in the inference.                                      |    Yes    |
+     * |  `root_link_frame_name`  | `string` |                                 Name of of the root link frame in the model.                                  |    Yes    |
+     * | `chest_link_frame_name`  | `string` |                                 Name of of the chest link frame in the model.                                 |    Yes    |
+     * | `right_foot_frame_name`  | `string` |                                 Name of of the right foot frame in the model.                                 |    Yes    |
+     * |  `left_foot_frame_name`  | `string` |                                  Name of of the left foot frame in the model.                                 |    Yes    |
+     * |    `forward_direction`   | `string` | String cointaining 'x', 'y' or 'z' representing the foot link forward axis. Currently, only 'x' is supported. |    Yes    |
+     * |    `slow_down_factor`    |   `int`  |      The `horizon` will be `horizon * slow_down_factor`. Same for the `sampling_time` (default value 1).      |    No     |
+     * It is also required to define two groups `LEFT_FOOT` and `RIGHT_FOOT` that contains the following parameter
+     * |      Parameter Name      |        Type       |                                        Description                                             | Mandatory |
+     * |:------------------------:|:-----------------:|:----------------------------------------------------------------------------------------------:|:---------:|
+     * |    `number_of_corners`   |        `int`      |                          Number of corners associated to the foot                              |    Yes    |
+     * |       `corner_<i>`       |  `vector<double>` | Position of the corner expressed in the foot frame. I must be from 0 to number_of_corners - 1  |    Yes    |
+     * Finally it also required to define a group named `MANN` that contains the following parameter
+     * |      Parameter Name      |   Type   |                          Description                                | Mandatory |
+     * |:------------------------:|:--------:|:-------------------------------------------------------------------:|:---------:|
+     * |    `onnx_model_path`     | `string` |  Path to the `onnx` model that will be loaded to perform inference  |    Yes    |
+     * | `projected_base_horizon` |  `int`   |    Number of samples of the base horizon considered in the model    |    Yes    |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Set the input to the planner model.
+     * @param input input to the model
+     * @return true in case of success, false otherwise.
+     */
+    bool setInput(const Input& input) override;
+
+    /**
+     * Generate the trajectory
+     * @return true in case of success, false otherwise.
+     */
+    bool advance() override;
+
+    /**
+     * Check if the output is valid.
+     * @return true if the output is valid, false otherwise.
+     */
+    bool isOutputValid() const override;
+
+    /**
+     * Get the output from trajectory.
+     * @return the output of the system.
+     */
+    const Output& getOutput() const override;
+
+    /**
+     * Set the initial state of the planner.
+     * @param jointPositions position of the joints.
+     * @param lefFoot status of the left foot.
+     * @param lefFoot status of the right foot.
+     * @param basePose pose of the base.
+     * @param time initial time of the planner.
+     */
+    void setInitialState(Eigen::Ref<const Eigen::VectorXd> jointPositions,
+                         const Contacts::EstimatedContact& leftFoot,
+                         const Contacts::EstimatedContact& rightFoot,
+                         const manif::SE3d& basePose,
+                         const std::chrono::nanoseconds& time);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_pimpl;
+};
+
+} // namespace ML
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ML_MANN_TRAJECTORY_GENERATOR_H

--- a/src/ML/src/MANNAutoregressive.cpp
+++ b/src/ML/src/MANNAutoregressive.cpp
@@ -705,6 +705,8 @@ bool MANNAutoregressive::advance()
     m_pimpl->output.jointsPosition = mannOutput.jointPositions;
     m_pimpl->output.basePose = I_H_base;
     m_pimpl->output.currentTime = m_pimpl->currentTime;
+    m_pimpl->output.comPosition = iDynTree::toEigen(m_pimpl->kinDyn.getCenterOfMassPosition());
+    m_pimpl->output.angularMomentum = iDynTree::toEigen(m_pimpl->kinDyn.getCentroidalTotalMomentum().getAngularVec3());
 
     // store the previous support foot and corner
     m_pimpl->supportFootPtr = supportFootPtr;

--- a/src/ML/src/MANNAutoregressive.cpp
+++ b/src/ML/src/MANNAutoregressive.cpp
@@ -254,11 +254,19 @@ bool MANNAutoregressive::reset(const MANNInput& input,
                                      const manif::SE3d& basePosition,
                                      const manif::SE3Tangentd& baseVelocity)
 {
-    // TODO remove 51
     AutoregressiveState state;
-    state.pastProjectedBasePositions = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{0.0, 0.0}};
-    state.pastProjectedBaseVelocity = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{0.0, 0.0}};
-    state.pastFacingDirection = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{1.0, 0.0}};
+
+    // 51 is the length of 1 second of past trajectory stored in the autoregressive state. Since the
+    // original mocap data are collected at 50 Hz, and therefore the trajectory generation is
+    // assumed to proceed at 50 Hz, we need 50 datapoints to store the past second of trajectory.
+    // Along with the present datapoint, they sum up to 51!
+    constexpr size_t lengthOfPresentPlusPastTrajectory = 51;
+    state.pastProjectedBasePositions
+        = std::deque<Eigen::Vector2d>{lengthOfPresentPlusPastTrajectory, Eigen::Vector2d{0.0, 0.0}};
+    state.pastProjectedBaseVelocity
+        = std::deque<Eigen::Vector2d>{lengthOfPresentPlusPastTrajectory, Eigen::Vector2d{0.0, 0.0}};
+    state.pastFacingDirection
+        = std::deque<Eigen::Vector2d>{lengthOfPresentPlusPastTrajectory, Eigen::Vector2d{1.0, 0.0}};
     state.I_H_FD = manif::SE2d::Identity();
     state.previousMannInput = input;
 

--- a/src/ML/src/MANNAutoregressive.cpp
+++ b/src/ML/src/MANNAutoregressive.cpp
@@ -249,11 +249,12 @@ bool MANNAutoregressive::initialize(
 }
 
 bool MANNAutoregressive::reset(const MANNInput& input,
-                                     const Contacts::EstimatedContact& leftFoot,
+                                const Contacts::EstimatedContact& leftFoot,
                                      const Contacts::EstimatedContact& rightFoot,
                                      const manif::SE3d& basePosition,
                                      const manif::SE3Tangentd& baseVelocity)
 {
+    // TODO remove 51
     AutoregressiveState state;
     state.pastProjectedBasePositions = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{0.0, 0.0}};
     state.pastProjectedBaseVelocity = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{0.0, 0.0}};
@@ -719,4 +720,14 @@ bool MANNAutoregressive::isOutputValid() const
 const MANNAutoregressive::Output& MANNAutoregressive::getOutput() const
 {
     return m_pimpl->output;
+}
+
+const MANNInput& MANNAutoregressive::getMANNInput() const
+{
+    return m_pimpl->mannInput;
+}
+
+const MANNAutoregressive::AutoregressiveState& MANNAutoregressive::getAutoregressiveState() const
+{
+    return m_pimpl->state;
 }

--- a/src/ML/src/MANNTrajectoryGenerator.cpp
+++ b/src/ML/src/MANNTrajectoryGenerator.cpp
@@ -1,0 +1,376 @@
+/**
+ * @file MANNTrajectoryGenerator.cpp
+ * @authors Paolo Maria Viceconte, Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/Contacts/ContactList.h>
+#include <chrono>
+
+#include <BipedalLocomotion/ML/MANNAutoregressive.h>
+#include <BipedalLocomotion/ML/MANNTrajectoryGenerator.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+#include <iDynTree/Model/Model.h>
+#include <manif/SE3.h>
+
+using namespace BipedalLocomotion::ML;
+using namespace BipedalLocomotion;
+
+struct MANNTrajectoryGenerator::Impl
+{
+    struct MergePointState
+    {
+        MANNInput input;
+        Contacts::EstimatedContact leftFoot;
+        Contacts::EstimatedContact rightFoot;
+        manif::SE3d basePosition;
+        manif::SE3Tangentd baseVelocity;
+        MANNAutoregressive::AutoregressiveState autoregressiveState;
+        std::chrono::nanoseconds time;
+    };
+
+    MANNAutoregressive mann;
+    MANNAutoregressiveInput mannAutoregressiveInput;
+    std::vector<MergePointState> mergePointStates;
+    std::chrono::nanoseconds dT;
+    bool isOutputValid{false};
+    int slowDownFactor{1};
+
+    Contacts::ContactListMap contactListMap;
+    MANNTrajectoryGeneratorOutput output;
+    std::chrono::nanoseconds horizon;
+    int projectedBaseHorizonSize;
+
+    bool updateContactList(const std::string& footName,
+                           const std::chrono::nanoseconds& currentTime,
+                           const Contacts::EstimatedContact& estimatedContact);
+
+    bool resetContactList(const Contacts::EstimatedContact& estimatedContact,
+                          const std::string& contactName);
+
+    static double extactYawAngle(const Eigen::Ref<const Eigen::Matrix3d>& R);
+};
+
+double MANNTrajectoryGenerator::Impl::extactYawAngle(const Eigen::Ref<const Eigen::Matrix3d>& R)
+{
+    if (R(2, 0) < 1.0)
+    {
+        if (R(2, 0) > -1.0)
+        {
+            return atan2(R(1, 0), R(0, 0));
+        } else
+        {
+            // Not a unique solution
+            return -atan2(-R(1, 2), R(1, 1));
+        }
+    }
+
+    // Not a unique solution
+    return atan2(-R(1, 2), R(1, 1));
+}
+
+bool MANNTrajectoryGenerator::Impl::resetContactList(
+    const Contacts::EstimatedContact& estimatedContact, const std::string& contactName)
+{
+    // if the contact is not active we do not have to add in the contact list
+    if (!estimatedContact.isActive)
+    {
+        return true;
+    }
+    Contacts::PlannedContact temp;
+    temp.activationTime = estimatedContact.switchTime * slowDownFactor;
+    temp.deactivationTime = std::chrono::nanoseconds::max();
+    temp.index = estimatedContact.index;
+    temp.name = estimatedContact.name;
+
+    const double yaw = this->extactYawAngle(estimatedContact.pose.quat().toRotationMatrix());
+    const Eigen::Vector3d position = estimatedContact.pose.translation();
+    temp.pose.translation({position[0], position[1], 0.0});
+    temp.pose.quat(Eigen::AngleAxis(yaw, Eigen::Vector3d::UnitZ()));
+
+    temp.type = Contacts::ContactType::FULL;
+    return this->contactListMap[contactName].addContact(temp);
+}
+
+bool MANNTrajectoryGenerator::Impl::updateContactList(
+    const std::string& footName,
+    const std::chrono::nanoseconds& currentTime,
+    const Contacts::EstimatedContact& estimatedContact)
+{
+
+    constexpr auto logPrefix = "[MANNTrajectoryGenerator::Impl::updateContactList]";
+
+    auto contactListIt = contactListMap.find(footName);
+    if (contactListIt == contactListMap.end())
+    {
+        log()->error("{} Unable to find the contact named {} in the dictionary.",
+                     logPrefix,
+                     footName);
+        return false;
+    }
+    Contacts::ContactList& contactList = contactListIt->second;
+
+    // if the contact list map is empty then this is the first contact that we have to add to the
+    // list read it as
+    // 1. if contact is active and the list is empty means that the foot just touched the ground
+    // 2. if contact is active and the last contact is not active means that the foot just touched
+    // the ground
+    if (estimatedContact.isActive
+        && (contactList.size() == 0
+            || !contactList.lastContact()->isContactActive(currentTime * this->slowDownFactor)))
+    {
+        Contacts::PlannedContact temp;
+        temp.activationTime = estimatedContact.switchTime * this->slowDownFactor;
+        temp.deactivationTime = std::chrono::nanoseconds::max();
+        temp.index = estimatedContact.index;
+        temp.name = estimatedContact.name;
+
+        // force the foot to be attached to a flat terrain
+        const double yaw = Impl::extactYawAngle(estimatedContact.pose.quat().toRotationMatrix());
+        temp.pose.translation(
+            {estimatedContact.pose.translation()[0], estimatedContact.pose.translation()[1], 0.0});
+        temp.pose.quat(Eigen::AngleAxis(yaw, Eigen::Vector3d::UnitZ()));
+
+        temp.type = Contacts::ContactType::FULL;
+        if (!contactList.addContact(temp))
+        {
+            log()->error("{} Unable to update the contact list for the contact named '{}",
+                         logPrefix,
+                         footName);
+            return false;
+        }
+    }
+    // In this case the contact ended so we have to set the deactivation time
+    else if (!estimatedContact.isActive && contactList.size() != 0
+             && contactList.lastContact()->isContactActive(currentTime * this->slowDownFactor))
+    {
+        // we cannot update the status of the last contact. We need to remove it and add it again
+        Contacts::PlannedContact lastContact = *(contactListMap[footName].lastContact());
+        lastContact.deactivationTime = currentTime * this->slowDownFactor;
+        contactList.removeLastContact();
+        if (!contactList.addContact(lastContact))
+        {
+            log()->error("{} Unable to update the contact list for the contact named '{}",
+                         logPrefix,
+                         footName);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+MANNTrajectoryGenerator::MANNTrajectoryGenerator()
+    : m_pimpl(std::make_unique<Impl>())
+{
+}
+
+MANNTrajectoryGenerator::~MANNTrajectoryGenerator() = default;
+
+bool MANNTrajectoryGenerator::setRobotModel(const iDynTree::Model& model)
+{
+    return m_pimpl->mann.setRobotModel(model);
+}
+
+bool MANNTrajectoryGenerator::initialize(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto logPrefix = "[MANNTrajectoryGenerator::initialize]";
+
+    auto getParameter
+        = [logPrefix](std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
+                      const std::string& paramName,
+                      auto& param) -> bool {
+        auto ptr = handler.lock();
+        if (ptr == nullptr)
+        {
+            log()->error("{} Invalid parameters handler.", logPrefix);
+            return false;
+        }
+
+        if (!ptr->getParameter(paramName, param))
+        {
+            log()->error("{} Unable to find the parameter named {}.", logPrefix, paramName);
+            return false;
+        }
+        return true;
+    };
+
+    // this parameter is optional
+    getParameter(paramHandler, "slow_down_factor", m_pimpl->slowDownFactor);
+
+    bool ok = getParameter(paramHandler, "time_horizon", m_pimpl->horizon);
+    ok = ok && getParameter(paramHandler, "sampling_time", m_pimpl->dT);
+    ok = ok
+         && getParameter(paramHandler.lock()->getGroup("MANN"),
+                         "projected_base_horizon",
+                         m_pimpl->projectedBaseHorizonSize);
+
+    if (!ok)
+    {
+        return false;
+    }
+
+    // resize the quantities
+    m_pimpl->mergePointStates.resize(m_pimpl->horizon / m_pimpl->dT);
+    m_pimpl->output.basePoses.resize(m_pimpl->horizon / m_pimpl->dT);
+    m_pimpl->output.jointPositions.resize(m_pimpl->horizon / m_pimpl->dT);
+    m_pimpl->output.angularMomentumTrajectory.resize(3, m_pimpl->horizon / m_pimpl->dT);
+    m_pimpl->output.comTrajectory.resize(3, m_pimpl->horizon / m_pimpl->dT);
+
+    return m_pimpl->mann.initialize(paramHandler);
+}
+
+void MANNTrajectoryGenerator::setInitialState(Eigen::Ref<const Eigen::VectorXd> jointPositions,
+                                              const Contacts::EstimatedContact& leftFoot,
+                                              const Contacts::EstimatedContact& rightFoot,
+                                              const manif::SE3d& basePose,
+                                              const std::chrono::nanoseconds& time)
+{
+    Impl::MergePointState temp;
+    temp.input.jointPositions = jointPositions;
+    temp.input.jointVelocities = Eigen::VectorXd::Zero(jointPositions.size());
+    temp.input.basePositionTrajectory = Eigen::MatrixXd::Zero(2, m_pimpl->projectedBaseHorizonSize);
+    temp.input.baseVelocitiesTrajectory
+        = Eigen::MatrixXd::Zero(2, m_pimpl->projectedBaseHorizonSize);
+    temp.input.facingDirectionTrajectory.resize(2, m_pimpl->projectedBaseHorizonSize);
+    for (int i = 0; i < m_pimpl->projectedBaseHorizonSize; i++)
+    {
+        temp.input.facingDirectionTrajectory.col(i) << 1.0, 0.0;
+    }
+    temp.basePosition = basePose;
+    temp.baseVelocity = manif::SE3Tangentd::Zero();
+    temp.leftFoot = leftFoot;
+    temp.rightFoot = rightFoot;
+    temp.time = time;
+
+    // TODO remove 51
+    temp.autoregressiveState.pastProjectedBasePositions
+        = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{0.0, 0.0}};
+    temp.autoregressiveState.pastProjectedBaseVelocity
+        = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{0.0, 0.0}};
+    temp.autoregressiveState.pastFacingDirection
+        = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{1.0, 0.0}};
+    temp.autoregressiveState.I_H_FD = manif::SE2d::Identity();
+    temp.autoregressiveState.previousMannInput = temp.input;
+
+    for (auto& state : m_pimpl->mergePointStates)
+    {
+        state = temp;
+    }
+}
+
+bool MANNTrajectoryGenerator::setInput(const Input& input)
+{
+    constexpr auto logPrefix = "[MANNTrajectoryGenerator::setInput]";
+
+    if (input.mergePointIndex > m_pimpl->mergePointStates.size())
+    {
+        log()->error("{} The index of the merge point is greater than the entire trajectory.  The "
+                     "trajectory lasts {}. I cannot attach a new trajectory at {}.",
+                     logPrefix,
+                     m_pimpl->horizon,
+                     input.mergePointIndex * m_pimpl->dT);
+        return false;
+    }
+
+    m_pimpl->mannAutoregressiveInput = input;
+
+    const auto& mergePointState = m_pimpl->mergePointStates[input.mergePointIndex];
+    if (!m_pimpl->mann.reset(mergePointState.input,
+                             mergePointState.leftFoot,
+                             mergePointState.rightFoot,
+                             mergePointState.basePosition,
+                             mergePointState.baseVelocity,
+                             mergePointState.autoregressiveState,
+                             mergePointState.time))
+    {
+        log()->error("{} Unable to reset MANN.", logPrefix);
+        return false;
+    }
+
+    // clean the contact list map this will also create the two values in the dictionary
+    m_pimpl->contactListMap["left_foot"].clear();
+    m_pimpl->contactListMap["right_foot"].clear();
+
+    // add the first contact if needed
+    return m_pimpl->resetContactList(mergePointState.leftFoot, "left_foot")
+           && m_pimpl->resetContactList(mergePointState.rightFoot, "right_foot");
+}
+
+bool MANNTrajectoryGenerator::advance()
+{
+    constexpr auto logPrefix = "[MANNTrajectoryGenerator::advance]";
+
+    // invalidate the output
+    m_pimpl->isOutputValid = false;
+
+    for (int i = 0; i < m_pimpl->mergePointStates.size(); i++)
+    {
+        if (!m_pimpl->mann.setInput(m_pimpl->mannAutoregressiveInput))
+        {
+            log()->error("{} Unable to set the input to MANN.", logPrefix);
+            return false;
+        }
+
+        if (!m_pimpl->mann.advance())
+        {
+            log()->error("{} Unable to perform the iteration number {} of MANN.", logPrefix, i);
+            return false;
+        }
+
+        const auto& MANNOutput = m_pimpl->mann.getOutput();
+
+        // store the status required to reset the system
+        m_pimpl->mergePointStates[i].basePosition = MANNOutput.basePose;
+        m_pimpl->mergePointStates[i].autoregressiveState = m_pimpl->mann.getAutoregressiveState();
+        m_pimpl->mergePointStates[i].baseVelocity = MANNOutput.baseVelocity;
+        m_pimpl->mergePointStates[i].input = m_pimpl->mann.getMANNInput();
+        m_pimpl->mergePointStates[i].leftFoot = MANNOutput.leftFoot;
+        m_pimpl->mergePointStates[i].rightFoot = MANNOutput.rightFoot;
+        m_pimpl->mergePointStates[i].time = MANNOutput.currentTime;
+
+        // populate the output of the trajectory generator
+        m_pimpl->output.basePoses[i] = MANNOutput.basePose;
+        m_pimpl->output.jointPositions[i] = MANNOutput.jointsPosition;
+        m_pimpl->output.angularMomentumTrajectory.col(i) = MANNOutput.angularMomentum;
+        m_pimpl->output.comTrajectory.col(i) = MANNOutput.comPosition;
+
+        if (!m_pimpl->updateContactList("left_foot", MANNOutput.currentTime, MANNOutput.leftFoot))
+        {
+            log()->error("{} Unable to update the contact list for the left_foot at iteration "
+                         "number {}.",
+                         logPrefix,
+                         i);
+            return false;
+        }
+
+        if (!m_pimpl->updateContactList("right_foot", MANNOutput.currentTime, MANNOutput.rightFoot))
+        {
+            log()->error("{} Unable to update the contact list for the right_foot at iteration "
+                         "number {}.",
+                         logPrefix,
+                         i);
+            return false;
+        }
+    }
+
+    // populate the phase list
+    m_pimpl->output.phaseList.setLists(m_pimpl->contactListMap);
+
+    m_pimpl->isOutputValid = true;
+
+    return true;
+}
+
+bool MANNTrajectoryGenerator::isOutputValid() const
+{
+    return m_pimpl->isOutputValid;
+}
+
+const MANNTrajectoryGenerator::Output& MANNTrajectoryGenerator::getOutput() const
+{
+    return m_pimpl->output;
+}

--- a/src/ML/src/MANNTrajectoryGenerator.cpp
+++ b/src/ML/src/MANNTrajectoryGenerator.cpp
@@ -246,13 +246,17 @@ void MANNTrajectoryGenerator::setInitialState(Eigen::Ref<const Eigen::VectorXd> 
     temp.rightFoot = rightFoot;
     temp.time = time;
 
-    // TODO remove 51
+    // 51 is the length of 1 second of past trajectory stored in the autoregressive state. Since the
+    // original mocap data are collected at 50 Hz, and therefore the trajectory generation is
+    // assumed to proceed at 50 Hz, we need 50 datapoints to store the past second of trajectory.
+    // Along with the present datapoint, they sum up to 51!
+    constexpr size_t lengthOfPresentPlusPastTrajectory = 51;
     temp.autoregressiveState.pastProjectedBasePositions
-        = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{0.0, 0.0}};
+        = std::deque<Eigen::Vector2d>{lengthOfPresentPlusPastTrajectory, Eigen::Vector2d{0.0, 0.0}};
     temp.autoregressiveState.pastProjectedBaseVelocity
-        = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{0.0, 0.0}};
+        = std::deque<Eigen::Vector2d>{lengthOfPresentPlusPastTrajectory, Eigen::Vector2d{0.0, 0.0}};
     temp.autoregressiveState.pastFacingDirection
-        = std::deque<Eigen::Vector2d>{51, Eigen::Vector2d{1.0, 0.0}};
+        = std::deque<Eigen::Vector2d>{lengthOfPresentPlusPastTrajectory, Eigen::Vector2d{1.0, 0.0}};
     temp.autoregressiveState.I_H_FD = manif::SE2d::Identity();
     temp.autoregressiveState.previousMannInput = temp.input;
 

--- a/src/ML/tests/CMakeLists.txt
+++ b/src/ML/tests/CMakeLists.txt
@@ -3,10 +3,9 @@
 # BSD-3-Clause license.
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/FolderPath.h.in" "${CMAKE_CURRENT_BINARY_DIR}/MANNModelFolderPath.h" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/FolderPath.h.in" "${CMAKE_CURRENT_BINARY_DIR}/FolderPath.h" @ONLY)
 
 set(MANN_ONNX_EXPECTED_MD5 d66042fdcd270d20b86e65b674eaa3fa)
-
 if (EXISTS "${CMAKE_CURRENT_BINARY_DIR}/model.onnx")
   file(MD5 "${CMAKE_CURRENT_BINARY_DIR}/model.onnx" ONNX_MODEL_CHECKSUM_VARIABLE)
   string(COMPARE EQUAL ${ONNX_MODEL_CHECKSUM_VARIABLE} ${MANN_ONNX_EXPECTED_MD5} MANN_ONNX_UPDATED)
@@ -22,8 +21,27 @@ if(NOT ${MANN_ONNX_UPDATED})
 endif()
 
 
+set(ERGOCUB_MODEL_EXPECTED_MD5 7d24f42cb415e660abc4bbc8a52d355f)
+if (EXISTS "${CMAKE_CURRENT_BINARY_DIR}/model.urdf")
+  file(MD5 "${CMAKE_CURRENT_BINARY_DIR}/model.urdf" ERGOCUB_MODEL_CHECKSUM_VARIABLE)
+  string(COMPARE EQUAL ${ERGOCUB_MODEL_CHECKSUM_VARIABLE} ${ERGOCUB_MODEL_EXPECTED_MD5} ERGOCUB_MODEL_UPDATED)
+else()
+  set(ERGOCUB_MODEL_UPDATED FALSE)
+endif()
+
+if(NOT ${ERGOCUB_MODEL_UPDATED})
+  message(STATUS "Fetching ergoCubSN000 model from icub-tech-iit/ergocub-software...")
+  file(DOWNLOAD https://raw.githubusercontent.com/icub-tech-iit/ergocub-software/f28733afcbbfcc99cbac13be530a6a072f832746/urdf/ergoCub/robots/ergoCubSN000/model.urdf
+    ${CMAKE_CURRENT_BINARY_DIR}/model.urdf
+    EXPECTED_MD5 ${ERGOCUB_MODEL_EXPECTED_MD5})
+endif()
 
 add_bipedal_test(
   NAME MANN
   SOURCES MANNTest.cpp
+  LINKS BipedalLocomotion::ML)
+
+add_bipedal_test(
+  NAME MANNTrajectoryGenerator
+  SOURCES MANNTrajectoryGeneratorTest.cpp
   LINKS BipedalLocomotion::ML)

--- a/src/ML/tests/FolderPath.h.in
+++ b/src/ML/tests/FolderPath.h.in
@@ -15,4 +15,9 @@ inline std::string getMANNModelPath()
     return std::string(SOURCE_CONFIG_DIR) + "/model.onnx";
 }
 
+inline std::string getRobotModelPath()
+{
+    return std::string(SOURCE_CONFIG_DIR) + "/model.urdf";
+}
+
 #endif // CONFIG_FOLDERPATH_H_IN

--- a/src/ML/tests/MANNTest.cpp
+++ b/src/ML/tests/MANNTest.cpp
@@ -13,7 +13,7 @@
 #include <BipedalLocomotion/ML/MANN.h>
 #include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
 
-#include <MANNModelFolderPath.h>
+#include <FolderPath.h>
 
 using namespace BipedalLocomotion::ML;
 using namespace BipedalLocomotion::ParametersHandler;

--- a/src/ML/tests/MANNTrajectoryGeneratorTest.cpp
+++ b/src/ML/tests/MANNTrajectoryGeneratorTest.cpp
@@ -1,0 +1,146 @@
+/**
+ * @file MANNTrajectoryGeneratorTest.cpp
+ * @authors Paolo Maria Viceconte, Giulio Romualdi
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <memory>
+
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+// Catch2
+#include <catch2/catch_test_macros.hpp>
+
+#include <BipedalLocomotion/Contacts/Contact.h>
+#include <BipedalLocomotion/ML/MANNTrajectoryGenerator.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+#include <FolderPath.h>
+
+using namespace BipedalLocomotion::ML;
+using namespace BipedalLocomotion::Contacts;
+using namespace BipedalLocomotion::ParametersHandler;
+
+TEST_CASE("MANNTrajectoryGenerator")
+{
+    using namespace std::chrono_literals;
+
+    auto jointsList
+        = std::vector<std::string>{"l_hip_pitch",      "l_hip_roll",       "l_hip_yaw",
+                                   "l_knee",           "l_ankle_pitch",    "l_ankle_roll",
+                                   "r_hip_pitch",      "r_hip_roll",       "r_hip_yaw",
+                                   "r_knee",           "r_ankle_pitch",    "r_ankle_roll",
+                                   "torso_pitch",      "torso_roll",       "torso_yaw",
+                                   "neck_pitch",       "neck_roll",        "neck_yaw",
+                                   "l_shoulder_pitch", "l_shoulder_roll",  "l_shoulder_yaw",
+                                   "l_elbow",          "r_shoulder_pitch", "r_shoulder_roll",
+                                   "r_shoulder_yaw",   "r_elbow"};
+
+    iDynTree::ModelLoader ml;
+    REQUIRE(ml.loadReducedModelFromFile(getRobotModelPath(), jointsList));
+
+    auto handler = std::make_shared<StdImplementation>();
+    handler->setParameter("joints_list", jointsList);
+    handler->setParameter("root_link_frame_name", "root_link");
+    handler->setParameter("chest_link_frame_name", "chest");
+    handler->setParameter("left_foot_frame_name", "l_sole");
+    handler->setParameter("right_foot_frame_name", "r_sole");
+    handler->setParameter("sampling_time", 20ms);
+    handler->setParameter("time_horizon", 10s);
+    handler->setParameter("slow_down_factor", 1);
+    handler->setParameter("forward_direction", "x");
+
+    auto leftFootGroup = std::make_shared<StdImplementation>();
+    leftFootGroup->setParameter("number_of_corners", 4);
+    leftFootGroup->setParameter("corner_0", std::vector<double>{+0.08, +0.03, 0.0});
+    leftFootGroup->setParameter("corner_1", std::vector<double>{+0.08, -0.03, 0.0});
+    leftFootGroup->setParameter("corner_2", std::vector<double>{-0.08, -0.03, 0.0});
+    leftFootGroup->setParameter("corner_3", std::vector<double>{-0.08, +0.03, 0.0});
+
+    auto rightFootGroup = std::make_shared<StdImplementation>();
+    rightFootGroup->setParameter("number_of_corners", 4);
+    rightFootGroup->setParameter("corner_0", std::vector<double>{+0.08, +0.03, 0.0});
+    rightFootGroup->setParameter("corner_1", std::vector<double>{+0.08, -0.03, 0.0});
+    rightFootGroup->setParameter("corner_2", std::vector<double>{-0.08, -0.03, 0.0});
+    rightFootGroup->setParameter("corner_3", std::vector<double>{-0.08, +0.03, 0.0});
+
+    auto mannGroup = std::make_shared<StdImplementation>();
+    mannGroup->setParameter("projected_base_horizon", 12);
+    mannGroup->setParameter("onnx_model_path", getMANNModelPath());
+
+    handler->setGroup("LEFT_FOOT", leftFootGroup);
+    handler->setGroup("RIGHT_FOOT", rightFootGroup);
+    handler->setGroup("MANN", mannGroup);
+
+    // input to generate a forward direction
+    MANNTrajectoryGeneratorInput generatorInput;
+    generatorInput.desiredFutureBaseTrajectory.resize(2, 7);
+    generatorInput.desiredFutureBaseVelocities.resize(2, 7);
+    generatorInput.desiredFutureFacingDirections.resize(2, 7);
+    generatorInput.desiredFutureBaseTrajectory << 0, 0.12, 0.22, 0.3, 0.35, 0.39, 0.4, 0, 0, 0, 0,
+        0, 0, 0;
+    generatorInput.mergePointIndex = 0;
+
+    for (int i = 0; i < generatorInput.desiredFutureFacingDirections.cols(); i++)
+    {
+        generatorInput.desiredFutureFacingDirections.col(i) << 1.0, 0;
+        generatorInput.desiredFutureBaseVelocities.col(i) << 0.4, 0;
+    }
+
+    EstimatedContact leftFoot, rightFoot;
+    leftFoot.isActive = true;
+    leftFoot.name = "left_foot";
+    leftFoot.index = ml.model().getFrameIndex("l_sole");
+    leftFoot.switchTime = 0s;
+    leftFoot.pose = manif::SE3d(Eigen::Vector3d{0, 0.08, 0}, manif::SO3d::Identity());
+
+    rightFoot.isActive = true;
+    rightFoot.name = "right_foot";
+    rightFoot.index = ml.model().getFrameIndex("r_sole");
+    rightFoot.switchTime = 0s;
+    rightFoot.pose = manif::SE3d(Eigen::Vector3d{0, -0.08, 0}, manif::SO3d::Identity());
+    const manif::SE3d basePose = manif::SE3d(Eigen::Vector3d{0, 0, 0.7748},
+                                             Eigen::AngleAxis(0.0, Eigen::Vector3d::UnitY()));
+
+    Eigen::VectorXd jointPositions(26);
+    jointPositions << -0.10922017141063572, 0.05081325960010118, 0.06581966291990003,
+        -0.0898053099824925, -0.09324922528169599, -0.05110058859172172, -0.11021232812838086,
+        0.054291515925228385, 0.0735575862560208, -0.09509332143185895, -0.09833823347493076,
+        -0.05367281245082792, 0.1531558711397399, -0.001030634273454133, 0.0006584764419034815,
+        -0.0016821925351926288, -0.004284529460797688, 0.030389771690123243, -0.040592118429752494,
+        -0.1695472679986807, -0.20799422095574033, 0.045397975984119654, -0.03946672931050908,
+        -0.16795588539580256, -0.20911090583076936, 0.0419854257806720;
+
+    MANNTrajectoryGenerator generator;
+    REQUIRE(generator.setRobotModel(ml.model()));
+    REQUIRE(generator.initialize(handler));
+    generator.setInitialState(jointPositions, leftFoot, rightFoot, basePose, 0s);
+    REQUIRE(generator.setInput(generatorInput));
+    REQUIRE(generator.advance());
+
+    // here we check that the robot was able to walk straight
+    Eigen::Vector3d finalCoMPosition = generator.getOutput().comTrajectory.rightCols<1>();
+    Eigen::Vector3d initialCoMPosition = generator.getOutput().comTrajectory.leftCols<1>();
+
+    constexpr double forwardTolerance = 2;
+    constexpr double lateralTolerance = 0.6;
+    constexpr double verticalTolerance = 0.1;
+    REQUIRE(std::abs(finalCoMPosition[0] - initialCoMPosition[0]) > forwardTolerance);
+    REQUIRE(std::abs(finalCoMPosition[1] - initialCoMPosition[1]) < lateralTolerance);
+    REQUIRE(std::abs(finalCoMPosition[2] - initialCoMPosition[2]) < verticalTolerance);
+
+    // test the reset
+    generatorInput.mergePointIndex = 10;
+    REQUIRE(generator.setInput(generatorInput));
+    REQUIRE(generator.advance());
+
+    // here we check that the robot was able to walk straight
+    finalCoMPosition = generator.getOutput().comTrajectory.rightCols<1>();
+    initialCoMPosition = generator.getOutput().comTrajectory.leftCols<1>();
+    REQUIRE(std::abs(finalCoMPosition[0] - initialCoMPosition[0]) > forwardTolerance);
+    REQUIRE(std::abs(finalCoMPosition[1] - initialCoMPosition[1]) < lateralTolerance);
+    REQUIRE(std::abs(finalCoMPosition[2] - initialCoMPosition[2]) < verticalTolerance);
+
+}


### PR DESCRIPTION
This PR implements `MANNTrajectoryGenerator`.

The `MANNTrajectoryGenerator` class utilizes the `MANNAutoregressive` algorithm to generate a kinematically feasible trajectory for humanoid robots. The planner generates a trajectory with a duration equal to `slow_down_factor * time_horizon` seconds.

The diagram shows how the `MANNAutoregressive` is used within the `MANNTrajectoryGenerator` class.

![image](https://github.com/ami-iit/bipedal-locomotion-framework/assets/16744101/1f23e08b-0091-475a-8879-61af66399c62)

To initialize the generator, the user must set the initial state using the `MANNTrajectoryGenerator::setInitialState` method. The generator takes `MANNTrajectoryGeneratorInput` as input, which is used as the input for `MANNAutoregressiveInput`, along with the `mergePointIndex`. The `MANNAutoregressiveInput` is assumed to remain constant within the trajectory horizon. The `mergePointIndex` indicates the index at which the new trajectory will be attached. For example, if the `MANNTrajectoryGenerator` generates a trajectory consisting of 'N' points and the `mergePointIndex` is set to 3, the first three elements of the new trajectory will be derived from the previously computed trajectory using `MANNTrajectoryGeneratorOutput` and the previous `MANNAutoregressiveInput`. Subsequently, all points from 3 to N will be evaluated using the current `MANNAutoregressiveInput`. This behavior is facilitated by storing the autoregressive state required for resetting the `MANNAutoregressive` at the designated merge point. Whenever the `MANNAutoregressive::advance()` function is invoked by the `MANNTrajectoryGenerator`, the autoregressive state is stored for future reference.


[Drawio diagram adherent_autregressive.zip](https://github.com/ami-iit/bipedal-locomotion-framework/files/11531867/adherent_autregressive.zip)
