### PR TITLE
MANN: support Windows 

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -43,7 +43,7 @@ jobs:
                       liblie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog \
                       nlohmann_json manif manifpy=*=*_12 pybind11 numpy pytest scipy opencv pcl \
                       tomlplusplus libunicycle-footstep-planner "icub-models>=1.23.4" \
-                      ros-humble-rclcpp
+                      ros-humble-rclcpp onnxruntime-cpp
 
     - name: Linux-only Dependencies [Linux]
       if: contains(matrix.os, 'ubuntu')
@@ -52,7 +52,7 @@ jobs:
         mamba install manifpy=*=*_12 expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 \
                       libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 \
                       libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64 \
-                      mesa-libgl-devel-cos6-x86_64 onnxruntime-cpp
+                      mesa-libgl-devel-cos6-x86_64 
 
     - name: maxOS-only Dependencies [macOS]
       if: contains(matrix.os, 'macos')

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -52,7 +52,7 @@ jobs:
         mamba install manifpy=*=*_12 expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 \
                       libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 \
                       libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64 \
-                      mesa-libgl-devel-cos6-x86_64 
+                      mesa-libgl-devel-cos6-x86_64
 
     - name: maxOS-only Dependencies [macOS]
       if: contains(matrix.os, 'macos')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project are documented in this file.
 
 ## [unreleased]
 ### Added
-- Implement a class to perform inference with the [MANN network](https://github.com/ami-iit/mann-pytorch) (https://github.com/ami-iit/bipedal-locomotion-framework/pull/652)
+- Implement a class to perform inference with the [MANN network](https://github.com/ami-iit/mann-pytorch) (https://github.com/ami-iit/bipedal-locomotion-framework/pull/652, https://github.com/ami-iit/bipedal-locomotion-framework/pull/686)
 - Add some useful methods to the `SubModel` and `SubModelKinDynWrapper` classes (https://github.com/ami-iit/bipedal-locomotion-framework/pull/661)
 - Implement `Dynamics`, `ZeroVelocityDynamics`, and `JointVelocityStateDynamics` classes in `RobotDynamicsEstimator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/662)
 - Implement `AccelerometerMeasurementDynamics` and `GyroscopeMeasurementDynamics` classes in `RobotDynamicsEstimator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/666)

--- a/cmake/Findonnxruntime.cmake
+++ b/cmake/Findonnxruntime.cmake
@@ -18,8 +18,7 @@ find_path(onnxruntime_INCLUDE_DIR
   PATH_SUFFIXES onnxruntime/core/session)
 mark_as_advanced(onnxruntime_INCLUDE_DIR)
 find_library(onnxruntime_LIBRARY
-  NAMES onnxruntime)
-mark_as_advanced(onnxruntime_LIBRARY)
+  NAMES onnxruntime onnxruntime_conda)
 mark_as_advanced(onnxruntime_LIBRARY)
 
 find_package_handle_standard_args(onnxruntime DEFAULT_MSG onnxruntime_INCLUDE_DIR onnxruntime_LIBRARY)

--- a/src/ML/src/MANN.cpp
+++ b/src/ML/src/MANN.cpp
@@ -167,8 +167,13 @@ bool MANN::initialize(
         return false;
     }
 
+    // Ort::Session's constructor is OS-dependent, wants wchar_t* on Windows and char* on other OSs
+    // Note: this only works with single-byte characters, such as ASCII or ISO-8859-1, 
+    // see https://stackoverflow.com/questions/2573834/c-convert-string-or-char-to-wstring-or-wchar-t
+    std::basic_string<ORTCHAR_T> networkModelPathAsOrtString(networkModelPath.begin(), networkModelPath.end());
+    
     m_pimpl->session = std::make_unique<Ort::Session>(m_pimpl->env,
-                                                      networkModelPath.c_str(),
+                                                      networkModelPathAsOrtString.c_str(),
                                                       Ort::SessionOptions{nullptr});
 
     if (m_pimpl->session == nullptr)

--- a/src/ML/src/MANN.cpp
+++ b/src/ML/src/MANN.cpp
@@ -168,10 +168,10 @@ bool MANN::initialize(
     }
 
     // Ort::Session's constructor is OS-dependent, wants wchar_t* on Windows and char* on other OSs
-    // Note: this only works with single-byte characters, such as ASCII or ISO-8859-1, 
+    // Note: this only works with single-byte characters, such as ASCII or ISO-8859-1,
     // see https://stackoverflow.com/questions/2573834/c-convert-string-or-char-to-wstring-or-wchar-t
     std::basic_string<ORTCHAR_T> networkModelPathAsOrtString(networkModelPath.begin(), networkModelPath.end());
-    
+
     m_pimpl->session = std::make_unique<Ort::Session>(m_pimpl->env,
                                                       networkModelPathAsOrtString.c_str(),
                                                       Ort::SessionOptions{nullptr});


### PR DESCRIPTION
This PR adds support for the MANN component on Windows.

It is composed by two changes:
* Fix for CMake: https://github.com/conda-forge/onnxruntime-feedstock/pull/56 added an onnxruntime-cpp package on Windows, but name of the shared library on Windows is `onnxruntime_conda.dll` and not `onnxruntime.dll`, so we need to change accordingly the `Findonnxruntime.cmake` script.
* On Windows the Ort::Session wants a wchar_t*, so we need to convert the std::string to std::wstring (see https://github.com/microsoft/onnxruntime/issues/15889).

