### PR TITLE
Add the possibility to change the orientation of the foot in the swing foot planner when the contact is not active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project are documented in this file.
 - 🤖 [ergoCubSN000] Clean the mas remapper files of the `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/673)
 - 🤖 [ergoCubSN000] Enable the logging of the realsense camera `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/672)
 - Add the possibility to force the internal state of the `SchmittTrigger` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/684)
+- Add the possibility to update the contact list in the swing foot planner when the contact is not active and the new orientation is different from the previous one (https://github.com/ami-iit/bipedal-locomotion-framework/pull/688)
+- Add the possibility to set the boundary condition for the velocity and acceleration of the `SO3Planner` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/688)
 
 ### Fixed
 - Fix RobotDynamicsEstimator compilation dependencies (https://github.com/ami-iit/bipedal-locomotion-framework/pull/665)

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,6 +1,6 @@
 [master]
 main_page = "docs/pages/main-page.dox"
-additional_pages = ["docs/pages/python-additional-info.md"]
+additional_pages = ["docs/pages/python-additional-info.md", "docs/pages/so3-minjerk.md"]
 src_folder = "src"
 
 ['v0.13.0']

--- a/docs/pages/main-page.dox
+++ b/docs/pages/main-page.dox
@@ -6,6 +6,9 @@
 \brief The **bipedal-locomotion-framework** project is a _suite_ of libraries for achieving
 bipedal locomotion on humanoid robots.
 
+\section interesting-math-notes 📚 Interesting Math Notes
+What follows is a list of interesting math notes that can be usefull to fully understand the usage of the library
+- \ref so3-minjerk
 
 \section mandatory-dependencies 📄 Mandatory dependencies
 The **bipedal-locomotion-framework** project is versatile and can be used to compile only some components.

--- a/docs/pages/so3-minjerk.md
+++ b/docs/pages/so3-minjerk.md
@@ -1,0 +1,134 @@
+# 🧮 SO3 Minimum jerk trajectory {#so3-minjerk}
+
+## Introduction
+Planning a minimum jerk trajectory in SO(3) can be a complex task. In this document, we aim to demonstrate the capabilities of the **bipedal-locomotion-framework** for generating minimum jerk trajectories in SO(3). The document is structured as follows: we first provide an overview of the mathematical foundations behind the planner, followed by a simple example illustrating its usage. Finally, we recommend some interesting readings for readers seeking more in-depth explanations and rigorous proofs.
+
+## 📐 Math
+Given a fixed initial rotation \f$(t_0, R_0)\f$ and a final rotation \f$(t_f, R_f)\f$ and the associated left trivialized angular velocities, \f$(t_0, \omega_0)\f$ and \f$(t_f, \omega_f)\f$,  we want to compute a trajectory \f$R : \mathbb{R}_+ \rightarrow SO(3)\f$ such that \f$R(t_0) = R_0\f$, \f$R(t_f) = R_f\f$,  \f$\omega(t_0) = \omega_0\f$, \f$\omega(t_f) = \omega_f\f$,  \f$\dot{\omega}(t_0) = \dot{\omega}_0\f$, \f$\dot{\omega}(t_f) = \dot{\omega}_f\f$ such that left trivialized angular jerk is minimized
+
+\f[
+\mathfrak{G} = \int_{t_0}^{t_f} \left({}^\mathcal{F} \ddot{\omega} _ {\mathcal{I}, F}^\top {}^\mathcal{F} \ddot{\omega} _ {\mathcal{I}, F}  \right)\text{d} t.
+\f]
+
+Following the work of [Zefran et al. "On the Generation of Smooth Three-Dimensional Rigid Body Motions"](https://doi.org/10.1109/70.704225) it is possible to prove that a trajectory \f$R(t)\f$ that satisfies the following equation is a minimum jerk trajectory in SO(3).
+
+\f[
+\begin{array}{ll}
+\omega ^{(5)} & + 2 \omega \times \omega ^{(4)} \\
+              & + \frac{4}{5} \omega \times (\omega  \times \omega ^{(3)}) + \frac{5}{2} \dot{\omega} \times \omega^{(3)} \\
+              & + \frac{1}{4} \omega \times (\omega \times (\omega \times \ddot{\omega})) \\
+              & + \frac{3}{2} \omega \times (\dot{\omega} \times \ddot{\omega}) \\
+              & - (\omega \times \ddot{\omega}) \times \dot{\omega} \\
+              & - \frac{1}{4} (\omega \times \dot{\omega}) \times \ddot{\omega} \\
+              & - \frac{3}{8} \omega \times ((\omega \times \dot{\omega}) \times \dot{\omega}) \\
+              & - \frac{1}{8} (\omega \times (\omega \times \dot{\omega})) \times \dot{\omega}  = 0.
+\end{array}
+\f]
+
+From now on we call this condition: **Minimum jerk trajectory condition**.
+
+It is worth noting that the above does not admit an analytic solution for arbitrary boundary conditions.
+However, in the case of zero boundary velocity and acceleration or specific structure of the boundary condition, it is possible to show that
+\f[
+R(t) =  R_{0} \exp{\left(s(t-t_0) \log\left(R_0^\top R_f \right) \right)} \quad \quad s(\tau) = a_5 \tau^5 + a_4 \tau^4 + a_3 \tau^3 + a_2 \tau^2 + a_1 \tau + a_0
+\f]
+satisfies condition the minimum jerk necessary condition. To prove the latest statement, we assume that \f$t_0 = 0\f$ and \f$t_1 = 1\f$, and then we compute the left trivialized angular velocity. The assumption can be easily removed with a simple change of variables.
+
+The angular velocity is given by
+
+\f[
+\begin{array}{ll}
+\omega^\wedge &= R^\top \dot{R} \\
+&= \dot{s} \exp{\left(-s\log\left( R _ 0^\top R _ f  \right) \right)}R_{0} ^\top R _ {0} \log\left( R _ 0^\top R _ f  \right) \exp{\left(s\log\left( R _ 0^\top R _ f \right) \right)} \\
+&= \dot{s}\exp{\left(-s\log\left(R _ 0^\top R _ f  \right) \right)} \log\left( R _ 0^\top R _ f \right) \exp{\left(s\log\left( R _ 0^\top R _ f  \right) \right)} \\
+&= \dot{s}\exp{\left(-s\log\left(R _ 0^\top R _ f  \right) \right)} \exp{\left(s\log\left( R _ 0^\top R _ f  \right) \right)}  \log\left( R _ 0^\top R _ f \right) \\
+&= \dot{s} \log\left( R _ 0^\top R _ f \right).
+\end{array}
+\f]
+
+In other words, the angular velocity will be always proportional to \f$\log\left( R_0^\top R_f \right)\f$.
+
+This means that we can ask for an initial and final angular velocity that is linearly dependent on \f$\log\left(R_0^\top R_f \right)\f$.
+Let us introduce \f$\omega^\wedge(0)\f$ and \f$\omega^\wedge(1)\f$ as
+
+\f[
+\omega^\wedge(0) = \lambda ^\omega _ 0 \log\left( R_0^\top R_f \right) \quad \omega^\wedge(1) = \lambda ^\omega _ 1 \log\left( R_0^\top R_f \right)
+\f]
+
+similarly for the angular acceleration
+
+\f[
+\dot{\omega}^\wedge(0) = \lambda ^\alpha _ 0 \log\left( R_0^\top R_f \right) \quad \dot{\omega}^\wedge(1) = \lambda ^\alpha _ 1 \log\left( R_0^\top R_f \right)
+\f]
+
+So combining the initial and the final boundary conditions we can write the following linear system.
+\f[
+\begin{array}{ll}
+s(0) &= 0 \\
+s(1) &= 1 \\
+\dot{s}(0) &= \lambda ^\omega _ 0 \\
+\dot{s}(1) &= \lambda ^\omega _ 1 \\
+\ddot{s}(0) &= \lambda ^\alpha _ 0 \\
+\ddot{s}(1) &= \lambda ^\alpha _ 1
+\end{array}
+\f]
+
+Solving the above system  we obtain
+
+\f[
+\begin{array}{ll}
+a_0 &= 0 \\
+a_1 &= \lambda ^\omega _ 0  \\
+a_2 &= \lambda ^\alpha _ 0/2 \\
+a_3 &= \lambda ^\alpha _ 1/2 - (3 \lambda ^\alpha _ 0)/2 - 6 \lambda ^\omega _ 0 - 4 \lambda ^\omega _ 1 + 10    \\
+a_4 &= (3 \lambda ^\alpha _ 0)/2 - \lambda ^\alpha _ 1 + 8 \lambda ^\omega _ 0 + 7 \lambda ^\omega _ 1 - 15      \\
+a_5 &= \lambda ^\alpha _ 1/2 - \lambda ^\alpha _ 0/2 - 3 \lambda ^\omega _ 0 - 3 \lambda ^\omega _ 1 + 6
+\end{array}
+\f]
+
+It is now easy to show that \f$\omega\f$ satisfies the minimum jerk condition indeed
+
+\f[
+\omega ^{(5)} = 0
+\f]
+
+and all the cross products vanish since the angular velocity and its derivatives are linearly dependent.
+
+## 💻 How to use the planner
+
+The SO3 minimum jerk planner is provided in **bipedal-locomotion-framework** through a template class that allows the user to use the left or the right trivialized angular velocity
+
+```cpp
+using namespace std::chrono_literals;
+
+manif::SO3d initialTransform = manif::SO3d::Random();
+manif::SO3d finalTransform = manif::SO3d::Random();
+
+constexpr std::chrono::nanoseconds T = 1s;
+
+BipedalLocomotion::Planner::SO3PlannerInertial planner;
+manif::SO3d::Tangent initialVelocity = (finalTransform * initialTransform.inverse()).log();
+
+initialVelocity.coeffs() = initialVelocity.coeffs() * 2;
+planner.setInitialConditions(initialVelocity, manif::SO3d::Tangent::Zero());
+planner.setFinalConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero());
+planner.setRotations(initialTransform, finalTransform, T);
+
+manif::SO3d rotation, predictedRotation;
+manif::SO3d::Tangent velocity, predictedVelocity;
+manif::SO3d::Tangent acceleration;
+planner.evaluatePoint(0.42s, rotation, velocity, acceleration);
+```
+
+## 📖 Interesting readings
+The interested reader
+can refer to the extensive literature, among which it is worth mentioning:
+
+- Žefran, M., Kumar, V., and Croke, C. (1998). _On the generation of smooth threedimensional rigid body motions_. IEEE Transactions on Robotics and Automation,
+14(4):576–589.
+- Dubrovin, B. A., Fomenko, A. T., and Novikov, S. P. (1984). _Modern Geometry —
+Methods and Applications, volume 93_. Springer New York, New York, NY.
+- Needham, T. (2021). _Visual Differential Geometry and Forms_. Princeton University
+Press.
+- Pressley, A. (2010). _Elementary Differential Geometry_. Springer London, London.
+- Giulio Romualdi (2022) _Online Control of Humanoid Robot Locomotion_ Ph.D. Thesis.

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
@@ -8,8 +8,8 @@
 #ifndef BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_TPP
 #define BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_TPP
 
-#include <iostream>
 #include <chrono>
+#include <iostream>
 
 #include <manif/SO3.h>
 
@@ -28,11 +28,108 @@ constexpr double durationToSeconds(const std::chrono::duration<Rep, Period>& d)
 }
 
 template <LieGroupTrivialization trivialization>
+bool SO3Planner<trivialization>::computeCoefficients()
+{
+    constexpr double tolerance = 1e-3;
+    constexpr auto logPrefix = "[SO3Planner::computeCoefficients]";
+
+    // no need to compute the coefficients again
+    if (areCoefficientsComputed)
+    {
+        return true;
+    }
+
+    if (!this->initialCondition.isSet)
+    {
+        log()->error("{} The initial boundary condition is not set.", logPrefix);
+        return false;
+    }
+
+    if (!this->finalCondition.isSet)
+    {
+        log()->error("{} The final boundary condition is not set.", logPrefix);
+        return false;
+    }
+
+    // in the following function we check that vector anc rotationError are linear dependent and we
+    // compute the coefficient such that "vector = coefficient * rotationError".
+    auto findVectorCoefficient = [tolerance, logPrefix](const manif::SO3d::Tangent& rotationError,
+                                                        const manif::SO3d::Tangent& vector,
+                                                        double& coefficient) -> bool {
+        if (rotationError.coeffs().isZero())
+        {
+            coefficient = 0;
+            return true;
+        }
+
+        if (vector.coeffs().isZero())
+        {
+            coefficient = 0;
+            return true;
+        }
+
+        const double dotProduct = rotationError.coeffs().dot(vector.coeffs());
+        const double rotationErrorNorm = rotationError.coeffs().norm();
+        const double vectorNorm = vector.coeffs().norm();
+
+        const double cosOfAngleBetweenTwoVectors = dotProduct / (rotationErrorNorm * vectorNorm);
+        constexpr double cosOfTwoParallelVectors = 1;
+        // the cosine of the angle of two parallel vector can be 1 or -1 for this reason we compute
+        // the absolute value
+        if (std::abs(std::abs(cosOfAngleBetweenTwoVectors) - cosOfTwoParallelVectors) > tolerance)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < rotationError.coeffs().size(); i++)
+        {
+            const double tmp = vector.coeffs()[i] / rotationError.coeffs()[i];
+            if (!std::isinf(tmp) && !std::isnan(tmp))
+            {
+                coefficient = tmp;
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    // check if the boundary conditions are linear independent with the error between the two
+    // rotation
+    double kv0, kv1, ka0, ka1;
+    if (!findVectorCoefficient(m_distance, initialCondition.velocity, kv0)
+        || !findVectorCoefficient(m_distance, initialCondition.acceleration, ka0)
+        || !findVectorCoefficient(m_distance, finalCondition.velocity, kv1)
+        || !findVectorCoefficient(m_distance, finalCondition.acceleration, ka1))
+    {
+        log()->error("{} The velocity and the boundary acceleration must be a linear dependent to "
+                     "the vector representing the axis between the two rotations.",
+                     logPrefix);
+        return false;
+    }
+
+    const double T = durationToSeconds(m_T);
+
+    polynomial.a0 = 0;
+    polynomial.a1 = kv0;
+    polynomial.a2 = ka0 / 2.0;
+    polynomial.a3 = -(12 * T * kv0 + 8 * T * kv1 + 3 * T * T * ka0 - T * T * ka1 - 20) //
+                    / (2 * T * T * T);
+    polynomial.a4 = (16 * T * kv0 + 14 * T * kv1 + 3 * T * T * ka0 - 2 * T * T * ka1 - 30)
+                    / (2 * T * T * T * T);
+    polynomial.a5 = -(6 * T * kv0 + 6 * T * kv1 + T * T * ka0 - T * T * ka1 - 12) //
+                    / (2 * T * T * T * T * T);
+
+    areCoefficientsComputed = true;
+
+    return true;
+}
+
+template <LieGroupTrivialization trivialization>
 bool SO3Planner<trivialization>::setRotations(const manif::SO3d& initialRotation,
                                               const manif::SO3d& finalRotation,
                                               const std::chrono::nanoseconds& duration)
 {
-
     constexpr auto logPrefix = "[SO3Planner::setRotation]";
 
     if (duration <= std::chrono::nanoseconds::zero())
@@ -43,15 +140,7 @@ bool SO3Planner<trivialization>::setRotations(const manif::SO3d& initialRotation
 
     m_initialRotation = initialRotation;
     m_T = duration;
-
-    if constexpr (trivialization == LieGroupTrivialization::Right)
-    {
-        m_distance = (finalRotation * initialRotation.inverse()).log();
-    } else
-    // Please read it as trivialization == LieGroupTrivialization::Left
-    {
-        m_distance = (initialRotation.inverse() * finalRotation).log();
-    }
+    m_distance = this->computeDistance(initialRotation, finalRotation);
 
     // reset the advance current time
     m_advanceCurrentTime = std::chrono::nanoseconds::zero();
@@ -60,7 +149,30 @@ bool SO3Planner<trivialization>::setRotations(const manif::SO3d& initialRotation
     m_state.rotation = m_initialRotation;
     m_state.velocity.setZero();
     m_state.acceleration.setZero();
+    this->areCoefficientsComputed = false;
 
+    return true;
+}
+
+template <LieGroupTrivialization trivialization>
+bool SO3Planner<trivialization>::setInitialConditions(const manif::SO3d::Tangent& velocity,
+                                                      const manif::SO3d::Tangent& acceleration)
+{
+    this->initialCondition.velocity = velocity;
+    this->initialCondition.acceleration = acceleration;
+    this->initialCondition.isSet = true;
+    this->areCoefficientsComputed = false;
+    return true;
+}
+
+template <LieGroupTrivialization trivialization>
+bool SO3Planner<trivialization>::setFinalConditions(const manif::SO3d::Tangent& velocity,
+                                                    const manif::SO3d::Tangent& acceleration)
+{
+    this->finalCondition.velocity = velocity;
+    this->finalCondition.acceleration = acceleration;
+    this->finalCondition.isSet = true;
+    this->areCoefficientsComputed = false;
     return true;
 }
 
@@ -69,9 +181,10 @@ template <class Derived>
 bool SO3Planner<trivialization>::evaluatePoint(const std::chrono::nanoseconds& time,
                                                manif::SO3d& rotation,
                                                manif::SO3TangentBase<Derived>& velocity,
-                                               manif::SO3TangentBase<Derived>& acceleration) const
+                                               manif::SO3TangentBase<Derived>& acceleration)
 {
     constexpr auto logPrefix = "[SO3Planner::evaluatePoint]";
+
     if (time < std::chrono::nanoseconds::zero() || time > m_T)
     {
         log()->error("{} The time has to be a real positive number between 0 and {}.",
@@ -80,8 +193,13 @@ bool SO3Planner<trivialization>::evaluatePoint(const std::chrono::nanoseconds& t
         return false;
     }
 
+    if (!this->computeCoefficients())
+    {
+        log()->error("{} Unable to compute the coefficients.", logPrefix);
+        return false;
+    }
+
     const double t = durationToSeconds(time);
-    const double T = durationToSeconds(m_T);
     // Compute the displacement in the tangent space
     // - displacement_tangent = log(finalRotation * initialRotation.inverse()) * s(t) (in case of
     //                                                                                 Right
@@ -91,10 +209,16 @@ bool SO3Planner<trivialization>::evaluatePoint(const std::chrono::nanoseconds& t
     //                                                                                 Trivialization)
     // You can find the computation of s in "Modern Robotics: Mechanics, Planning, and Control"
     // (Chapter 9.2)
-    // TODO (Giulio) avoid to use t / T you may use std::chrono::ratio
-    const double s = 10 * std::pow(t / T, 3)
-                     - 15 * std::pow(t / T, 4)
-                     + 6 * std::pow(t / T, 5);
+    const double t2 = t * t;
+    const double t3 = t * t2;
+    const double t4 = t * t3;
+    const double t5 = t * t4;
+    const double s = polynomial.a0 + //
+                     polynomial.a1 * t + //
+                     polynomial.a2 * t2 + //
+                     polynomial.a3 * t3 + //
+                     polynomial.a4 * t4 + //
+                     polynomial.a5 * t5;
     const manif::SO3d::Tangent displacementTangent = m_distance * s;
 
     if constexpr (trivialization == LieGroupTrivialization::Right)
@@ -110,28 +234,31 @@ bool SO3Planner<trivialization>::evaluatePoint(const std::chrono::nanoseconds& t
 
     // compute velocity (it is expressed in body / inertial frame accordingly to the chosen
     // trivialization)
-    // You can find the computation of sDot in "Modern Robotics: Mechanics, Planning, and Control"
+    // You can find the computation of dds in "Modern Robotics: Mechanics, Planning, and Control"
     // (Chapter 9.2)
-    const double sDot = 10 * 3 * std::pow(t, 2) / std::pow(T, 3)
-                        - 15 * 4 * std::pow(t, 3) / std::pow(T, 4)
-                        + 6 * 5 * std::pow(t, 4) / std::pow(T, 5);
-    velocity = m_distance * sDot;
+    const double ds = polynomial.a1 + //
+                      2 * polynomial.a2 * t + //
+                      3 * polynomial.a3 * t2 + //
+                      4 * polynomial.a4 * t3 + //
+                      5 * polynomial.a5 * t4;
+    velocity = m_distance * ds;
 
     // compute acceleration (it is expressed in body / inertial frame accordingly to the chosen
     // trivialization)
-    // You can find the computation of sDdot in "Modern Robotics: Mechanics,
+    // You can find the computation of dds in "Modern Robotics: Mechanics,
     // Planning, and Control" (Chapter 9.2)
-    const double sDdot = 10 * 3 * 2 * t / std::pow(T, 3)
-                         - 15 * 4 * 3 * std::pow(t, 2) / std::pow(T, 4)
-                         + 6 * 5 * 4 * std::pow(t, 3) / std::pow(T, 5);
-    acceleration = m_distance * sDdot;
+    const double dds = 2 * polynomial.a2 + //
+                       3 * 2 * polynomial.a3 * t + //
+                       4 * 3 * polynomial.a4 * t2 + //
+                       5 * 4 * polynomial.a5 * t3;
+    acceleration = m_distance * dds;
 
     return true;
 }
 
 template <LieGroupTrivialization trivialization>
 bool SO3Planner<trivialization>::evaluatePoint(const std::chrono::nanoseconds& time,
-                                               SO3PlannerState& state) const
+                                               SO3PlannerState& state)
 {
     return this->evaluatePoint(time, state.rotation, state.velocity, state.acceleration);
 }
@@ -181,6 +308,39 @@ template <LieGroupTrivialization trivialization>
 const SO3PlannerState& SO3Planner<trivialization>::getOutput() const
 {
     return m_state;
+}
+
+template <LieGroupTrivialization trivialization>
+manif::SO3d::Tangent SO3Planner<trivialization>::computeDistance(const manif::SO3d& initialRotation,
+                                                                 const manif::SO3d& finalRotation)
+{
+    if constexpr (trivialization == LieGroupTrivialization::Right)
+    {
+        return (finalRotation * initialRotation.inverse()).log();
+    } else
+    // Please read it as trivialization == LieGroupTrivialization::Left
+    {
+        return (initialRotation.inverse() * finalRotation).log();
+    }
+}
+
+template <LieGroupTrivialization trivialization>
+manif::SO3d::Tangent
+SO3Planner<trivialization>::projectTangentVector(const manif::SO3d& initialRotation,
+                                                 const manif::SO3d& finalRotation,
+                                                 const manif::SO3d::Tangent& vector)
+{
+    const manif::SO3d::Tangent distanceVector = computeDistance(initialRotation, finalRotation);
+    const double distance = distanceVector.coeffs().norm();
+    if (distance < 1e-4)
+    {
+        return manif::SO3d::Tangent::Zero();
+    }
+
+    // here we project vector on the vector named distance
+    manif::SO3d::Tangent ret;
+    ret.coeffs() =  distanceVector.coeffs().dot(vector.coeffs()) / distance * distanceVector.coeffs();
+    return ret;
 }
 
 } // namespace Planners

--- a/src/Planners/src/SwingFootPlanner.cpp
+++ b/src/Planners/src/SwingFootPlanner.cpp
@@ -274,6 +274,8 @@ bool SwingFootPlanner::createSE3Traj(Eigen::Ref<const Eigen::Vector2d> initialPl
     // The rotation cannot change when the contact list is updated. For this reason we can build the
     // trajectory considering the initial and the final conditions
     const auto T = nextContactPtr->activationTime - m_currentContactPtr->deactivationTime;
+    m_SO3Planner.setInitialConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero());
+    m_SO3Planner.setFinalConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero());
     if (!m_SO3Planner.setRotations(m_currentContactPtr->pose.asSO3(),
                                    nextContactPtr->pose.asSO3(),
                                    T))

--- a/src/Planners/src/SwingFootPlanner.cpp
+++ b/src/Planners/src/SwingFootPlanner.cpp
@@ -157,7 +157,11 @@ bool SwingFootPlanner::setContactList(const ContactList& contactList)
     // - Given the current time instant the both the original and the new contact list have an
     //   active contact at the same position.
     // - If the contact is not active we have to check that:
-    //    1. the final orientation didn't change
+    //    1. the final orientation may change still the error (in the tangent space) between the
+    //       new orientation and the current one should be parallel to the current velocity and
+    //       acceleration vectors. This is required to keep the SO3Planner problem still treatable
+    //       online. This check is not done here since the SO3Planner will complain in case of
+    //       issues.
     //    2. the swing foot trajectory duration did not change
 
     // Here the case where the contact is active
@@ -183,7 +187,12 @@ bool SwingFootPlanner::setContactList(const ContactList& contactList)
         && newContactAtCurrentTime != contactList.lastContact())
     {
         // we take the next contact of the new contact list and we check:
-        // 1. the final orientation didn't change
+        // 1. the final orientation may change still the error (in the tangent space) between the
+        //     new orientation and the current one should be parallel to the current velocity and
+        //     acceleration vectors. This is required to keep the SO3Planner problem still treatable
+        //     online. This check is not done here since the SO3Planner will complain in case of
+        //     issues.
+        //
         // 2. the swing foot trajectory duration didn't change
         auto newNextContactAtCurrentTime = std::next(newContactAtCurrentTime, 1);
 
@@ -197,21 +206,19 @@ bool SwingFootPlanner::setContactList(const ContactList& contactList)
         const auto newSwingFootTrajectoryDuration = newNextContactAtCurrentTime->activationTime
                                                     - newContactAtCurrentTime->deactivationTime;
 
-        if (!newNextContactAtCurrentTime->pose.quat().isApprox(
-                nextContactAtCurrentTime->pose.quat())
-            || newSwingFootTrajectoryDuration != originalSwingFootTrajectoryDuration)
+        if (newSwingFootTrajectoryDuration != originalSwingFootTrajectoryDuration)
         {
             log()->error("{} Failing to update the contact list. At the give time instant t = {} "
-                        "the foot is swinging. In order to update the conatct list we ask: 1) the "
-                        "final orientation didn't change. 2) the duration of the swing foot phase "
-                        "do not change. In this case we have. New Orientation {}, original "
-                        "orientation {}. New duration {}, original duration {}.",
-                        logPrefix,
-                        m_currentTrajectoryTime,
-                        newNextContactAtCurrentTime->pose.quat().coeffs().transpose(),
-                        nextContactAtCurrentTime->pose.quat().coeffs().transpose(),
-                        newSwingFootTrajectoryDuration,
-                        originalSwingFootTrajectoryDuration);
+                         "the foot is swinging. In order to update the conatct list we ask. The "
+                         "duration of the swing foot phase do not change. In this case we have. "
+                         "New Orientation {}, original orientation {}. New duration {}, original "
+                         "duration {}.",
+                         logPrefix,
+                         m_currentTrajectoryTime,
+                         newNextContactAtCurrentTime->pose.quat().coeffs().transpose(),
+                         nextContactAtCurrentTime->pose.quat().coeffs().transpose(),
+                         newSwingFootTrajectoryDuration,
+                         originalSwingFootTrajectoryDuration);
             return false;
         }
 
@@ -221,7 +228,9 @@ bool SwingFootPlanner::setContactList(const ContactList& contactList)
         if (!this->createSE3Traj(m_state.mixedVelocity.lin().head<2>(),
                                  m_state.mixedAcceleration.lin().head<2>(),
                                  m_state.mixedVelocity.lin().tail<1>(),
-                                 m_state.mixedAcceleration.lin().tail<1>()))
+                                 m_state.mixedAcceleration.lin().tail<1>(),
+                                 m_state.mixedVelocity.ang(),
+                                 m_state.mixedAcceleration.ang()))
         {
             log()->error("{} Unable to create the new SE(3) trajectory.", logPrefix);
             return false;
@@ -258,7 +267,9 @@ void SwingFootPlanner::setTime(const std::chrono::nanoseconds& time)
 bool SwingFootPlanner::createSE3Traj(Eigen::Ref<const Eigen::Vector2d> initialPlanarVelocity,
                                      Eigen::Ref<const Eigen::Vector2d> initialPlanarAcceleration,
                                      Eigen::Ref<const Vector1d> initialVerticalVelocity,
-                                     Eigen::Ref<const Vector1d> initialVerticalAcceleration)
+                                     Eigen::Ref<const Vector1d> initialVerticalAcceleration,
+                                     const manif::SO3d::Tangent& initialAngularVelocity,
+                                     const manif::SO3d::Tangent& initialAngularAcceleration)
 {
     constexpr auto logPrefix = "[SwingFootPlanner::createSE3Traj]";
 
@@ -273,18 +284,16 @@ bool SwingFootPlanner::createSE3Traj(Eigen::Ref<const Eigen::Vector2d> initialPl
 
     // The rotation cannot change when the contact list is updated. For this reason we can build the
     // trajectory considering the initial and the final conditions
-    const auto T = nextContactPtr->activationTime - m_currentContactPtr->deactivationTime;
-    m_SO3Planner.setInitialConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero());
+    m_staringTimeOfCurrentSO3Traj = m_currentTrajectoryTime;
+    const auto T = nextContactPtr->activationTime - m_staringTimeOfCurrentSO3Traj;
+    m_SO3Planner.setInitialConditions(initialAngularVelocity, initialAngularAcceleration);
     m_SO3Planner.setFinalConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero());
-    if (!m_SO3Planner.setRotations(m_currentContactPtr->pose.asSO3(),
-                                   nextContactPtr->pose.asSO3(),
-                                   T))
+    if (!m_SO3Planner.setRotations(m_state.transform.quat(), nextContactPtr->pose.asSO3(), T))
     {
         log()->error("{} Unable to set the initial and final rotations for the SO(3) planner.",
                      logPrefix);
         return false;
     }
-
 
     m_planarPlanner->setInitialConditions(initialPlanarVelocity, initialPlanarAcceleration);
     m_planarPlanner->setFinalConditions(Eigen::Vector2d::Zero(), Eigen::Vector2d::Zero());
@@ -309,7 +318,6 @@ bool SwingFootPlanner::createSE3Traj(Eigen::Ref<const Eigen::Vector2d> initialPl
     const std::chrono::nanoseconds footHeightViaPointTime
         = std::chrono::duration_cast<std::chrono::nanoseconds>(
             m_footApexTime * T + m_currentContactPtr->deactivationTime);
-
 
     m_heightPlanner->setInitialConditions(initialVerticalVelocity, initialVerticalAcceleration);
     m_heightPlanner->setFinalConditions(Vector1d::Constant(m_footLandingVelocity),
@@ -348,7 +356,7 @@ bool SwingFootPlanner::updateSE3Traj()
     constexpr auto logPrefix = "[SwingFootPlanner::updateSE3Traj]";
 
     // compute the trajectory at the current time
-    const auto shiftedTime = m_currentTrajectoryTime - m_currentContactPtr->deactivationTime;
+    const auto shiftedTime = m_currentTrajectoryTime - m_staringTimeOfCurrentSO3Traj;
 
     manif::SO3d rotation;
 
@@ -410,7 +418,8 @@ bool SwingFootPlanner::advance()
 
     if (m_contactList.size() == 0)
     {
-        log()->error("{} Empty contact list. Please call SwingFootPlanner::setContactList()", logPrefix);
+        log()->error("{} Empty contact list. Please call SwingFootPlanner::setContactList()",
+                     logPrefix);
         return false;
     }
 
@@ -463,7 +472,9 @@ bool SwingFootPlanner::advance()
         if (!this->createSE3Traj(Eigen::Vector2d::Zero(),
                                  Eigen::Vector2d::Zero(),
                                  Vector1d::Constant(m_footTakeOffVelocity),
-                                 Vector1d::Constant(m_footTakeOffAcceleration)))
+                                 Vector1d::Constant(m_footTakeOffAcceleration),
+                                 manif::SO3d::Tangent::Zero(),
+                                 manif::SO3d::Tangent::Zero()))
         {
             log()->error("{} Unable to create the new SE(3) trajectory.", logPrefix);
             return false;

--- a/src/Planners/tests/SO3PlannerTest.cpp
+++ b/src/Planners/tests/SO3PlannerTest.cpp
@@ -5,8 +5,8 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
-#include <chrono>
 #include <Eigen/Geometry> // Required because of https://github.com/artivis/manif/issues/162
+#include <chrono>
 
 // Catch2
 #include <catch2/catch_test_macros.hpp>
@@ -33,8 +33,10 @@ TEST_CASE("SO3 planner")
     SECTION("Left - Trivialized [Body]")
     {
         SO3PlannerBody planner;
-        REQUIRE(planner.setInitialConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero()));
-        REQUIRE(planner.setFinalConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero()));
+        REQUIRE(planner.setInitialConditions(manif::SO3d::Tangent::Zero(),
+                                             manif::SO3d::Tangent::Zero()));
+        REQUIRE(
+            planner.setFinalConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero()));
         REQUIRE(planner.setRotations(initialTranform, finalTranform, T));
 
         manif::SO3d rotation, predictedRotation;
@@ -52,7 +54,8 @@ TEST_CASE("SO3 planner")
         {
             // propagate the system
             predictedRotation = rotation + (velocity * std::chrono::duration<double>(dT).count());
-            predictedVelocity = velocity + (acceleration * std::chrono::duration<double>(dT).count());
+            predictedVelocity
+                = velocity + (acceleration * std::chrono::duration<double>(dT).count());
 
             planner.evaluatePoint(i * dT, rotation, velocity, acceleration);
 
@@ -69,8 +72,10 @@ TEST_CASE("SO3 planner")
     SECTION("Right - Trivialized [Inertial]")
     {
         SO3PlannerInertial planner;
-        REQUIRE(planner.setInitialConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero()));
-        REQUIRE(planner.setFinalConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero()));
+        REQUIRE(planner.setInitialConditions(manif::SO3d::Tangent::Zero(),
+                                             manif::SO3d::Tangent::Zero()));
+        REQUIRE(
+            planner.setFinalConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero()));
         REQUIRE(planner.setRotations(initialTranform, finalTranform, T));
 
         manif::SO3d rotation, predictedRotation;
@@ -88,7 +93,8 @@ TEST_CASE("SO3 planner")
         {
             // propagate the system
             predictedRotation = (velocity * std::chrono::duration<double>(dT).count()) + rotation;
-            predictedVelocity = velocity + (acceleration * std::chrono::duration<double>(dT).count());
+            predictedVelocity
+                = velocity + (acceleration * std::chrono::duration<double>(dT).count());
 
             planner.evaluatePoint(i * dT, rotation, velocity, acceleration);
 
@@ -108,7 +114,8 @@ TEST_CASE("SO3 planner")
         manif::SO3d::Tangent initialVelocity = (finalTranform * initialTranform.inverse()).log();
         initialVelocity.coeffs() = initialVelocity.coeffs() * 2;
         REQUIRE(planner.setInitialConditions(initialVelocity, manif::SO3d::Tangent::Zero()));
-        REQUIRE(planner.setFinalConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero()));
+        REQUIRE(
+            planner.setFinalConditions(manif::SO3d::Tangent::Zero(), manif::SO3d::Tangent::Zero()));
         REQUIRE(planner.setRotations(initialTranform, finalTranform, T));
 
         manif::SO3d rotation, predictedRotation;
@@ -126,7 +133,8 @@ TEST_CASE("SO3 planner")
         {
             // propagate the system
             predictedRotation = (velocity * std::chrono::duration<double>(dT).count()) + rotation;
-            predictedVelocity = velocity + (acceleration * std::chrono::duration<double>(dT).count());
+            predictedVelocity
+                = velocity + (acceleration * std::chrono::duration<double>(dT).count());
 
             planner.evaluatePoint(i * dT, rotation, velocity, acceleration);
 
@@ -138,5 +146,28 @@ TEST_CASE("SO3 planner")
         REQUIRE(rotation.isApprox(finalTranform, tolerance));
         REQUIRE(velocity.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
         REQUIRE(acceleration.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
+    }
+
+    SECTION("Right - Trivialized [Inertial] Projected Initial velocity")
+    {
+        SO3PlannerInertial planner;
+        manif::SO3d rotation, predictedRotation;
+        manif::SO3d::Tangent velocity, predictedVelocity;
+        manif::SO3d::Tangent acceleration;
+        manif::SO3d::Tangent initialVelocity = manif::SO3d::Tangent::Random();
+        REQUIRE(planner.setInitialConditions(initialVelocity, manif::SO3d::Tangent::Zero()));
+        REQUIRE(planner.setFinalConditions(manif::SO3d::Tangent::Zero(), //
+                                           manif::SO3d::Tangent::Zero()));
+        REQUIRE(planner.setRotations(initialTranform, finalTranform, T));
+
+        REQUIRE_FALSE(planner.evaluatePoint(0s, rotation, velocity, acceleration));
+
+        // update the initial velocity by projecting the previous one
+        initialVelocity = SO3PlannerInertial::projectTangentVector(initialTranform,
+                                                                   finalTranform,
+                                                                   initialVelocity);
+        REQUIRE(planner.setInitialConditions(initialVelocity, manif::SO3d::Tangent::Zero()));
+
+        REQUIRE(planner.evaluatePoint(0s, rotation, velocity, acceleration));
     }
 }

--- a/src/Planners/tests/SwingFootPlannerTest.cpp
+++ b/src/Planners/tests/SwingFootPlannerTest.cpp
@@ -84,7 +84,7 @@ ContactList createModifiedContactList()
 
     // third
     transform = manif::SE3d({0.5104, 0.415, 0.400},
-                            Eigen::AngleAxisd(2.0208, Eigen::Vector3d::UnitZ()));
+                            Eigen::AngleAxisd(2.4, Eigen::Vector3d::UnitZ()));
     REQUIRE(contactList.addContact(transform, 1s + 800ms, 2s + 700ms));
 
     // forth


### PR DESCRIPTION
Thanks to this PR we can update the contact list in the swing foot planner when the contact is not active and the new orientation is different from the previous one.

- [x] Publish the theory implemented in the planner
- [x] update the changelog