### PR TITLE
Fix standalone Python bindings workflow

### DIFF
--- a/bindings/python/Contacts/CMakeLists.txt
+++ b/bindings/python/Contacts/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_Contact)
+if(TARGET BipedalLocomotion::Contacts AND TARGET BipedalLocomotion::ContactDetectors)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/Contacts)
 

--- a/bindings/python/ContinuousDynamicalSystem/CMakeLists.txt
+++ b/bindings/python/ContinuousDynamicalSystem/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT). All rights reserved.
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
-if(FRAMEWORK_COMPILE_ContinuousDynamicalSystem)
+if(TARGET BipedalLocomotion::ContinuousDynamicalSystem)
   set(H_PREFIX include/BipedalLocomotion/bindings/ContinuousDynamicalSystem)
 
   add_bipedal_locomotion_python_module(

--- a/bindings/python/Conversions/CMakeLists.txt
+++ b/bindings/python/Conversions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_ManifConversions)
+if(TARGET BipedalLocomotion::ManifConversions)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/Conversions)
 

--- a/bindings/python/FloatingBaseEstimators/CMakeLists.txt
+++ b/bindings/python/FloatingBaseEstimators/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_FloatingBaseEstimators)
+if(TARGET BipedalLocomotion::FloatingBaseEstimators)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/FloatingBaseEstimators)
 

--- a/bindings/python/IK/CMakeLists.txt
+++ b/bindings/python/IK/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_IK)
+if(TARGET BipedalLocomotion::IK)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/IK)
 

--- a/bindings/python/ML/CMakeLists.txt
+++ b/bindings/python/ML/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_ML)
+if(TARGET BipedalLocomotion::ML)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/ML)
 

--- a/bindings/python/ParametersHandler/CMakeLists.txt
+++ b/bindings/python/ParametersHandler/CMakeLists.txt
@@ -13,7 +13,7 @@ add_bipedal_locomotion_python_module(
   )
 
 
-if(FRAMEWORK_COMPILE_YarpImplementation)
+if(TARGET BipedalLocomotion::ParametersHandlerYarpImplementation)
 
   add_bipedal_locomotion_python_module(
     NAME  ParametersHandlerYarpImplementationBindings
@@ -29,7 +29,7 @@ if(FRAMEWORK_COMPILE_YarpImplementation)
 endif()
 
 
-if(FRAMEWORK_COMPILE_TomlImplementation)
+if(TARGET BipedalLocomotion::ParametersHandlerTomlImplementation)
 
   add_bipedal_locomotion_python_module(
     NAME  ParametersHandlerTomlImplementationBindings

--- a/bindings/python/Planners/CMakeLists.txt
+++ b/bindings/python/Planners/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_Planners)
+if(TARGET BipedalLocomotion::Planners)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/Planners)
 
@@ -32,7 +32,7 @@ if(FRAMEWORK_COMPILE_Planners)
 
 endif()
 
-if(FRAMEWORK_COMPILE_Unicycle)
+if(TARGET BipedalLocomotion::Unicycle)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/Planners)
 

--- a/bindings/python/ReducedModelControllers/CMakeLists.txt
+++ b/bindings/python/ReducedModelControllers/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_ReducedModelControllers)
+if(TARGET BipedalLocomotion::ReducedModelControllers)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/ReducedModelControllers)
 

--- a/bindings/python/RobotInterface/CMakeLists.txt
+++ b/bindings/python/RobotInterface/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_RobotInterface AND FRAMEWORK_COMPILE_YarpImplementation)
+if(TARGET BipedalLocomotion::RobotInterface AND TARGET BipedalLocomotion::RobotInterfaceYarpImplementation)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/RobotInterface)
 

--- a/bindings/python/System/CMakeLists.txt
+++ b/bindings/python/System/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_System)
+if(TARGET BipedalLocomotion::System)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/System)
 
@@ -14,7 +14,7 @@ if(FRAMEWORK_COMPILE_System)
     TESTS tests/test_variables_handler.py
     )
 
-  if(FRAMEWORK_COMPILE_YarpImplementation)
+  if(TARGET BipedalLocomotion::SystemYarpImplementation)
 
     add_bipedal_locomotion_python_module(
       NAME  SystemYarpImplementationBindings
@@ -25,7 +25,7 @@ if(FRAMEWORK_COMPILE_System)
 
   endif()
 
-  if(FRAMEWORK_COMPILE_RosImplementation)
+  if(TARGET BipedalLocomotion::SystemRosImplementation)
 
     add_bipedal_locomotion_python_module(
       NAME  SystemRosImplementationBindings

--- a/bindings/python/TSID/CMakeLists.txt
+++ b/bindings/python/TSID/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_TSID)
+if(TARGET BipedalLocomotion::TSID)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/TSID)
 

--- a/bindings/python/TextLogging/CMakeLists.txt
+++ b/bindings/python/TextLogging/CMakeLists.txt
@@ -16,7 +16,7 @@ add_bipedal_locomotion_python_module(
   BipedalLocomotion::TextLogging
   )
 
-if(FRAMEWORK_COMPILE_RosImplementation)
+if(TARGET BipedalLocomotion::TextLoggingRosImplementation)
 
   add_bipedal_locomotion_python_module(
     NAME  TextLoggingRosImplementation
@@ -27,7 +27,7 @@ if(FRAMEWORK_COMPILE_RosImplementation)
 endif()
 
 
-if(FRAMEWORK_COMPILE_YarpImplementation)
+if(TARGET BipedalLocomotion::TextLoggingYarpImplementation)
 
   add_bipedal_locomotion_python_module(
     NAME  TextLoggingYarpImplementation

--- a/bindings/python/YarpUtilities/CMakeLists.txt
+++ b/bindings/python/YarpUtilities/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_YarpUtilities)
+if(TARGET BipedalLocomotion::YarpUtilities)
 
   set(H_PREFIX include/BipedalLocomotion/bindings/YarpUtilities)
 


### PR DESCRIPTION
https://github.com/ami-iit/bipedal-locomotion-framework/pull/697 introduced an untested and undocumented support for building the Python bindings in a standalone way against an existing compiled version of BLF, that we plan to use in conda-forge packaging. However, that patch was not complete as the CMakeLists.txt in `bindings/python` still referred to CMake options that do not exists if an external blf is used.

I am testing the patch in https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/30 .