### PR TITLE
conda-forge CI: Remove manifpy strict pin

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -38,10 +38,9 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        # manifpy is pinned as a workaround for https://github.com/ami-iit/bipedal-locomotion-framework/issues/674
         mamba install "idyntree>=8.0.0" "yarp>=3.5.0" libmatio libmatio-cpp librobometry \
                       liblie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog \
-                      nlohmann_json manif manifpy=*=*_12 pybind11 numpy pytest scipy opencv pcl \
+                      nlohmann_json manif manifpy pybind11 numpy pytest scipy opencv pcl \
                       tomlplusplus libunicycle-footstep-planner "icub-models>=1.23.4" \
                       ros-humble-rclcpp onnxruntime-cpp
 
@@ -49,7 +48,7 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
-        mamba install manifpy=*=*_12 expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 \
+        mamba install manifpy expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 \
                       libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 \
                       libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64 \
                       mesa-libgl-devel-cos6-x86_64


### PR DESCRIPTION
The pin was added in https://github.com/ami-iit/bipedal-locomotion-framework/pull/675 as a workaround for https://github.com/ami-iit/bipedal-locomotion-framework/issues/674 (root issue for reference: https://github.com/conda-forge/pybind11-feedstock/issues/77) until https://github.com/conda-forge/compilers-feedstock/pull/57 was merged. Now that https://github.com/conda-forge/compilers-feedstock/pull/57 was merged, we can remove the workaround.