### PR TITLE
Fix the time logging in YarpRobotLogger device

### DIFF
--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -1202,7 +1202,7 @@ void YarpRobotLoggerDevice::run()
         log()->error("{} Could not advance sensor bridge.", logPrefix);
     }
 
-    const double time = BipedalLocomotion::clock().now().count();
+    const double time = std::chrono::duration<double>(BipedalLocomotion::clock().now()).count();
 
     std::lock_guard lock(m_bufferManagerMutex);
     // collect the data


### PR DESCRIPTION
The time is now saved again in seconds and not in nanoseconds

Regression due to https://github.com/ami-iit/bipedal-locomotion-framework/pull/702


cc @gabrielenava @davidegorbani 