### PR TITLE
Attempt to use the c version of qhull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ env:
   YCM_TAG: v0.14.2
   YARP_TAG: v3.7.0
   iDynTree_TAG: v8.0.0
-  Qhull_TAG: 2020.2
   CasADi_TAG: 3.5.5.2
   manif_TAG: 0.0.4
   matioCpp_TAG: v0.2.0
@@ -128,8 +127,8 @@ jobs:
                              qtmultimedia5-dev libxml2-dev liburdfdom-dev libtinyxml-dev \
                              liburdfdom-dev liboctave-dev python3-dev valgrind coinor-libipopt-dev \
                              libmatio-dev python3-pytest python3-numpy python3-scipy \
-                             python3-setuptools  libspdlog-dev  libopencv-dev libpcl-dev \
-                             python3-pybind11 nlohmann-json3-dev libassimp-dev
+                             python3-setuptools  libspdlog-dev libopencv-dev libpcl-dev \
+                             python3-pybind11 nlohmann-json3-dev libassimp-dev libqhull-dev
         # install realsense from apt (see https://github.com/IntelRealSense/librealsense/blob/master/doc/distribution_linux.md#installing-the-packages)
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCD
         sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo $(lsb_release -cs) main" -u
@@ -158,7 +157,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/install/deps
-        key: source-deps-${{ runner.os }}-os-${{ matrix.os }}-build-type-${{ matrix.build_type }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-iDynTree-${{ env.iDynTree_TAG }}-qhull-${{ env.Qhull_TAG }}-casADi-${{ env.CasADi_TAG }}-manif-${{ env.manif_TAG }}-matioCpp-${{ env.matioCpp_TAG }}-LieGroupControllers-${{ env.LieGroupControllers_TAG }}-osqp-${{ env.osqp_TAG }}-osqp-eigen-${{ env.OsqpEigen_TAG }}-tomlplusplus-${{ env.tomlplusplus_TAG }}-unicycle-${{ env.UnicyclePlanner_TAG }}-icub-models-${{ env.icub_models_TAG }}-robometry-${{ env.telemetry_TAG }}
+        key: source-deps-${{ runner.os }}-os-${{ matrix.os }}-build-type-${{ matrix.build_type }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-iDynTree-${{ env.iDynTree_TAG }}-casADi-${{ env.CasADi_TAG }}-manif-${{ env.manif_TAG }}-matioCpp-${{ env.matioCpp_TAG }}-LieGroupControllers-${{ env.LieGroupControllers_TAG }}-osqp-${{ env.osqp_TAG }}-osqp-eigen-${{ env.OsqpEigen_TAG }}-tomlplusplus-${{ env.tomlplusplus_TAG }}-unicycle-${{ env.UnicyclePlanner_TAG }}-icub-models-${{ env.icub_models_TAG }}-robometry-${{ env.telemetry_TAG }}
 
 
     - name: Source-based Dependencies [Windows]
@@ -473,18 +472,6 @@ jobs:
       if: steps.cache-source-deps.outputs.cache-hit != 'true' && startsWith(matrix.os, 'ubuntu')
       shell: bash
       run: |
-        # Qhull
-        cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/qhull/qhull
-        cd qhull
-        git checkout ${Qhull_TAG}
-        mkdir -p build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps \
-              -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
-        cmake --build . --config ${{ matrix.build_type }} --target install -j${{env.NUM_CORES_FOR_CMAKE_BUILD}}
-
         # CppAD
         git clone https://github.com/coin-or/CppAD.git
         cd CppAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 - Use `std::chorno::nanoseconds` in `clock` and `AdvanceableRunner` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/702)
 - Give the possibility to set an external wrench in the `CentroidalDynamics` instead of a pure force (https://github.com/ami-iit/bipedal-locomotion-framework/pull/705)
+- Use c version of `qhull` in the Planner component. This fixes the compatibility with PCL in ubuntu 20.04 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/713)
 
 ### Fixed
 - Remove duplicated `find_package` in `BipedalLocomotionFrameworkDependencies.cmake` file (https://github.com/ami-iit/bipedal-locomotion-framework/pull/709)

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -37,9 +37,9 @@ checkandset_dependency(YARP MINIMUM_VERSION 3.7.0)
 dependency_classifier(YARP MINIMUM_VERSION 3.7.0 IS_USED ${FRAMEWORK_USE_YARP}
                       COMPONENTS companion profiler dev os idl_tools PUBLIC)
 
-find_package(Qhull 8.0.0 QUIET)
-checkandset_dependency(Qhull MINIMUM_VERSION 8.0.0)
-dependency_classifier(Qhull MINIMUM_VERSION 8.0.0 IS_USED ${FRAMEWORK_USE_Qhull} PUBLIC)
+find_package(Qhull QUIET)
+checkandset_dependency(Qhull MINIMUM_VERSION)
+dependency_classifier(Qhull MINIMUM_VERSION IS_USED ${FRAMEWORK_USE_Qhull} PRIVATE)
 
 find_package(casadi QUIET)
 checkandset_dependency(casadi)

--- a/cmake/FindQhull.cmake
+++ b/cmake/FindQhull.cmake
@@ -9,7 +9,7 @@ FindQhull
 This is just a simple compatibility script that ensures that Qhull
 provided by apt on Ubuntu 20.04 works fine with blf. It is not meant
 to work fine in general (it only defines the imported targets required by blf).
-Please remove as soon as Ubuntu 20.04 apt compatibiliy is dropped.
+Please remove as soon as Ubuntu 20.04 apt compatibility is dropped.
 
 #]=======================================================================]
 
@@ -21,7 +21,7 @@ find_package(Qhull CONFIG)
 if(Qhull_FOUND)
   find_package_handle_standard_args(Qhull CONFIG_MODE)
 else()
-  find_path(qhull_INCLUDE_DIR linqhull_r/libqhull_r.h)
+  find_path(qhull_INCLUDE_DIR libqhull_r/libqhull_r.h)
   mark_as_advanced(qhull_INCLUDE_DIR)
   find_library(qhull_r_LIBRARY qhull_r)
   mark_as_advanced(qhull_r_LIBRARY)

--- a/cmake/FindQhull.cmake
+++ b/cmake/FindQhull.cmake
@@ -1,0 +1,40 @@
+
+# SPDX-FileCopyrightText: 2023 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+#[=======================================================================[.rst:
+FindQhull
+-----------
+
+This is just a simple compatibility script that ensures that Qhull
+provided by apt on Ubuntu 20.04 works fine with blf. It is not meant
+to work fine in general (it only defines the imported targets required by blf).
+Please remove as soon as Ubuntu 20.04 apt compatibiliy is dropped.
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+# First of all, try if Qhull installs a config file
+find_package(Qhull CONFIG)
+
+if(Qhull_FOUND)
+  find_package_handle_standard_args(Qhull CONFIG_MODE)
+else()
+  find_path(qhull_INCLUDE_DIR linqhull_r/libqhull_r.h)
+  mark_as_advanced(qhull_INCLUDE_DIR)
+  find_library(qhull_r_LIBRARY qhull_r)
+  mark_as_advanced(qhull_r_LIBRARY)
+
+  find_package_handle_standard_args(Qhull DEFAULT_MSG qhull_INCLUDE_DIR qhull_r_LIBRARY)
+
+  if(Qhull_FOUND)
+    if(NOT TARGET Qhull::qhull_r)
+      add_library(Qhull::qhull_r UNKNOWN IMPORTED)
+      set_target_properties(Qhull::qhull_r PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${qhull_INCLUDE_DIR}")
+      set_property(TARGET Qhull::qhull_r PROPERTY
+        IMPORTED_LOCATION "${qhull_r_LIBRARY}")
+    endif()
+  endif()
+endif()

--- a/src/Planners/CMakeLists.txt
+++ b/src/Planners/CMakeLists.txt
@@ -31,8 +31,8 @@ if (FRAMEWORK_COMPILE_Planners)
     BipedalLocomotion::System
     BipedalLocomotion::Contacts
     PRIVATE_LINK_LIBRARIES
-    Qhull::qhullcpp
     Qhull::qhull_r
+    Qhull::libqhull
     casadi
     iDynTree::idyntree-core
     BipedalLocomotion::Math

--- a/src/Planners/CMakeLists.txt
+++ b/src/Planners/CMakeLists.txt
@@ -32,7 +32,6 @@ if (FRAMEWORK_COMPILE_Planners)
     BipedalLocomotion::Contacts
     PRIVATE_LINK_LIBRARIES
     Qhull::qhull_r
-    Qhull::libqhull
     casadi
     iDynTree::idyntree-core
     BipedalLocomotion::Math

--- a/src/Planners/src/ConvexHullHelper.cpp
+++ b/src/Planners/src/ConvexHullHelper.cpp
@@ -54,7 +54,7 @@ bool ConvexHullHelper::buildConvexHull(Eigen::Ref<const Eigen::MatrixXd> points)
 
     // set the input
     char flags[250];
-    sprintf(flags, "qhull");
+    sprintf(flags, "qhull ");
     int exitCode = qh_new_qhull(qh,
                                 numberOfCoordinates,
                                 numberOfPoints,

--- a/src/Planners/src/ConvexHullHelper.cpp
+++ b/src/Planners/src/ConvexHullHelper.cpp
@@ -5,7 +5,10 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+extern "C"
+{
 #include <libqhull_r/libqhull_r.h>
+}
 
 #include <BipedalLocomotion/Planners/ConvexHullHelper.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>


### PR DESCRIPTION
On ubuntu 22.04 I got the following error
```
usr/bin/ld: ../../../lib/libBipedalLocomotionFrameworkPlanners.so.0.14.200: undefined reference to `qh_new_qhull(int, int, double*, unsigned int, char*, _IO_FILE*, _IO_FILE*)'
/usr/bin/ld: ../../../lib/libBipedalLocomotionFrameworkPlanners.so.0.14.200: undefined reference to `qh_memfreeshort(int*, int*)'
/usr/bin/ld: ../../../lib/libBipedalLocomotionFrameworkPlanners.so.0.14.200: undefined reference to `qh_freeqhull(unsigned int)'
collect2: error: ld returned 1 exit status
make[3]: *** [src/Planners/tests/CMakeFiles/SwingFootPlannerUnitTests.dir/build.make:108: bin/SwingFootPlannerUnitTests] Error 1
make[2]: *** [CMakeFiles/Makefile2:3853: src/Planners/tests/CMakeFiles/SwingFootPlannerUnitTests.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:3860: src/Planners/tests/CMakeFiles/SwingFootPlannerUnitTests.dir/rule] Error 2
make: *** [Makefile:1141: SwingFootPlannerUnitTests] Error 2

```

with qhull installed via APT