### PR TITLE
Fix changelog-checker CI check

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Changelog check
-        uses: Zomzog/changelog-checker@v1.1.0
+        uses: Zomzog/changelog-checker@14fa5f86a23c48fddade9c0e0331b90844a8ea20
         with:
           fileName: CHANGELOG.md
           noChangelogLabel: '[disable changelog ci]'


### PR DESCRIPTION
Fix failure in the changelog-checker. The issue that created problems with v1.1.0 is https://github.com/Zomzog/changelog-checker/issues/53, it was fixed in https://github.com/Zomzog/changelog-checker/pull/55 so I used the commit corresponding to the lates master commit to get things to work. 

I checked that it fails (but with the correct error) if their is no label `[disable changelog ci]`, and that with the label it passes.