### PR TITLE
Introducing Metadata Support for Vectors Collection

### DIFF
--- a/src/YarpUtilities/thrifts/BipedalLocomotion/YarpUtilities/VectorsCollection.thrift
+++ b/src/YarpUtilities/thrifts/BipedalLocomotion/YarpUtilities/VectorsCollection.thrift
@@ -4,3 +4,16 @@ struct VectorsCollection
 {
     1: map<string, list<double>> vectors;
 }
+
+struct VectorsCollectionMetadata
+{
+    1: map<string, list<string>> vectors;
+}
+
+service VectorsCollectionMetadataService
+{
+    /**
+     * Read the sensor metadata necessary to interpret the data.
+     */
+    VectorsCollectionMetadata getMetadata();
+}


### PR DESCRIPTION
This PR introduces metadata for the `VectorsCollection`, allowing each component of the vector saved by the logger to have a specific label. This enhancement simplifies data analysis, as it enables the display of associated labels in the robot-log-visualizer, as shown in the following image:

![image](https://github.com/ami-iit/bipedal-locomotion-framework/assets/16744101/8f3dafb3-3550-4923-b5bb-f911c611e8c8)

To ensure metadata consistency, I've implemented it using the client-server paradigm in YARP. I declared the `VectorsCollectionMetadataService` in `VectorsCollection.thrift` (commit: cf151be70ad143f39113fea93ee851a79c84dff7). This change enables asynchronous metadata requests for a specific VectorsCollection, following the same paradigm used in `multipleananolgsensorserver` and `multipleananolgsensorclient`.

In this context, the `YarpRobotLoggerDevice` functions as a client, while the server must be implemented in the application sending the data. The application must expose two ports: a buffered port for streaming data and an rpc port for requesting metadata. The buffered port name should end with the string `\measures:o`, while the RPC port should end with `\rpc:o`.

Here's an example of how to use this feature in your code:

```cpp
#include <BipedalLocomotion/YarpUtilities/VectorsCollection.h>
#include <BipedalLocomotion/YarpUtilities/VectorsCollectionMetadataService.h>
#include <BipedalLocomotion/YarpUtilities/VectorsCollectionMetadata.h> 

class Module : public BipedalLocomotion::YarpUtilities::VectorsCollectionMetadataService
{
    yarp::os::BufferedPort<BipedalLocomotion::YarpUtilities::VectorsCollection> m_loggerPort; /**< Logger port. */
    yarp::os::Port m_loggerMetadataPort; /**< Logger metadata port. */
    BipedalLocomotion::YarpUtilities::VectorsCollectionMetadata m_loggerMetadata;

   /**
    * @brief Populate the metadata structure.
    */
    void populateMetadata();

public:
    /**
     * Get the metadata of the logged signals.
     * @return The metadata of the logged signals.
     */
    virtual BipedalLocomotion::YarpUtilities::VectorsCollectionMetadata getMetadata() override;
};
```
The `populateMetadata()` function is optional but can be useful for populating the metadata struct. The `getMetadata()` function is required to enable the YarpRobotLoggerDevice to retrieve the metadata.

In the source file, you should implement `Module::populateMetadata()` and `Module::getMetadata()`:

```cpp
void Module::populateMetadata()
{
    auto populateData = [this](const std::string& signal, const std::vector<std::string>& labels)
    {
        this->m_loggerMetadata.vectors[signal] = labels;
    };

    std::vector<std::string> signal3D{"x", "y", "z"};

    populateData("dcm::position::measured", signal3D);
    populateData("dcm::position::desired", signal3D);
};

BipedalLocomotion::YarpUtilities::VectorsCollectionMetadata
Module::getMetadata()
{
    return m_loggerMetadata;
}
```

To use this functionality, call `populateMetadata()` during the configuration phase. In this phase, open the `loggerPort` and the `loggerMetadataPort`. The connection is established automatically by the YarpRobotLoggerDevice:
```cpp
//This code should go into the configuration phase

this->populateMetadata();
std::string portPrefix = "module";

//Open the logger port
m_loggerPort.open("/" + portPrefix + "/measures:o");
        
// open the metadata rpc port
m_loggerMetadataPort.open("/" + portPrefix + "/rpc:o");
if (!BipedalLocomotion::YarpUtilities::VectorsCollectionMetadataService::yarp().attachAsServer(this->m_loggerMetadataPort))
{
    yError() << "[Module::configure] Unable to attach the logger metadata port.";
    return false;
}
```

In the main loop, add the following code to prepare and populate the data:

```cpp
BipedalLocomotion::YarpUtilities::VectorsCollection& data = m_loggerPort.prepare();
data.vectors.clear();

auto populateData = [&](const std::string& name, const auto& signal)
{
    data.vectors[name].assign(signal.data(), signal.data() + signal.size());
};

// DCM
populateData("dcm::position::measured", <signal>);
populateData("dcm::position::desired", <signal>);
```