### PR TITLE
Fix timestamp logging for the cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project are documented in this file.
 - Modify CI to install `RobotDynamicsEstimator` library (https://github.com/ami-iit/bipedal-locomotion-framework/pull/746)
 - Restructure the balancing-position-control script (https://github.com/ami-iit/bipedal-locomotion-framework/pull/716)
 
+### Fixed
+- Fix timestamp logging for the cameras (https://github.com/ami-iit/bipedal-locomotion-framework/pull/748)
+
 ## [0.15.0] - 2023-09-05
 ### Added
 - 🤖 Add the configuration files to use `YarpRobotLogger` with  `ergoCubGazeboV1` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/690)

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -63,7 +63,7 @@ VISITABLE_STRUCT(TextLoggingEntry,
                  yarprun_timestamp,
                  local_timestamp);
 
-void findAndReplaceAll(std::string& data, std::string toSearch, std::string replaceStr)
+void findAndReplaceAll(std::string& data, const std::string& toSearch, const std::string& replaceStr)
 {
     // Get the first occurrence
     size_t pos = data.find(toSearch);
@@ -1120,8 +1120,8 @@ void YarpRobotLoggerDevice::recordVideo(const std::string& cameraName, VideoWrit
                 std::lock_guard lock(m_bufferManagerMutex);
 
                 // TODO here we may save the frame itself
-                m_bufferManager.push_back(time.count(),
-                                          time.count(),
+                m_bufferManager.push_back(std::chrono::duration<double>(time).count(),
+                                          std::chrono::duration<double>(time).count(),
                                           "camera::" + cameraName + "::rgb");
             }
         }
@@ -1167,8 +1167,8 @@ void YarpRobotLoggerDevice::recordVideo(const std::string& cameraName, VideoWrit
                 std::lock_guard lock(m_bufferManagerMutex);
 
                 // TODO here we may save the frame itself
-                m_bufferManager.push_back(time.count(),
-                                          time.count(),
+                m_bufferManager.push_back(std::chrono::duration<double>(time).count(),
+                                          std::chrono::duration<double>(time).count(),
                                           "camera::" + cameraName + "::depth");
             }
         }


### PR DESCRIPTION
With this PR, I saved the timestamps of the frames collected with the YarpRobotLoggerDevice in seconds instead of nanoseconds.