### PR TITLE
Implement `RobotDynamicsEstimatorDevice` - PR6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project are documented in this file.
 - Finalize `RobotDynamicsEstimator` library and add complete library test (https://github.com/ami-iit/bipedal-locomotion-framework/pull/744)
 - Add Python bindings for `RobotDynamicsEstimator` library (https://github.com/ami-iit/bipedal-locomotion-framework/pull/755)
 - Add possibility to set the regularization on the mass matrix for the `TSID::JointDynamicsTask` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/722)
+- Implement `RobotDynamicsEstimatorDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/756)
 
 ### Changed
 - Remove the possibility to disable the telemetry in `System::AdvanceableRunner` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/726)

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -3,6 +3,7 @@
 # BSD-3-Clause license.
 
 add_subdirectory(FloatingBaseEstimatorDevice)
+add_subdirectory(RobotDynamicsEstimatorDevice)
 add_subdirectory(YarpRobotLoggerDevice)
 add_subdirectory(VectorsCollectionWrapper)
 

--- a/devices/RobotDynamicsEstimatorDevice/CMakeLists.txt
+++ b/devices/RobotDynamicsEstimatorDevice/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license.
+
+if(FRAMEWORK_COMPILE_YarpImplementation AND FRAMEWORK_COMPILE_RobotDynamicsEstimator AND FRAMEWORK_COMPILE_ManifConversions)
+    # Warning: the CONFIGURE_PACKAGE_NAME option should be different from the plugin NAME
+    add_bipedal_yarp_device(
+        NAME RobotDynamicsEstimatorDevice
+        TYPE BipedalLocomotion::RobotDynamicsEstimatorDevice
+        SOURCES src/RobotDynamicsEstimatorDevice.cpp
+        PUBLIC_HEADERS include/BipedalLocomotion/RobotDynamicsEstimatorDevice.h
+        PUBLIC_LINK_LIBRARIES ${YARP_LIBRARIES} ${iDynTree_LIBRARIES} BipedalLocomotion::YarpUtilities
+        BipedalLocomotion::RobotInterfaceYarpImplementation
+        BipedalLocomotion::ParametersHandlerYarpImplementation
+        BipedalLocomotion::RobotDynamicsEstimator
+        BipedalLocomotion::ManifConversions
+        BipedalLocomotion::VectorsCollection
+        CONFIGURE_PACKAGE_NAME robot_dynamics_estimator_device)
+endif()

--- a/devices/RobotDynamicsEstimatorDevice/README.md
+++ b/devices/RobotDynamicsEstimatorDevice/README.md
@@ -1,0 +1,27 @@
+# RobotDynamicsEstimatorDevice
+
+The **RobotDynamicsEstimatorDevice** is a YARP device based on `RobotDynamicsEstimator` to estimate joint torques from a YARP-based robot.
+
+
+## :running: How to use the device
+
+To run the device on a robot (whether in simulation or on a real robot), make sure to define the configuration files for the robot in the `app/robots` folder.
+
+- **ergoCubGazeboV1**
+
+  - open the robot model in Gazebo
+  - launch `RobotDynamicsEstimatorDevice`
+    ```
+    YARP_ROBOT_NAME=ergoCubGazeboV1 yarprobotinterface --config launch-robot-dynamics-estimator.xml
+    ```
+    in case you started gazebo with the real-time clock option (`gazebo -slibgazebo_yarp_clock.so`) add `YARP_CLOCK=/clock` to the previous command.
+    ```
+    YARP_CLOCK=/clock YARP_ROBOT_NAME=ergoCubGazeboV1 yarprobotinterface --config launch-robot-dynamics-estimator.xml
+    ```
+- **ergoCubSN000**
+
+  - Launch `yarprobotinterface` on the robot.
+  - launch `RobotDynamicsEstimatorDevice`
+    ```
+    YARP_ROBOT_NAME=ergoCubSN000 yarprobotinterface --config launch-robot-dynamics-estimator.xml
+    ```

--- a/devices/RobotDynamicsEstimatorDevice/app/CMakeLists.txt
+++ b/devices/RobotDynamicsEstimatorDevice/app/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license.
+
+# Get list of models
+subdirlist(subdirs ${CMAKE_CURRENT_SOURCE_DIR}/robots/)
+# Install each model
+foreach (dir ${subdirs})
+  yarp_install(DIRECTORY robots/${dir} DESTINATION ${YARP_ROBOTS_INSTALL_DIR})
+endforeach ()

--- a/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/interface-robot-dynamics-estimator/all_joints_mc.xml
+++ b/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/interface-robot-dynamics-estimator/all_joints_mc.xml
@@ -1,0 +1,13 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+BSD-3-Clause license. -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="all_joints_mc" type="remotecontrolboardremapper">
+    <param name="remoteControlBoards">("/ergocubSim/right_leg")</param>
+    <param name="axesNames">("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+    <param name="localPortPrefix">/robot_dynamics_estimator/joints</param>
+
+    <group name="REMOTE_CONTROLBOARD_OPTIONS">
+      <param name="carrier">udp</param>
+    </group>
+</device>

--- a/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/interface-robot-dynamics-estimator/ft_clients.xml
+++ b/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/interface-robot-dynamics-estimator/ft_clients.xml
@@ -1,0 +1,14 @@
+<!-- Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+     This software may be modified and distributed under the terms of the
+     BSD-3-Clause license. -->
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<devices>
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg_ft_client" type="multipleanalogsensorsclient">
+        <param name="remote">/ergocubSim/right_leg/FT</param>
+        <param name="local">/robot_dynamics_estimator/right_leg_hip</param>
+        <param name="timeout">0.5</param>
+        <param name="carrier">fast_tcp</param>
+    </device>
+
+</devices>

--- a/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/interface-robot-dynamics-estimator/mas-remapper.xml
+++ b/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/interface-robot-dynamics-estimator/mas-remapper.xml
@@ -1,0 +1,20 @@
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+     This software may be modified and distributed under the terms of the
+     BSD-3-Clause license. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="mas-remapper" type="multipleanalogsensorsremapper">
+  <param name="period">10</param>
+
+  <param name="SixAxisForceTorqueSensorsNames">
+    (r_leg_ft, r_foot_front_ft, r_foot_rear_ft)
+  </param>
+
+  <action phase="startup" level="5" type="attach">
+    <paramlist name="networks">
+      <elem name="right_leg_ft_client">right_leg_ft_client</elem>
+    </paramlist>
+  </action>
+
+  <action phase="shutdown" level="5" type="detach" />
+</device>

--- a/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/launch-robot-dynamics-estimator.xml
+++ b/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/launch-robot-dynamics-estimator.xml
@@ -1,0 +1,15 @@
+<!-- Copyright (C) 2019-2022 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+BSD-3-Clause license. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="ergoCubGazeboV1" portprefix="RobotDynamicsEstimator" build="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <xi:include href="interface-robot-dynamics-estimator/all_joints_mc.xml" />
+        <xi:include href="interface-robot-dynamics-estimator/mas-remapper.xml" />
+        <xi:include href="interface-robot-dynamics-estimator/ft_clients.xml" />
+        <xi:include href="./robot-dynamics-estimator.xml" />
+    </devices>
+</robot>

--- a/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/robot-dynamics-estimator.xml
+++ b/devices/RobotDynamicsEstimatorDevice/app/robots/ergoCubGazeboV1/robot-dynamics-estimator.xml
@@ -1,0 +1,172 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+BSD-3-Clause license. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="robot-dynamics-estimator" type="RobotDynamicsEstimatorDevice">
+    <group name="GENERAL">
+        <param name="sampling_time">0.01</param>
+        <param name="port_prefix">/robot-dynamics-estimator</param>
+    </group>
+
+    <group name="MODEL">
+        <param name="model_file">model.urdf</param>
+        <param name="base_link">root_link</param>
+        <param name="joint_list">("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+        <param name="gear_ratio">(100.0, -160.0, 100.0, 100.0, 100.0, 160.0)</param>
+        <param name="torque_constant">(0.111, 0.047, 0.047, 0.111, 0.111, 0.025)</param>
+
+        <group name="FT">
+            <param name="names">("r_leg_ft", "r_foot_front_ft", "r_foot_rear_ft")</param>
+            <param name="frames">("r_leg_ft", "r_foot_front_ft", "r_foot_rear_ft")</param>
+            <param name="associated_joints">("r_leg_ft_sensor", "r_foot_front_ft_sensor", "r_foot_rear_ft_sensor")</param>
+        </group>
+
+        <group name="ACCELEROMETER">
+            <param name="names">()</param>
+            <param name="frames">()</param>
+        </group>
+
+        <group name="GYROSCOPE">
+            <param name="names">()</param>
+            <param name="frames">()</param>
+        </group>
+
+        <group name="EXTERNAL_CONTACT">
+            <param name="frames">()</param>
+        </group>
+    </group>
+
+    <group name="RobotSensorBridge">
+        <param name="check_for_nan">false</param>
+        <param name="stream_joint_states">true</param>
+        <param name="stream_inertials">false</param>
+        <param name="stream_forcetorque_sensors">true</param>
+        <param name="stream_motor_states">true</param>
+
+        <group name="RemoteControlBoardRemapper">
+          <param name="joints_list">("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+        </group>
+
+        <group name="SixAxisForceTorqueSensors">
+          <param name="sixaxis_forcetorque_sensors_list">("r_leg_ft", "r_foot_front_ft", "r_foot_rear_ft")</param>
+        </group>
+    </group>
+
+    <group name="UKF">
+        <param name="alpha">1.0</param>
+        <param name="beta">2.0</param>
+        <param name="kappa">0.0</param>
+        <group name="UKF_STATE">
+            <!--param name="dynamics_list">
+                ("JOINT_VELOCITY", "MOTOR_TORQUE", "FRICTION_TORQUE", "RIGHT_LEG_FT", "RIGHT_FOOT_FRONT_FT", "RIGHT_FOOT_REAR_FT",
+                 "RIGHT_LEG_FT_BIAS", "RIGHT_FOOT_FRONT_FT_BIAS", "RIGHT_FOOT_REAR_FT_BIAS",
+                 "RIGHT_LEG_ACC_BIAS", "RIGHT_FOOT_FRONT_ACC_BIAS", "RIGHT_FOOT_REAR_ACC_BIAS",
+                 "RIGHT_LEG_GYRO_BIAS", "RIGHT_FOOT_FRONT_GYRO_BIAS", "RIGHT_FOOT_REAR_GYRO_BIAS")
+             </param-->
+             <param name="dynamics_list">
+                 ("JOINT_VELOCITY", "MOTOR_TORQUE", "FRICTION_TORQUE", "RIGHT_LEG_FT", "RIGHT_FOOT_FRONT_FT", "RIGHT_FOOT_REAR_FT")
+              </param>
+             <!-- Available models = ["ZeroVelocityStateDynamics", "JointVelocityStateDynamics", "FrictionTorqueStateDynamics"] -->
+             <group name="JOINT_VELOCITY">
+                <param name="name">ds</param>
+                <param name="elements">("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+                <param name="covariance">(1e-3, 1e-3, 1e-3, 1e-3, 1e-3, 1e-3)</param>
+                <param name="initial_covariance">(0.01, 0.01, 0.01, 0.01, 0.01, 0.01)</param>
+                <param name="dynamic_model">JointVelocityStateDynamics</param>
+             </group>
+             <group name="MOTOR_TORQUE">
+                <param name="name">tau_m</param>
+                <param name="elements">("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+                <param name="covariance">(1e-3, 1e-3, 1e-3, 1e-3, 1e-3, 1e-3)</param>
+                <param name="initial_covariance">(0.01, 0.01, 0.01, 0.01, 0.01, 0.01)</param>
+                <param name="dynamic_model">ZeroVelocityStateDynamics</param>
+             </group>
+             <group name="FRICTION_TORQUE">
+                <param name="name">tau_F</param>
+                <param name="elements">("r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+                <param name="covariance">(1e-1, 1e-1, 1e-1, 1e-1, 1e-1, 1e-1)</param>
+                <param name="initial_covariance">(0.01, 0.01, 0.01, 0.01, 0.01, 0.01)</param>
+                <param name="friction_k0">(0.001, 0.001, 0.001, 0.001, 0.001, 0.001)</param>
+                <param name="friction_k1">(0.01, 0.01, 0.01, 0.01, 0.01, 0.01)</param>
+                <param name="friction_k2">(0.01, 0.01, 0.01, 0.01, 0.01, 0.01)</param>
+                <param name="dynamic_model">FrictionTorqueStateDynamics</param>
+             </group>
+             <group name="RIGHT_LEG_FT">
+                <param name="name">r_leg_ft</param>
+                <param name="covariance">(1e-3, 1e-3, 1e-3, 1e-4, 1e-4, 1e-4)</param>
+                <param name="initial_covariance">(0.01, 0.01, 0.01, 0.01, 0.01, 0.01)</param>
+                <param name="dynamic_model">ZeroVelocityStateDynamics</param>
+             </group>
+             <group name="RIGHT_FOOT_FRONT_FT">
+                <param name="name">r_foot_front_ft</param>
+                <param name="covariance">(1e-3, 1e-3, 1e-3, 1e-6, 1e-6, 1e-6)</param>
+                <param name="initial_covariance">(0.01, 0.01, 0.01, 0.01, 0.01, 0.01)</param>
+                <param name="dynamic_model">ZeroVelocityStateDynamics</param>
+             </group>
+             <group name="RIGHT_FOOT_REAR_FT">
+                <param name="name">r_foot_rear_ft</param>
+                <param name="covariance">(1e-3, 1e-3, 1e-3, 1e-6, 1e-6, 1e-6)</param>
+                <param name="initial_covariance">(0.01, 0.01, 0.01, 0.01, 0.01, 0.01)</param>
+                <param name="dynamic_model">ZeroVelocityStateDynamics</param>
+             </group>
+        </group>
+
+        <group name="UKF_MEASUREMENT">
+            <!--param name="dynamics_list">
+                ("JOINT_VELOCITY", "MOTOR_CURRENT",
+                 "RIGHT_LEG_FT", "RIGHT_FOOT_FRONT_FT", "RIGHT_FOOT_REAR_FT",
+                 "RIGHT_LEG_ACC", "RIGHT_FOOT_FRONT_ACC", "RIGHT_FOOT_REAR_ACC",
+                 "RIGHT_LEG_GYRO", "RIGHT_FOOT_FRONT_GYRO", "RIGHT_FOOT_REAR_GYRO")
+             </param-->
+             <param name="dynamics_list">
+                 ("JOINT_VELOCITY", "MOTOR_CURRENT",
+                  "RIGHT_LEG_FT", "RIGHT_FOOT_FRONT_FT", "RIGHT_FOOT_REAR_FT")
+              </param>
+             <!-- Available models = ["ConstantMeasurementModel", "AccelerometerMeasurementDynamics",
+                                      "GyroscopeMeasurementDynamics", "MotorCurrentMeasurementDynamics"] -->
+             <group name="JOINT_VELOCITY">
+                <param name="name">ds</param>
+                <param name="covariance">(1e-1, 1e-1, 1e-1, 1e-1, 1e-1, 1e-1)</param>
+                <param name="dynamic_model">ConstantMeasurementModel</param>
+             </group>
+             <group name="MOTOR_CURRENT">
+                <param name="name">i_m</param>
+                <param name="covariance">(1e-2, 1e-2, 1e-1, 1e-1, 1e-1, 1e-1)</param>
+                <param name="gear_ratio">(100.0, -160.0, 100.0, 100.0, 100.0, 160.0)</param>
+                <param name="torque_constant">(0.111, 0.047, 0.047, 0.111, 0.111, 0.025)</param>
+                <param name="dynamic_model">MotorCurrentMeasurementDynamics</param>
+             </group>
+             <group name="RIGHT_LEG_FT">
+                <param name="name">r_leg_ft</param>
+                <param name="covariance">(1e-1, 1e-1, 1e-1, 1e-1, 1e-1, 1e-1)</param>
+                <param name="use_bias">false</param>
+                <param name="dynamic_model">ConstantMeasurementModel</param>
+             </group>
+             <group name="RIGHT_FOOT_FRONT_FT">
+                <param name="name">r_foot_front_ft</param>
+                <param name="covariance">(1e-1, 1e-1, 1e-1, 1e-1, 1e-1, 1e-1)</param>
+                <param name="use_bias">false</param>
+                <param name="dynamic_model">ConstantMeasurementModel</param>
+             </group>
+             <group name="RIGHT_FOOT_REAR_FT">
+                <param name="name">r_foot_rear_ft</param>
+                <param name="covariance">(1e-1, 1e-1, 1e-1, 1e-1, 1e-1, 1e-1)</param>
+                <param name="use_bias">false</param>
+                <param name="dynamic_model">ConstantMeasurementModel</param>
+             </group>
+        </group>
+    </group>
+
+    <!-- ATTACH -->
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="all_joints">all_joints_mc</elem>
+            <elem name="mas-remapper">mas-remapper</elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="2" type="detach" />
+    <!-- FINISH ATTACH-->
+
+</device>

--- a/devices/RobotDynamicsEstimatorDevice/include/BipedalLocomotion/RobotDynamicsEstimatorDevice.h
+++ b/devices/RobotDynamicsEstimatorDevice/include/BipedalLocomotion/RobotDynamicsEstimatorDevice.h
@@ -1,0 +1,243 @@
+/**
+ * @file RobotDynamicsEstimatorDevice.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_FRAMEWORK_ROBOT_DYNAMICS_ESTIMATOR_DEVICE_H
+#define BIPEDAL_LOCOMOTION_FRAMEWORK_ROBOT_DYNAMICS_ESTIMATOR_DEVICE_H
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/KinDynWrapper.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/RobotDynamicsEstimator.h>
+#include <BipedalLocomotion/RobotDynamicsEstimator/SubModel.h>
+#include <BipedalLocomotion/RobotInterface/YarpSensorBridge.h>
+#include <BipedalLocomotion/YarpUtilities/VectorsCollection.h>
+
+#include <iDynTree/Estimation/ContactStateMachine.h>
+#include <iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IFrameTransform.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IVirtualAnalogSensor.h>
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/os/ResourceFinder.h>
+
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+
+namespace BipedalLocomotion
+{
+class RobotDynamicsEstimatorDevice;
+}
+
+/**
+ * RobotDynamicsEstimatorDevice is a concrete class and implements yarp device.
+ * The device uses the RobotDynamicsEstimator library to estimate joint torques and
+ * external contact wrenches.
+ */
+class BipedalLocomotion::RobotDynamicsEstimatorDevice : public yarp::dev::DeviceDriver,
+                                                        public yarp::dev::IMultipleWrapper,
+                                                        public yarp::os::PeriodicThread
+{
+public:
+    /**
+     * Constructor.
+     */
+    RobotDynamicsEstimatorDevice(double period,
+                                 yarp::os::ShouldUseSystemClock useSystemClock
+                                 = yarp::os::ShouldUseSystemClock::No);
+    /**
+     * Constructor.
+     */
+    RobotDynamicsEstimatorDevice();
+
+    /**
+     * Destructor.
+     */
+    ~RobotDynamicsEstimatorDevice();
+
+    /**
+     * Open the DeviceDriver.
+     * @param config is a list of parameters for the device.
+     * @return true/false upon success/failure
+     */
+    virtual bool open(yarp::os::Searchable& config) final;
+
+    /**
+     * Close the DeviceDriver.
+     * @return true/false on success/failure.
+     */
+    virtual bool close() final;
+
+    /**
+     * Attach drivers to the device.
+     * @param poly is a yarp::dev::PolyDriverList object containing the list of drivers to attach.
+     * @return true/false on success/failure.
+     */
+    virtual bool attachAll(const yarp::dev::PolyDriverList& poly) final;
+
+    /**
+     * Detach drivers from the device.
+     * @return true/false on success/failure.
+     */
+    virtual bool detachAll() final;
+
+    /**
+     * Loop function. This is the thread itself.
+     * The thread calls the run() function every <period> ms.
+     */
+    virtual void run() final;
+
+private:
+    // class members
+    std::string m_portPrefix{"/rde"}; /**< Default port prefix. */
+    std::string m_robot{"ergocubSim"}; /**< Robot name. Default is ergocubSim. */
+    std::string m_baseLink{"root_link"}; /**< Base link name. Default is root_link. */
+    std::vector<std::string> m_jointNameList{}; /**< Joint name list. */
+    Eigen::VectorXd m_gearboxRatio; /**< Gearbox ratio list. */
+    Eigen::VectorXd m_torqueConstant; /**< Torque constant list. */
+    std::shared_ptr<iDynTree::KinDynComputations> m_kinDyn; /**< KinDynComputations object. */
+    std::unique_ptr<BipedalLocomotion::Estimators::RobotDynamicsEstimator::RobotDynamicsEstimator>
+        m_estimator; /**< RobotDynamicsEstimator object. */
+    std::unique_ptr<BipedalLocomotion::RobotInterface::YarpSensorBridge>
+        m_robotSensorBridge; /**<
+                             YarpSensorBridge
+                             object.
+                           */
+    yarp::os::BufferedPort<BipedalLocomotion::YarpUtilities::VectorsCollection>
+        m_loggerPort; /**<
+                         Logger
+                         port.
+                       */
+    std::unordered_map<std::string, Eigen::VectorXd> m_ftOffset; /**<
+                                                                    Map containing the offset for
+                                                                    the force torque sensors.
+                                                                  */
+    bool m_isFirstRun{true}; /**< Flag to check if it is the first run. */
+    iDynTree::ExtWrenchesAndJointTorquesEstimator
+        m_iDynEstimator; /**<
+                           iDynTree
+                           ExtWrenchesAndJointTorquesEstimator
+                           object.
+                         */
+    std::thread m_publishEstimationThread; /**< Thread to publish the estimation. */
+    struct EstimatorInput
+    {
+        std::mutex mutex;
+        BipedalLocomotion::Estimators::RobotDynamicsEstimator::RobotDynamicsEstimatorInput input;
+    } m_estimatorInput; /**< Estimator input. */
+    struct EstimatorOutput
+    {
+        std::mutex mutex;
+        BipedalLocomotion::Estimators::RobotDynamicsEstimator::RobotDynamicsEstimatorOutput output;
+    } m_estimatorOutput; /**< Estimator output. */
+    bool m_estimatorIsRunning; /**< Flag to check if the estimator is running. */
+    Eigen::VectorXd m_estimatedTauj; /**< Estimated joint torques. */
+    Eigen::VectorXd m_measuredTauj; /**< Measured joint torques. */
+    yarp::dev::PolyDriver m_remappedVirtualAnalogSensors; /**< Remapped virtual analog sensor
+                                                           containg the axes for which the joint
+                                                           torques estimates are published */
+    struct
+    {
+        yarp::dev::IVirtualAnalogSensor* ivirtsens;
+        yarp::dev::IMultipleWrapper* multwrap;
+    } m_remappedVirtualAnalogSensorsInterfaces; /**< Remapped virtual analog sensor interfaces. */
+    yarp::sig::Vector m_estimatedJointTorquesYARP; /**< Estimated joint torques in YARP format. */
+    Eigen::Vector3d m_temp3DMeasurement; /**< Temporary 3D measurement. */
+
+    // class methods
+    /**
+     * Setup the robot model from parameter handler.
+     * @param paramHandler is a pointer to the parameter handler.
+     * @param mdlLdr is a reference to the model loader.
+     * @return true/false on success/failure.
+     */
+    bool setupRobotModel(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler,
+                         iDynTree::ModelLoader& mdlLdr);
+
+    /**
+     * Create the SubModel list and the KinDynWrapper list for the robot dynamics estimator.
+     * @param paramHandler is a pointer to the parameter handler.
+     * @param modelLoader is a reference to the model loader.
+     * @param subModelList is a reference to the SubModel list.
+     * @param kinDynWrapperList is a reference to the KinDynWrapper list.
+     * @return true/false on success/failure.
+     */
+    bool
+    createSubModels(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler,
+                    iDynTree::ModelLoader& modelLoader,
+                    std::vector<Estimators::RobotDynamicsEstimator::SubModel>& subModelList,
+                    std::vector<std::shared_ptr<Estimators::RobotDynamicsEstimator::KinDynWrapper>>&
+                        kinDynWrapperList);
+
+    /**
+     * Setup the robot dynamics estimator.
+     * @param paramHandler is a pointer to the parameter handler.
+     * @return true/false on success/failure.
+     */
+    bool setupRobotDynamicsEstimator(
+        std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler);
+
+    /**
+     * Setup the robot sensor bridge.
+     * @param paramHandler is a pointer to the parameter handler.
+     * @return true/false on success/failure.
+     */
+    bool
+    setupRobotSensorBridge(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler);
+
+    /**
+     * Open the communication ports.
+     * @return true/false on success/failure.
+     */
+    bool openCommunications();
+
+    /**
+     * Update the measurements used by the estimator.
+     * @return true/false on success/failure.
+     */
+    bool updateMeasurements();
+
+    /**
+     * Resize the estimator initial state based on configuration.
+     * @param modelHandler is a pointer to the parameter handler.
+     * @return true/false on success/failure.
+     */
+    bool resizeEstimatorInitialState(
+        BipedalLocomotion::ParametersHandler::IParametersHandler::weak_ptr modelHandler);
+
+    /**
+     * Set the estimator initial state based on configuration.
+     * @return true/false on success/failure.
+     */
+    bool setEstimatorInitialState();
+
+    /**
+     * Resize the estimator measurement based on configuration.
+     * @param modelHandler is a pointer to the parameter handler.
+     * @return true/false on success/failure.
+     */
+    bool resizeEstimatorMeasurement(
+        BipedalLocomotion::ParametersHandler::IParametersHandler::weak_ptr modelHandler);
+
+    /**
+     * Published the estimator output.
+     * This is a separate thread.
+     */
+    void publishEstimatorOutput();
+
+    /**
+     * Open the remapper virtual sensors.
+     * @return true/false on success/failure.
+     */
+    bool openRemapperVirtualSensors();
+};
+
+#endif // BIPEDAL_LOCOMOTION_FRAMEWORK_ROBOT_DYNAMICS_ESTIMATOR_DEVICE_H

--- a/devices/RobotDynamicsEstimatorDevice/src/RobotDynamicsEstimatorDevice.cpp
+++ b/devices/RobotDynamicsEstimatorDevice/src/RobotDynamicsEstimatorDevice.cpp
@@ -1,0 +1,850 @@
+/**
+ * @file RobotDynamicsEstimatorDevice.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/RobotDynamicsEstimatorDevice.h>
+#include <BipedalLocomotion/System/Clock.h>
+#include <BipedalLocomotion/YarpUtilities/Helper.h>
+
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/yarp/YARPConversions.h>
+#include <yarp/eigen/Eigen.h>
+
+using namespace BipedalLocomotion;
+using namespace BipedalLocomotion::Estimators;
+using namespace BipedalLocomotion::RobotInterface;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+RobotDynamicsEstimatorDevice::RobotDynamicsEstimatorDevice(
+    double period, yarp::os::ShouldUseSystemClock useSystemClock)
+    : yarp::os::PeriodicThread(period, useSystemClock)
+{
+}
+
+RobotDynamicsEstimatorDevice::RobotDynamicsEstimatorDevice()
+    : yarp::os::PeriodicThread(0.01, yarp::os::ShouldUseSystemClock::No)
+{
+}
+
+RobotDynamicsEstimatorDevice::~RobotDynamicsEstimatorDevice() = default;
+
+bool RobotDynamicsEstimatorDevice::setupRobotModel(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler,
+    iDynTree::ModelLoader& mdlLdr)
+{
+    constexpr auto logPrefix = "[RobotDynamicsEstimatorDevice::setupRobotModel]";
+
+    auto ptr = paramHandler.lock();
+
+    std::string modelFileName;
+    std::vector<std::string> ftJointList;
+
+    if (!ptr->getParameter("base_link", m_baseLink))
+    {
+        log()->info("{} The parameter 'base_link' is not provided. The default one "
+                    "will be used {}.",
+                    logPrefix,
+                    m_baseLink);
+    }
+
+    if (!ptr->getParameter("model_file", modelFileName))
+    {
+        log()->error("{} Could not find parameter `model_file`.", logPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("joint_list", m_jointNameList))
+    {
+        log()->error("{} Could not find parameter `joint_list`.", logPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("gear_ratio", m_gearboxRatio))
+    {
+        log()->error("{} Could not find parameter `gear_ratio`", logPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("torque_constant", m_torqueConstant))
+    {
+        log()->error("{} Could not find parameter `torque_constant`", logPrefix);
+        return false;
+    }
+
+    auto ftGroup = ptr->getGroup("FT").lock();
+    if (ftGroup == nullptr)
+    {
+        log()->error("{} Group `FT` does not exist.", logPrefix);
+        return false;
+    }
+    if (!ftGroup->getParameter("associated_joints", ftJointList))
+    {
+        log()->error("{} Could not find parameter `associated_joints` in group `ft`.", logPrefix);
+        return false;
+    }
+
+    yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
+    std::string modelFilePath{rf.findFileByName(modelFileName)};
+    log()->info("{} Loading model from {}", logPrefix, modelFilePath);
+
+    std::vector<std::string> jointsAndFTs;
+    jointsAndFTs.insert(jointsAndFTs.begin(), m_jointNameList.begin(), m_jointNameList.end());
+    jointsAndFTs.insert(jointsAndFTs.end(), ftJointList.begin(), ftJointList.end());
+
+    if (!mdlLdr.loadReducedModelFromFile(modelFilePath, jointsAndFTs))
+    {
+        log()->error("{} Could not load robot model", logPrefix);
+        return false;
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::createSubModels(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler,
+    iDynTree::ModelLoader& modelLoader,
+    std::vector<SubModel>& subModelList,
+    std::vector<std::shared_ptr<KinDynWrapper>>& kinDynWrapperList)
+{
+    constexpr auto logPrefix = "[RobotDynamicsEstimatorDevice::createSubModels]";
+
+    SubModelCreator subModelCreator;
+    subModelCreator.setModelAndSensors(m_kinDyn->model(), modelLoader.sensors());
+    if (!subModelCreator.setKinDyn(m_kinDyn))
+    {
+        log()->error("{} Failed while setting the KinDynComputation object to the SubModelCreator "
+                     "object.",
+                     logPrefix);
+        return false;
+    }
+
+    if (!subModelCreator.createSubModels(paramHandler))
+    {
+        log()->error("{} Failed while creating the list of SubModel objects.", logPrefix);
+        return false;
+    }
+    subModelList = subModelCreator.getSubModelList();
+
+    for (int idx = 0; idx < subModelList.size(); idx++)
+    {
+        kinDynWrapperList.emplace_back(std::make_shared<KinDynWrapper>());
+        if (!kinDynWrapperList[idx]->setModel(subModelList[idx]))
+        {
+            log()->error("{} Failed while initializing the `KinDynWrapper` object "
+                         "associated to the submodel with index `{}`.",
+                         logPrefix,
+                         idx);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::setupRobotSensorBridge(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto logPrefix = "[RobotDynamicsEstimatorDevice::setupRobotSensorBridge]";
+
+    auto groupSensorBridge = paramHandler.lock()->getGroup("RobotSensorBridge").lock();
+    if (groupSensorBridge == nullptr)
+    {
+        log()->error("{} Missing required group `RobotSensorBridge`.", logPrefix);
+        return false;
+    }
+
+    m_robotSensorBridge = std::make_unique<YarpSensorBridge>();
+    if (!m_robotSensorBridge->initialize(groupSensorBridge))
+    {
+        log()->error("{} Could not configure RobotSensorBridge.", logPrefix);
+        return false;
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::resizeEstimatorInitialState(
+    IParametersHandler::weak_ptr modelHandler)
+{
+    m_estimatorOutput.output.ds.resize(m_kinDyn->model().getNrOfDOFs());
+    m_estimatorOutput.output.tau_m.resize(m_kinDyn->model().getNrOfDOFs());
+    m_estimatorOutput.output.tau_F.resize(m_kinDyn->model().getNrOfDOFs());
+    m_estimatedTauj.resize(m_kinDyn->model().getNrOfDOFs());
+    m_measuredTauj.resize(m_kinDyn->model().getNrOfDOFs());
+    m_estimatedJointTorquesYARP.resize(m_kinDyn->model().getNrOfDOFs());
+
+    std::vector<std::string> ftList;
+    auto ftGroup = modelHandler.lock()->getGroup("FT").lock();
+    if (!ftGroup->getParameter("names", ftList))
+    {
+        return false;
+    }
+
+    for (const auto& ft : ftList)
+    {
+        m_estimatorOutput.output.ftWrenches[ft] = Eigen::VectorXd::Zero(6);
+
+        std::string ftBias = ft + "_bias";
+        m_estimatorOutput.output.ftWrenchesBiases[ftBias] = Eigen::VectorXd(6).setZero(); // FT bias
+    }
+
+    std::vector<std::string> contactList;
+    auto contactGroup = modelHandler.lock()->getGroup("EXTERNAL_CONTACT").lock();
+    if (!contactGroup->getParameter("frames", contactList))
+    {
+        return false;
+    }
+    for (const auto& contact : contactList)
+    {
+        m_estimatorOutput.output.contactWrenches[contact] = Eigen::VectorXd::Zero(6);
+    }
+
+    std::vector<std::string> accList;
+    auto accGroup = modelHandler.lock()->getGroup("ACCELEROMETER").lock();
+    if (!accGroup->getParameter("names", accList))
+    {
+        return false;
+    }
+    for (auto acc : accList)
+    {
+        std::string accBias = acc + "_bias";
+        m_estimatorOutput.output.accelerometerBiases[accBias] = Eigen::VectorXd::Zero(3); // ACC
+                                                                                          // BIAS
+    }
+
+    std::vector<std::string> gyroList;
+    auto gyroGroup = modelHandler.lock()->getGroup("GYROSCOPE").lock();
+    if (!gyroGroup->getParameter("names", gyroList))
+    {
+        return false;
+    }
+    for (auto gyro : gyroList)
+    {
+        std::string gyroBias = gyro + "_bias";
+        m_estimatorOutput.output.gyroscopeBiases[gyroBias] = Eigen::VectorXd(3).setZero(); // GYRO
+                                                                                           // BIAS
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::setEstimatorInitialState()
+{
+    Eigen::VectorXd s(m_kinDyn->model().getNrOfDOFs());
+    Eigen::VectorXd dds(m_kinDyn->model().getNrOfDOFs());
+
+    if (!m_robotSensorBridge->getJointPositions(s))
+    {
+        return false;
+    }
+    if (!m_robotSensorBridge->getJointVelocities(m_estimatorOutput.output.ds))
+    {
+        return false;
+    }
+    if (!m_robotSensorBridge->getJointAccelerations(dds))
+    {
+        return false;
+    }
+
+    m_estimatorOutput.output.tau_F.setZero();
+
+    // Set contact information and specify the unknown wrench on the base link
+    auto fixedFrameIdx = m_iDynEstimator.model().getFrameIndex(m_baseLink);
+    auto fullBodyUnknowns = iDynTree::LinkUnknownWrenchContacts(m_iDynEstimator.model());
+    fullBodyUnknowns.clear();
+    fullBodyUnknowns.addNewUnknownFullWrenchInFrameOrigin(m_iDynEstimator.model(), fixedFrameIdx);
+
+    // Initialize variables for estimation
+    auto expectedFT = iDynTree::SensorsMeasurements(m_iDynEstimator.sensors());
+    auto estimatedContacts = iDynTree::LinkContactWrenches(m_iDynEstimator.model());
+    auto estimatedTau = iDynTree::JointDOFsDoubleArray(m_iDynEstimator.model());
+
+    iDynTree::Vector3 gravity;
+    gravity.zero();
+    gravity.setVal(2, -BipedalLocomotion::Math::StandardAccelerationOfGravitation);
+
+    auto sidyn = iDynTree::JointPosDoubleArray(m_iDynEstimator.model());
+    auto dsidyn = iDynTree::JointDOFsDoubleArray(m_iDynEstimator.model());
+    auto ddsidyn = iDynTree::JointDOFsDoubleArray(m_iDynEstimator.model());
+
+    for (int index = 0; index < sidyn.size(); index++)
+    {
+        sidyn.setVal(index, s[index]);
+        dsidyn.setVal(index, m_estimatorOutput.output.ds[index]);
+        ddsidyn.setVal(index, dds[index]);
+    }
+
+    if (!m_iDynEstimator
+             .updateKinematicsFromFixedBase(sidyn, dsidyn, ddsidyn, fixedFrameIdx, gravity))
+    {
+        return false;
+    }
+
+    if (!m_iDynEstimator.computeExpectedFTSensorsMeasurements(fullBodyUnknowns,
+                                                              expectedFT,
+                                                              estimatedContacts,
+                                                              estimatedTau))
+    {
+        return false;
+    }
+
+    std::unordered_map<std::string, Eigen::VectorXd> ftFromModel;
+    auto ftWrench = iDynTree::Wrench();
+    for (auto& [key, value] : m_estimatorOutput.output.ftWrenches)
+    {
+        auto ftIndex
+            = m_iDynEstimator.sensors().getSensorIndex(iDynTree::SIX_AXIS_FORCE_TORQUE, key);
+
+        if (ftIndex == iDynTree::FRAME_INVALID_INDEX)
+        {
+            return false;
+        }
+
+        if (!expectedFT.getMeasurement(iDynTree::SIX_AXIS_FORCE_TORQUE, ftIndex, ftWrench))
+        {
+            return false;
+        }
+        ftFromModel[key] = iDynTree::toEigen(ftWrench);
+
+        if (!m_robotSensorBridge
+                 ->getSixAxisForceTorqueMeasurement(key, m_estimatorOutput.output.ftWrenches[key]))
+        {
+            return false;
+        }
+
+        m_ftOffset[key] = m_estimatorOutput.output.ftWrenches[key] - ftFromModel[key];
+        m_estimatorOutput.output.ftWrenches[key] = ftFromModel[key];
+        std::string ftBias = key + "_bias";
+        m_estimatorOutput.output.ftWrenchesBiases[ftBias].setZero(); // FT bias
+    }
+
+    if (!m_robotSensorBridge->getMotorCurrents(m_estimatorOutput.output.tau_m))
+    {
+        return false;
+    }
+    Eigen::VectorXd temp(m_gearboxRatio.size());
+    temp = m_gearboxRatio.array() * m_torqueConstant.array();
+    m_estimatorOutput.output.tau_m = m_estimatorOutput.output.tau_m.array() * temp.array();
+
+    if (!m_estimator->setInitialState(m_estimatorOutput.output))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::resizeEstimatorMeasurement(
+    IParametersHandler::weak_ptr modelHandler)
+{
+    m_estimatorInput.input.jointPositions.resize(m_kinDyn->model().getNrOfDOFs());
+    m_estimatorInput.input.jointVelocities.resize(m_kinDyn->model().getNrOfDOFs());
+    m_estimatorInput.input.motorCurrents.resize(m_kinDyn->model().getNrOfDOFs());
+
+    std::vector<std::string> ftList;
+    auto ftGroup = modelHandler.lock()->getGroup("FT").lock();
+    if (!ftGroup->getParameter("names", ftList))
+    {
+        return false;
+    }
+
+    for (const auto& ft : ftList)
+    {
+        m_estimatorInput.input.ftWrenches[ft] = Eigen::VectorXd::Zero(6);
+    }
+
+    std::vector<std::string> accList;
+    auto accGroup = modelHandler.lock()->getGroup("ACCELEROMETER").lock();
+    if (!accGroup->getParameter("names", accList))
+    {
+        return false;
+    }
+    for (auto acc : accList)
+    {
+        m_estimatorInput.input.linearAccelerations[acc] = Eigen::VectorXd::Zero(3); // ACC BIAS
+    }
+
+    std::vector<std::string> gyroList;
+    auto gyroGroup = modelHandler.lock()->getGroup("GYROSCOPE").lock();
+    if (!gyroGroup->getParameter("names", gyroList))
+    {
+        return false;
+    }
+    for (auto gyro : gyroList)
+    {
+        m_estimatorInput.input.angularVelocities[gyro] = Eigen::VectorXd(3).setZero(); // GYRO BIAS
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::setupRobotDynamicsEstimator(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto logPrefix = "[RobotDynamicsEstimatorDevice::setupRobotDynamicsEstimator]";
+
+    auto modelGroupHandler = paramHandler.lock()->getGroup("MODEL").lock();
+    if (modelGroupHandler == nullptr)
+    {
+        log()->error("{} Group `MODEL` not found in configuration.", logPrefix);
+        return false;
+    }
+
+    iDynTree::ModelLoader modelLoader;
+    if (!setupRobotModel(modelGroupHandler, modelLoader))
+    {
+        log()->error("{} Failed while setting the robot model.", logPrefix);
+        return false;
+    }
+
+    m_kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    if (!m_kinDyn->loadRobotModel(modelLoader.model()))
+    {
+        log()->error("{} Failed while setting the robot model to the KinDynComputation object.",
+                     logPrefix);
+        return false;
+    }
+    if (!m_kinDyn->setFrameVelocityRepresentation(iDynTree::BODY_FIXED_REPRESENTATION))
+    {
+        log()->error("{} Failed while setting the frame velocity representation.", logPrefix);
+        return false;
+    }
+
+    if (!m_iDynEstimator.setModelAndSensors(m_kinDyn->model(), modelLoader.sensors()))
+    {
+        log()->error("{} Impossible to create ExtWrenchesAndJointTorquesEstimator.", logPrefix);
+        return false;
+    }
+
+    std::vector<SubModel> subModelList;
+    std::vector<std::shared_ptr<KinDynWrapper>> kinDynWrapperList;
+    if (!createSubModels(modelGroupHandler, modelLoader, subModelList, kinDynWrapperList))
+    {
+        log()->error("{} Failed while creating the objects needed to handle the sub-models.",
+                     logPrefix);
+        return false;
+    }
+
+    m_estimator = BipedalLocomotion::Estimators::RobotDynamicsEstimator::RobotDynamicsEstimator::
+        build(paramHandler, m_kinDyn, subModelList, kinDynWrapperList);
+    if (m_estimator == nullptr)
+    {
+        log()->error("{} Could not create the RobotDynamicsEstimator object.", logPrefix);
+        return false;
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::open(yarp::os::Searchable& config)
+{
+    constexpr auto logPrefix = "[RobotDynamicsEstimatorDevice::open]";
+    auto params = std::make_shared<ParametersHandler::YarpImplementation>(config);
+
+    auto generalGroupHandler = params->getGroup("GENERAL").lock();
+    if (generalGroupHandler == nullptr)
+    {
+        log()->error("{} Group `GENERAL` not found in configuration.", logPrefix);
+        return false;
+    }
+    double devicePeriod{0.01};
+    if (generalGroupHandler->getParameter("sampling_time", devicePeriod))
+    {
+        this->setPeriod(devicePeriod);
+    } else
+    {
+        generalGroupHandler->setParameter("sampling_time", devicePeriod);
+        if (!params->setGroup("GENERAL", generalGroupHandler))
+        {
+            log()->error("{} Could not set group `GENERAL`.", logPrefix);
+            return false;
+        }
+    }
+
+    if (!generalGroupHandler->getParameter("robot", m_robot))
+    {
+        log()->info("{} The parameter 'robot' is not provided. The default one "
+                    "will be used {}.",
+                    logPrefix,
+                    m_robot);
+    }
+
+    if (!generalGroupHandler->getParameter("port_prefix", m_portPrefix))
+    {
+        log()->info("{} The parameter 'port_prefix' is not provided. The default one "
+                    "will be used {}.",
+                    logPrefix,
+                    m_portPrefix);
+    }
+
+    if (!setupRobotSensorBridge(params))
+    {
+        log()->error("{} Could not setup the RobotSensorBridge.", logPrefix);
+        return false;
+    }
+
+    if (!setupRobotDynamicsEstimator(params))
+    {
+        log()->error("{} Could not configure the estimator.", logPrefix);
+        return false;
+    }
+
+    auto modelGroupHandler = params->getGroup("MODEL").lock();
+    if (modelGroupHandler == nullptr)
+    {
+        log()->error("{} Group `MODEL` not found in configuration.", logPrefix);
+        return false;
+    }
+    if (!resizeEstimatorInitialState(modelGroupHandler))
+    {
+        log()->error("{} Could not resize the RobotDynamicsEstimator state.", logPrefix);
+        return false;
+    }
+    if (!resizeEstimatorMeasurement(modelGroupHandler))
+    {
+        log()->error("{} Could not resize the RobotDynamicsEstimator input.", logPrefix);
+        return false;
+    }
+
+    if (!openRemapperVirtualSensors())
+    {
+        log()->error("{} Could not open virtual analog sensors remapper.", logPrefix);
+        return false;
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::openCommunications()
+{
+    if (!m_loggerPort.open(m_portPrefix + "/data:o"))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::openRemapperVirtualSensors()
+{
+    constexpr auto logPrefix = "[RobotDynamicsEstimatorDevice::openRemapperVirtualSensors]";
+    // Pass to the remapper just the relevant parameters (axesList)
+    yarp::os::Property propRemapper;
+    propRemapper.put("device", "virtualAnalogRemapper");
+
+    propRemapper.addGroup("axesNames");
+    yarp::os::Bottle& bot = propRemapper.findGroup("axesNames").addList();
+    for (size_t i = 0; i < m_jointNameList.size(); i++)
+    {
+        bot.addString(m_jointNameList[i].c_str());
+    }
+
+    if (!m_remappedVirtualAnalogSensors.open(propRemapper))
+    {
+        log()->error("{} Error opening the virtual analog sensor port", logPrefix);
+        return false;
+    }
+
+    // View relevant interfaces for the remappedVirtualAnalogSensors
+    bool ok
+        = m_remappedVirtualAnalogSensors.view(m_remappedVirtualAnalogSensorsInterfaces.ivirtsens);
+    ok = ok
+         && m_remappedVirtualAnalogSensors.view(m_remappedVirtualAnalogSensorsInterfaces.multwrap);
+
+    if (!ok)
+    {
+        log()->error("{} Could not find the necessary interfaces in remappedControlBoard",
+                     logPrefix);
+        return ok;
+    }
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::attachAll(const yarp::dev::PolyDriverList& poly)
+{
+    constexpr auto logPrefix = "[RobotDynamicsEstimatorDevice::attachAll]";
+
+    if (!m_robotSensorBridge->setDriversList(poly))
+    {
+        log()->error("{} Failed to attach to devices through RobotSensorBridge.", logPrefix);
+        return false;
+    }
+
+    if (!m_remappedVirtualAnalogSensorsInterfaces.multwrap->attachAll(poly))
+    {
+        log()->error("{} Could not attach virtual sensors.", logPrefix);
+        return false;
+    }
+
+    if (!openCommunications())
+    {
+        log()->error("{} Could not open ports for publishing outputs.", logPrefix);
+        return false;
+    }
+
+    // run the thread
+    m_publishEstimationThread = std::thread([this] { this->publishEstimatorOutput(); });
+
+    start();
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::updateMeasurements()
+{
+    m_estimatorInput.input.basePose.setIdentity();
+    m_estimatorInput.input.baseVelocity.setZero();
+    m_estimatorInput.input.baseAcceleration.setZero();
+
+    if (!m_robotSensorBridge->getJointPositions(m_estimatorInput.input.jointPositions))
+    {
+        return false;
+    }
+
+    if (!m_robotSensorBridge->getJointVelocities(m_estimatorInput.input.jointVelocities))
+    {
+        return false;
+    }
+
+    if (!m_robotSensorBridge->getMotorCurrents(m_estimatorInput.input.motorCurrents))
+    {
+        return false;
+    }
+
+    for (auto& [key, value] : m_estimatorInput.input.ftWrenches)
+    {
+        if (!m_robotSensorBridge
+                 ->getSixAxisForceTorqueMeasurement(key, m_estimatorInput.input.ftWrenches[key]))
+        {
+            return false;
+        }
+        m_estimatorInput.input.ftWrenches[key] -= m_ftOffset[key];
+    }
+
+    for (auto& [key, value] : m_estimatorInput.input.linearAccelerations)
+    {
+        if (!m_robotSensorBridge->getLinearAccelerometerMeasurement(key,
+                                                                    m_estimatorInput.input
+                                                                        .linearAccelerations[key]))
+        {
+            return false;
+        }
+    }
+
+    for (auto& [key, value] : m_estimatorInput.input.angularVelocities)
+    {
+        if (!m_robotSensorBridge->getGyroscopeMeasure(key,
+                                                      m_estimatorInput.input.angularVelocities[key]))
+        {
+            return false;
+        }
+    }
+
+    m_robotSensorBridge->getJointTorques(m_measuredTauj);
+
+    return true;
+}
+
+void RobotDynamicsEstimatorDevice::publishEstimatorOutput()
+{
+    constexpr auto logPrefix = "[RobotDynamicsEstimatorDevice::publishEstimatorOutput]";
+
+    auto time = BipedalLocomotion::clock().now();
+    auto oldTime = time;
+    auto wakeUpTime = time;
+    const auto publishOutputPeriod = std::chrono::duration<double>(0.01);
+
+    m_estimatorIsRunning = true;
+
+    while (m_estimatorIsRunning)
+    {
+        auto& data = m_loggerPort.prepare();
+        data.vectors.clear();
+
+        // detect if a clock has been reset
+        oldTime = time;
+        time = BipedalLocomotion::clock().now();
+        // if the current time is lower than old time, the timer has been reset.
+        if ((time - oldTime).count() < 1e-12)
+        {
+            wakeUpTime = time;
+        }
+        wakeUpTime = std::chrono::duration_cast<std::chrono::nanoseconds>(wakeUpTime
+                                                                          + publishOutputPeriod);
+
+        {
+
+            std::lock_guard<std::mutex> lockOutput(m_estimatorOutput.mutex);
+
+            data.vectors["ds::estimated"].assign(m_estimatorOutput.output.ds.data(),
+                                                 m_estimatorOutput.output.ds.data()
+                                                     + m_estimatorOutput.output.ds.size());
+            data.vectors["tau_m::estimated"].assign(m_estimatorOutput.output.tau_m.data(),
+                                                    m_estimatorOutput.output.tau_m.data()
+                                                        + m_estimatorOutput.output.tau_m.size());
+            data.vectors["tau_F::estimated"].assign(m_estimatorOutput.output.tau_F.data(),
+                                                    m_estimatorOutput.output.tau_F.data()
+                                                        + m_estimatorOutput.output.tau_F.size());
+
+            m_estimatedTauj = m_estimatorOutput.output.tau_m - m_estimatorOutput.output.tau_F;
+            data.vectors["tau_j::estimated"].assign(m_estimatedTauj.data(),
+                                                    m_estimatedTauj.data()
+                                                        + m_estimatedTauj.size());
+            data.vectors["tau_j::measured"].assign(m_measuredTauj.data(),
+                                                   m_measuredTauj.data() + m_measuredTauj.size());
+
+            for (auto& [key, value] : m_estimatorOutput.output.ftWrenches)
+            {
+                data.vectors["fts::" + key + "::estimated"].assign(value.data(),
+                                                                   value.data() + value.size());
+            }
+            for (auto& [key, value] : m_estimatorOutput.output.contactWrenches)
+            {
+                data.vectors["contacts::" + key + "::estimated"].assign(value.data(),
+                                                                        value.data()
+                                                                            + value.size());
+            }
+            for (auto& [key, value] : m_estimatorOutput.output.ftWrenchesBiases)
+            {
+                data.vectors["fts_biases::" + key + "::estimated"].assign(value.data(),
+                                                                          value.data()
+                                                                              + value.size());
+            }
+            for (auto& [key, value] : m_estimatorOutput.output.accelerometerBiases)
+            {
+                data.vectors["accelerometer_biases::" + key + "::estimated"]
+                    .assign(value.data(), value.data() + value.size());
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lockInput(m_estimatorInput.mutex);
+
+            data.vectors["im::measured"].assign(m_estimatorInput.input.motorCurrents.data(),
+                                                m_estimatorInput.input.motorCurrents.data()
+                                                    + m_estimatorInput.input.motorCurrents.size());
+            data.vectors["ds::measured"].assign(m_estimatorInput.input.jointVelocities.data(),
+                                                m_estimatorInput.input.jointVelocities.data()
+                                                    + m_estimatorInput.input.jointVelocities.size());
+            for (auto& [key, value] : m_estimatorInput.input.ftWrenches)
+            {
+                data.vectors["fts::" + key + "::measured"].assign(value.data(),
+                                                                  value.data() + value.size());
+            }
+            for (auto& [key, value] : m_estimatorInput.input.linearAccelerations)
+            {
+                data.vectors["accelerometers::" + key + "::measured"].assign(value.data(),
+                                                                             value.data()
+                                                                                 + value.size());
+            }
+            for (auto& [key, value] : m_estimatorInput.input.angularVelocities)
+            {
+                data.vectors["gyroscopes::" + key + "::measured"].assign(value.data(),
+                                                                         value.data()
+                                                                             + value.size());
+            }
+        }
+        m_loggerPort.write();
+
+        // Publish on WBD ports
+        yarp::eigen::toEigen(m_estimatedJointTorquesYARP) = m_estimatedTauj;
+        m_remappedVirtualAnalogSensorsInterfaces.ivirtsens->updateVirtualAnalogSensorMeasure(
+            m_estimatedJointTorquesYARP);
+
+        // release the CPU
+        BipedalLocomotion::clock().yield();
+
+        // sleep
+        BipedalLocomotion::clock().sleepUntil(wakeUpTime);
+    }
+}
+
+void RobotDynamicsEstimatorDevice::run()
+{
+    constexpr auto logPrefix = "[RobotDynamicsEstimatorDevice::run]";
+
+    // advance sensor bridge
+    if (!m_robotSensorBridge->advance())
+    {
+        log()->warn("{} Advance Sensor bridge failed.", logPrefix);
+        return;
+    }
+
+    if (m_isFirstRun)
+    {
+        if (!setEstimatorInitialState())
+        {
+            log()->error("{} Could not set estimator initial state", logPrefix);
+            detachAll();
+            close();
+            return;
+        }
+
+        m_isFirstRun = false;
+    }
+
+    // update estimator measurements
+    {
+        std::lock_guard<std::mutex> lockInput(m_estimatorInput.mutex);
+        if (!updateMeasurements())
+        {
+            log()->error("{} Measurement updates failed.", logPrefix);
+            return;
+        }
+
+        if (!m_estimator->setInput(m_estimatorInput.input))
+        {
+            log()->error("{} Could not set estimator input.", logPrefix);
+            return;
+        }
+    }
+
+    if (!m_estimator->advance())
+    {
+        log()->warn("{} Advance RobotDynamicsEstimator failed.", logPrefix);
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lockOutput(m_estimatorOutput.mutex);
+        m_estimatorOutput.output = m_estimator->getOutput();
+    }
+
+    return;
+}
+
+bool RobotDynamicsEstimatorDevice::detachAll()
+{
+    if (isRunning())
+    {
+        stop();
+    }
+
+    m_remappedVirtualAnalogSensorsInterfaces.multwrap->detachAll();
+
+    return true;
+}
+
+bool RobotDynamicsEstimatorDevice::close()
+{
+    m_estimatorIsRunning = false;
+    if (m_publishEstimationThread.joinable())
+    {
+        m_publishEstimationThread.join();
+    }
+
+    m_remappedVirtualAnalogSensors.close();
+
+    if (!m_loggerPort.isClosed())
+    {
+        m_loggerPort.close();
+    }
+
+    return true;
+}


### PR DESCRIPTION
This is the last PR for the `RobotDynamicsEstimator`. It implements the device that will be running on the robot and uses the full `RDE` library. I tested the device in simulation by commenting out the readings of the motor currents (not available in Gazebo) and by setting them manually.