### PR TITLE
Add missing include(FetchContent) in bindings/python/RobotInterface/CMakeLists.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 - Fix timestamp logging for the cameras (https://github.com/ami-iit/bipedal-locomotion-framework/pull/748)
+- Fix missing include(FetchContent) in Python bindings CMake code (https://github.com/ami-iit/bipedal-locomotion-framework/pull/757)
 
 ## [0.15.0] - 2023-09-05
 ### Added

--- a/bindings/python/RobotInterface/CMakeLists.txt
+++ b/bindings/python/RobotInterface/CMakeLists.txt
@@ -27,6 +27,7 @@ if(TARGET BipedalLocomotion::RobotInterface
   # https://github.com/pybind/pybind11/commit/74a767d42921001fc4569ecee3b8726383c42ad4
   # https://github.com/pybind/pybind11/pull/2864
   if (${pybind11_VERSION} VERSION_GREATER_EQUAL "2.7.0")
+    include(FetchContent)
     FetchContent_Declare(
       cvnp
       GIT_REPOSITORY https://github.com/pthom/cvnp


### PR DESCRIPTION
Fix "standalone" Python bindings build used in conda-forge builds.