### PR TITLE
Add process dynamics class for external contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 - Implement `MANN::generateDummyMANNOutput` and `MANN::generateDummyMANNInput` in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/771)
 - Add `MANNAutoregressive` and `MANNTrajectoryGenerator` examples (https://github.com/ami-iit/bipedal-locomotion-framework/pull/771)
 - Implement `Spline::evaluateOrderedPoints` to evaluate the spline at a set of time ordered points (https://github.com/ami-iit/bipedal-locomotion-framework/pull/773)
+- Add process model for external contacts in `RobotDynamicsEstimator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/759)
 
 ### Changed
 - Restructure of the `CentroidalMPC` class in `ReducedModelControllers` component. Specifically, the `CentroidalMPC` now provides a contact phase list instead of indicating the next active contact. Additionally, users can now switch between `ipopt` and `sqpmethod` to solve the optimization problem. Furthermore, the update allows for setting the warm-start for the non-linear solver. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/766)
@@ -17,6 +18,7 @@ All notable changes to this project are documented in this file.
 - Restructure `MANNTrajectoryGenerator` to remove the need for foot positions in `setInitialState` and enhanced reset capabilities. Corrected position and time scaling for precise CoM, base, and feet positioning (https://github.com/ami-iit/bipedal-locomotion-framework/pull/771)
 - Move `Spline` into `Math` component. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/773)
 - Deprecate `Planners::Spline`, `Planners::QuinticSpline`, `Planners::CubicSpline` in favor of `Math::Spline`, `Math::QuinticSpline`, `Math::CubicSpline` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/773)
+- Change use of dynamics name for fts, contacts, accelerometers, gyroscopes in `RobotDynamicsEstimator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/759)
 
 ### Fixed
 

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -30,12 +30,13 @@ if(FRAMEWORK_COMPILE_RobotDynamicsEstimator)
     SOURCES                 src/SubModel.cpp src/KinDynWrapper.cpp src/Dynamics.cpp src/ZeroVelocityStateDynamics.cpp src/JointVelocityStateDynamics.cpp
                             src/ConstantMeasurementModel.cpp src/AccelerometerMeasurementDynamics.cpp src/GyroscopeMeasurementDynamics.cpp
                             src/FrictionTorqueStateDynamics.cpp src/MotorCurrentMeasurementDynamics.cpp src/UkfModel.cpp
-                            src/UkfState.cpp src/UkfMeasurement.cpp src/RobotDynamicsEstimator.cpp
+                            src/UkfState.cpp src/UkfMeasurement.cpp src/RobotDynamicsEstimator.cpp src/ExternalContactStateDynamics.cpp
     SUBDIRECTORIES          tests/RobotDynamicsEstimator
     PUBLIC_HEADERS          ${H_PREFIX}/SubModel.h ${H_PREFIX}/KinDynWrapper.h ${H_PREFIX}/Dynamics.h ${H_PREFIX}/ZeroVelocityStateDynamics.h
                             ${H_PREFIX}/JointVelocityStateDynamics.h ${H_PREFIX}/ConstantMeasurementModel.h ${H_PREFIX}/AccelerometerMeasurementDynamics.h
                             ${H_PREFIX}/GyroscopeMeasurementDynamics.h ${H_PREFIX}/FrictionTorqueStateDynamics.h ${H_PREFIX}/MotorCurrentMeasurementDynamics.h
                             ${H_PREFIX}/UkfModel.h ${H_PREFIX}/UkfState.h ${H_PREFIX}/UkfMeasurement.h ${H_PREFIX}/RobotDynamicsEstimator.h
+                            ${H_PREFIX}/ExternalContactStateDynamics.h
     PUBLIC_LINK_LIBRARIES   BipedalLocomotion::ParametersHandler MANIF::manif BipedalLocomotion::System BipedalLocomotion::Math iDynTree::idyntree-high-level
                             iDynTree::idyntree-core iDynTree::idyntree-model iDynTree::idyntree-modelio Eigen3::Eigen BayesFilters::BayesFilters
                             BipedalLocomotion::ManifConversions

--- a/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/ExternalContactStateDynamics.h
+++ b/src/Estimators/include/BipedalLocomotion/RobotDynamicsEstimator/ExternalContactStateDynamics.h
@@ -1,0 +1,113 @@
+/**
+ * @file ExternalContactStateDynamics.h
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_EXTERNAL_CONTACT_STATE_DYNAMICS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_EXTERNAL_CONTACT_STATE_DYNAMICS_H
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/Dynamics.h>
+#include <memory>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+namespace RobotDynamicsEstimator
+{
+
+/**
+ * The ExternalContactStateDynamics class is a concrete implementation of the Dynamics.
+ * Please use this element if you do not know the specific dynamics of a state variable.
+ * The ExternalContactStateDynamics represents the following equation in the continuous time:
+ * \f[
+ * \dot{x} = - k x
+ * \f]
+ * In the discrete time the following dynamics assigns the current state to the next state:
+ * \f[
+ * x_{k+1} = x_{k} + \Delta t (- k x_{k})
+ * \f]
+ */
+class ExternalContactStateDynamics : public Dynamics
+{
+    Eigen::VectorXd m_currentState; /**< Current state. */
+    std::string m_name; /**< Name of dynamics. */
+    std::vector<std::string> m_elements = {}; /**< Elements composing the variable vector. */
+    System::VariablesHandler m_stateVariableHandler; /**< Variable handler describing the variables
+                                                        and the sizes in the ukf state vector. */
+    std::chrono::nanoseconds m_dT{std::chrono::nanoseconds::zero()}; /**< Sampling time. */
+    Eigen::VectorXd m_k; /**< Model constant. */
+
+    /**
+     * Controls whether the variable handler contains the variables on which the dynamics depend.
+     * @return True in case all the dependencies are contained in the variable handler, false
+     * otherwise.
+     */
+    bool checkStateVariableHandler() override;
+
+public:
+    /**
+     * Initialize the state dynamics.
+     * @param paramHandler pointer to the parameters handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name           |   Type   |                                       Description                                                       | Mandatory |
+     * |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------:|:---------:|
+     * |               `name`               | `string` |   Name of the state contained in the `VariablesHandler` describing the state associated to this dynamics|    Yes    |
+     * |            `covariance`            | `vector` |                                Process covariances                                                      |    Yes    |
+     * |         `initial_covariance`       | `vector` |                             Initial state covariances                                                   |    Yes    |
+     * |           `dynamic_model`          | `string` |               Type of dynamic model describing the state dynamics.                                      |    Yes    |
+     * |             `elements`             | `vector` |  Vector of strings describing the list of sub variables composing the state associated to this dynamics.|    No     |
+     * @return True in case of success, false otherwise.
+     */
+    bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+
+    /**
+     * Finalize the Dynamics.
+     * @param stateVariableHandler object describing the variables in the state vector.
+     * @note You should call this method after you add ALL the state dynamics to the state variable
+     * handler.
+     * @return true in case of success, false otherwise.
+     */
+    bool finalize(const System::VariablesHandler& stateVariableHandler) override;
+
+    /**
+     * Set the KinDynWrapper object.
+     * @param subModelList list of SubModel objects
+     * @param kinDynWrapperList list of pointers to KinDynWrapper objects.
+     * @return True in case of success, false otherwise.
+     */
+    bool
+    setSubModels(const std::vector<SubModel>& subModelList,
+                 const std::vector<std::shared_ptr<KinDynWrapper>>& kinDynWrapperList) override;
+
+    /**
+     * Update the content of the element.
+     * @return True in case of success, false otherwise.
+     */
+    bool update() override;
+
+    /**
+     * Set the state of the ukf needed to update the dynamics of the state/measurement variable
+     * associated to ths object.
+     * @param ukfState reference to the ukf state.
+     */
+    void setState(const Eigen::Ref<const Eigen::VectorXd> ukfState) override;
+
+    /**
+     * Set a `UKFInput` object.
+     * @param ukfInput reference to the UKFInput struct.
+     */
+    void setInput(const UKFInput& ukfInput) override;
+
+}; // class ExternalContactStateDynamics
+
+BLF_REGISTER_UKF_DYNAMICS(ExternalContactStateDynamics,
+                          ::BipedalLocomotion::Estimators::RobotDynamicsEstimator::Dynamics);
+
+} // namespace RobotDynamicsEstimator
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_EXTERNAL_CONTACT_STATE_DYNAMICS_H

--- a/src/Estimators/src/ExternalContactStateDynamics.cpp
+++ b/src/Estimators/src/ExternalContactStateDynamics.cpp
@@ -1,0 +1,148 @@
+/**
+ * @file ExternalContactStateDynamics.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/ExternalContactStateDynamics.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+namespace RDE = BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+
+bool RDE::ExternalContactStateDynamics::initialize(
+    std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler)
+{
+    constexpr auto errorPrefix = "[ExternalContactStateDynamics::initialize]";
+
+    auto ptr = paramHandler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The parameter handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    // Set the state dynamics name
+    if (!ptr->getParameter("name", m_name))
+    {
+        log()->error("{} Error while retrieving the name variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state process covariance
+    if (!ptr->getParameter("covariance", m_covariances))
+    {
+        log()->error("{} Error while retrieving the covariance variable.", errorPrefix);
+        return false;
+    }
+
+    // Set the state initial covariance
+    if (!ptr->getParameter("initial_covariance", m_initialCovariances))
+    {
+        log()->error("{} Variable initial_covariance not found.", errorPrefix);
+        return false;
+    }
+
+    // Set the list of elements if it exists
+    if (!ptr->getParameter("elements", m_elements))
+    {
+        log()->debug("{} Variable elements not found.", errorPrefix);
+    }
+
+    if (!ptr->getParameter("sampling_time", m_dT))
+    {
+        log()->error("{} Error while retrieving the sampling_time variable.", errorPrefix);
+        return false;
+    }
+
+    if (!ptr->getParameter("k", m_k))
+    {
+        log()->error("{} Error while retrieving the friction_k2 variable.", errorPrefix);
+        return false;
+    }
+
+    m_description = "Zero velocity dynamics";
+
+    m_isInitialized = true;
+
+    return true;
+}
+
+bool RDE::ExternalContactStateDynamics::finalize(
+    const System::VariablesHandler& stateVariableHandler)
+{
+    constexpr auto errorPrefix = "[ExternalContactStateDynamics::finalize]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the dynamics before calling finalize.", errorPrefix);
+        return false;
+    }
+
+    if (stateVariableHandler.getNumberOfVariables() == 0)
+    {
+        log()->error("{} The state variable handler is empty.", errorPrefix);
+        return false;
+    }
+
+    m_stateVariableHandler = stateVariableHandler;
+
+    if (!checkStateVariableHandler())
+    {
+        log()->error("{} The state variable handler is not valid.", errorPrefix);
+        return false;
+    }
+
+    m_size = m_covariances.size();
+
+    m_currentState.resize(m_size);
+    m_currentState.setZero();
+
+    m_updatedVariable.resize(m_size);
+    m_updatedVariable.setZero();
+
+    return true;
+}
+
+bool RDE::ExternalContactStateDynamics::setSubModels(
+    const std::vector<RDE::SubModel>& /*subModelList*/,
+    const std::vector<std::shared_ptr<RDE::KinDynWrapper>>& /*kinDynWrapperList*/)
+{
+    return true;
+}
+
+bool RDE::ExternalContactStateDynamics::checkStateVariableHandler()
+{
+    constexpr auto errorPrefix = "[ExternalContactStateDynamics::checkStateVariableHandler]";
+
+    // Check if the variable handler contains the variables used by this dynamics
+    if (!m_stateVariableHandler.getVariable(m_name).isValid())
+    {
+        log()->error("{} The variable handler does not contain the expected state with name `{}`.",
+                     errorPrefix,
+                     m_name);
+        return false;
+    }
+
+    return true;
+}
+
+bool RDE::ExternalContactStateDynamics::update()
+{
+    m_updatedVariable = m_k.asDiagonal() * m_currentState;
+    m_updatedVariable *= -std::chrono::duration<double>(m_dT).count();
+    m_updatedVariable += m_currentState;
+
+    return true;
+}
+
+void RDE::ExternalContactStateDynamics::setState(const Eigen::Ref<const Eigen::VectorXd> ukfState)
+{
+    m_currentState = ukfState.segment(m_stateVariableHandler.getVariable(m_name).offset,
+                                      m_stateVariableHandler.getVariable(m_name).size);
+}
+
+void RDE::ExternalContactStateDynamics::setInput(const UKFInput& /*ukfInput*/)
+{
+    return;
+}

--- a/src/Estimators/src/GyroscopeMeasurementDynamics.cpp
+++ b/src/Estimators/src/GyroscopeMeasurementDynamics.cpp
@@ -177,7 +177,7 @@ bool RDE::GyroscopeMeasurementDynamics::update()
     {
         m_accelerometerVelocity = Conversions::toManifTwist(
             m_subModelKinDynList[m_subModelWithGyro[index]]->getFrameVel(
-                m_subModelList[m_subModelWithGyro[index]].getGyroscope(m_name).index));
+                m_subModelList[m_subModelWithGyro[index]].getGyroscope(m_name).frameIndex));
 
         m_updatedVariable.segment(index * m_covSingleVar.size(), m_covSingleVar.size())
             = m_accelerometerVelocity.ang();

--- a/src/Estimators/tests/RobotDynamicsEstimator/AccelerometerMeasurementDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/AccelerometerMeasurementDynamicsTest.cpp
@@ -104,20 +104,20 @@ IParametersHandler::shared_ptr createModelParameterHandler()
     std::vector<std::string> emptyVectorString;
     emptyGroupNamesFrames->setParameter("names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("frames", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("ukf_names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("associated_joints", emptyVectorString);
     REQUIRE(modelParamHandler->setGroup("FT", emptyGroupNamesFrames));
     REQUIRE(modelParamHandler->setGroup("GYROSCOPE", emptyGroupNamesFrames));
+    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupNamesFrames));
 
     auto accGroup = std::make_shared<StdImplementation>();
     std::vector<std::string> accNameList = {"r_leg_ft_acc"};
     std::vector<std::string> accFrameList = {"r_leg_ft"};
+    std::vector<std::string> accUkfNameList = {"r_leg_ft_acc"};
     accGroup->setParameter("names", accNameList);
     accGroup->setParameter("frames", accFrameList);
+    accGroup->setParameter("ukf_names", accUkfNameList);
     REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", accGroup));
-
-    auto emptyGroupFrames = std::make_shared<StdImplementation>();
-    emptyGroupFrames->setParameter("frames", emptyVectorString);
-    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupFrames));
 
     modelParamHandler->setParameter("joint_list", jointList);
 

--- a/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
+++ b/src/Estimators/tests/RobotDynamicsEstimator/CMakeLists.txt
@@ -11,6 +11,12 @@ add_bipedal_test(NAME ZeroVelocityStateDynamics
                 BipedalLocomotion::ParametersHandler
                 Eigen3::Eigen)
 
+add_bipedal_test(NAME ExternalContactStateDynamics
+                SOURCES ExternalContactStateDynamicsTest.cpp
+                LINKS BipedalLocomotion::RobotDynamicsEstimator
+                BipedalLocomotion::ParametersHandler
+                Eigen3::Eigen)
+
 add_bipedal_test(NAME ConstantMeasurementModel
                 SOURCES ConstantMeasurementModelTest.cpp
                 LINKS BipedalLocomotion::RobotDynamicsEstimator

--- a/src/Estimators/tests/RobotDynamicsEstimator/ExternalContactStateDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/ExternalContactStateDynamicsTest.cpp
@@ -1,0 +1,81 @@
+/**
+ * @file ZeroVelocityStateDynamicsTest.cpp
+ * @authors Ines Sorrentino
+ * @copyright 2023 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include <chrono>
+
+#include <yarp/os/ResourceFinder.h>
+
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+#include <BipedalLocomotion/RobotDynamicsEstimator/ExternalContactStateDynamics.h>
+
+using namespace BipedalLocomotion::Estimators::RobotDynamicsEstimator;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::System;
+
+TEST_CASE("External Contact State Dynamics")
+{
+    auto parameterHandler = std::make_shared<StdImplementation>();
+
+    // Test without bias
+    const std::string name = "r_sole";
+    Eigen::VectorXd covariance(6);
+    covariance << 1e-3, 1e-3, 5e-3, 5e-3, 5e-3, 5e-3;
+    const std::string model = "ExternalContactStateDynamics";
+    Eigen::VectorXd k(6);
+    k << 1e-1, 1e-1, 1e-1, 1e-1, 1e-1, 1e-1;
+    using namespace std::chrono_literals;
+    constexpr std::chrono::nanoseconds dT = 10ms;
+
+    parameterHandler->setParameter("name", name);
+    parameterHandler->setParameter("covariance", covariance);
+    parameterHandler->setParameter("initial_covariance", covariance);
+    parameterHandler->setParameter("dynamic_model", model);
+    parameterHandler->setParameter("sampling_time", dT);
+    parameterHandler->setParameter("k", k);
+
+    // Create variable handler
+    constexpr size_t sizeVariable = 6;
+    VariablesHandler variableHandler;
+    REQUIRE(variableHandler.addVariable("ds", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_m", sizeVariable));
+    REQUIRE(variableHandler.addVariable("tau_F", sizeVariable));
+    REQUIRE(variableHandler.addVariable("r_sole", 6));
+
+    ExternalContactStateDynamics r_sole_contact;
+
+    REQUIRE(r_sole_contact.initialize(parameterHandler));
+    REQUIRE(r_sole_contact.finalize(variableHandler));
+
+    Eigen::VectorXd currentState(covariance.size());
+    for (int index = 0; index < covariance.size(); index++)
+    {
+        currentState(index) = GENERATE(take(1, random(-100, 100)));
+    }
+
+    Eigen::VectorXd state(sizeVariable * variableHandler.getNumberOfVariables());
+    state.setZero();
+    state.segment(variableHandler.getVariable("r_sole").offset,
+                  variableHandler.getVariable("r_sole").size)
+        = currentState;
+
+    r_sole_contact.setState(state);
+
+    REQUIRE(r_sole_contact.update());
+
+    Eigen::VectorXd nextState(covariance.size());
+    nextState = r_sole_contact.getUpdatedVariable();
+
+    Eigen::VectorXd expectedNextState(covariance.size());
+    expectedNextState
+        = currentState.array()
+          - k.array() * currentState.array() * std::chrono::duration<double>(dT).count();
+
+    REQUIRE((expectedNextState - nextState).isZero());
+}

--- a/src/Estimators/tests/RobotDynamicsEstimator/FrictionTorqueStateDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/FrictionTorqueStateDynamicsTest.cpp
@@ -102,13 +102,12 @@ IParametersHandler::shared_ptr createModelParameterHandler()
     std::vector<std::string> emptyVectorString;
     emptyGroupNamesFrames->setParameter("names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("frames", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("ukf_names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("associated_joints", emptyVectorString);
     REQUIRE(modelParamHandler->setGroup("FT", emptyGroupNamesFrames));
     REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", emptyGroupNamesFrames));
     REQUIRE(modelParamHandler->setGroup("GYROSCOPE", emptyGroupNamesFrames));
-    auto emptyGroupFrames = std::make_shared<StdImplementation>();
-    emptyGroupFrames->setParameter("frames", emptyVectorString);
-    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupFrames));
+    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupNamesFrames));
 
     modelParamHandler->setParameter("joint_list", jointList);
 

--- a/src/Estimators/tests/RobotDynamicsEstimator/GyroscopeMeasurementDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/GyroscopeMeasurementDynamicsTest.cpp
@@ -104,20 +104,20 @@ IParametersHandler::shared_ptr createModelParameterHandler()
     std::vector<std::string> emptyVectorString;
     emptyGroupNamesFrames->setParameter("names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("frames", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("ukf_names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("associated_joints", emptyVectorString);
     REQUIRE(modelParamHandler->setGroup("FT", emptyGroupNamesFrames));
     REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", emptyGroupNamesFrames));
+    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupNamesFrames));
 
     auto gyroGroup = std::make_shared<StdImplementation>();
     std::vector<std::string> gyroNameList = {"r_leg_ft_gyro"};
     std::vector<std::string> gyroFrameList = {"r_leg_ft"};
+    std::vector<std::string> gyroUkfNameList = {"r_leg_ft_gyro"};
     gyroGroup->setParameter("names", gyroNameList);
     gyroGroup->setParameter("frames", gyroFrameList);
+    gyroGroup->setParameter("ukf_names", gyroUkfNameList);
     REQUIRE(modelParamHandler->setGroup("GYROSCOPE", gyroGroup));
-
-    auto emptyGroupFrames = std::make_shared<StdImplementation>();
-    emptyGroupFrames->setParameter("frames", emptyVectorString);
-    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupFrames));
 
     modelParamHandler->setParameter("joint_list", jointList);
 

--- a/src/Estimators/tests/RobotDynamicsEstimator/JointVelocityStateDynamicsTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/JointVelocityStateDynamicsTest.cpp
@@ -105,20 +105,20 @@ IParametersHandler::shared_ptr createModelParameterHandler()
     std::vector<std::string> emptyVectorString;
     emptyGroupNamesFrames->setParameter("names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("frames", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("ukf_names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("associated_joints", emptyVectorString);
     REQUIRE(modelParamHandler->setGroup("FT", emptyGroupNamesFrames));
     REQUIRE(modelParamHandler->setGroup("GYROSCOPE", emptyGroupNamesFrames));
+    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupNamesFrames));
 
     auto accGroup = std::make_shared<StdImplementation>();
     std::vector<std::string> accNameList = {"r_leg_ft_acc"};
     std::vector<std::string> accFrameList = {"r_leg_ft"};
+    std::vector<std::string> accUkfNameList = {"r_leg_ft_acc"};
     accGroup->setParameter("names", accNameList);
     accGroup->setParameter("frames", accFrameList);
+    accGroup->setParameter("ukf_names", accUkfNameList);
     REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", accGroup));
-
-    auto emptyGroupFrames = std::make_shared<StdImplementation>();
-    emptyGroupFrames->setParameter("frames", emptyVectorString);
-    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupFrames));
 
     modelParamHandler->setParameter("joint_list", jointList);
 

--- a/src/Estimators/tests/RobotDynamicsEstimator/KinDynWrapperTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/KinDynWrapperTest.cpp
@@ -104,13 +104,12 @@ IParametersHandler::shared_ptr createModelParameterHandler()
     std::vector<std::string> emptyVectorString;
     emptyGroupNamesFrames->setParameter("names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("frames", emptyVectorString);
+    emptyGroupNamesFrames->setParameter("ukf_names", emptyVectorString);
     emptyGroupNamesFrames->setParameter("associated_joints", emptyVectorString);
     REQUIRE(modelParamHandler->setGroup("FT", emptyGroupNamesFrames));
     REQUIRE(modelParamHandler->setGroup("GYROSCOPE", emptyGroupNamesFrames));
     REQUIRE(modelParamHandler->setGroup("ACCELEROMETER", emptyGroupNamesFrames));
-    auto emptyGroupFrames = std::make_shared<StdImplementation>();
-    emptyGroupFrames->setParameter("frames", emptyVectorString);
-    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupFrames));
+    REQUIRE(modelParamHandler->setGroup("EXTERNAL_CONTACT", emptyGroupNamesFrames));
 
     modelParamHandler->setParameter("joint_list", jointList);
 

--- a/src/Estimators/tests/RobotDynamicsEstimator/SubModelCreatorTest.cpp
+++ b/src/Estimators/tests/RobotDynamicsEstimator/SubModelCreatorTest.cpp
@@ -74,6 +74,7 @@ TEST_CASE("SubModel Creation")
     REQUIRE(kinDyn->loadRobotModel(mdlLdr.model()));
 
     // Case with FT, the model will be splitted
+    BipedalLocomotion::log()->info("Case FT");
     RDE::SubModelCreator subModelCreatorWithFT;
     subModelCreatorWithFT.setModelAndSensors(mdlLdr.model(), mdlLdr.sensors());
     REQUIRE(subModelCreatorWithFT.setKinDyn(kinDyn));
@@ -82,6 +83,14 @@ TEST_CASE("SubModel Creation")
     REQUIRE(subModelCreatorWithFT.getNrOfSubModels() == (1 + mdlLdr.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE)));
 
     // Case without FT, the model is not splitted and the only sub-model is the full model
+    BipedalLocomotion::log()->info("Case without FT");
+
+    jointsAndFTs.clear();
+    jointsAndFTs.insert(jointsAndFTs.begin(), jointList.begin(), jointList.end());
+
+    REQUIRE(mdlLdr.loadReducedModelFromFile(getRobotModelPath(), jointsAndFTs));
+
+    REQUIRE(kinDyn->loadRobotModel(mdlLdr.model()));
     RDE::SubModelCreator subModelCreatorWithoutFT;
     subModelCreatorWithoutFT.setModelAndSensors(mdlLdr.model(), mdlLdr.sensors());
     REQUIRE(subModelCreatorWithoutFT.setKinDyn(kinDyn));
@@ -90,6 +99,7 @@ TEST_CASE("SubModel Creation")
     std::vector<std::string> emptyVector;
     groupFT->setParameter("names", emptyVector);
     groupFT->setParameter("frames", emptyVector);
+    groupFT->setParameter("ukf_names", emptyVector);
     groupFT->setParameter("associated_joints", emptyVector);
     groupModel->setGroup("FT", groupFT);
     REQUIRE(subModelCreatorWithoutFT.createSubModels(groupModel));

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/model.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/model.ini
@@ -2,17 +2,22 @@ joint_list ("joint_1", "joint_2", "joint_3", "joint_4")
 base_link "base_link"
 
 [EXTERNAL_CONTACT]
-frames ()
+names ("ft_1")
+frames ("ft_1")
+ukf_names ("ft_1_contact")
 
 [FT]
 names ("ft_1", "ft_2")
 frames ("ft_1", "ft_2")
 associated_joints ("ft_1", "ft_2")
+ukf_names ("ft_1_ft", "ft_2_ft")
 
 [ACCELEROMETER]
 names ("ft_1_acc", "ft_2_acc")
 frames ("ft_1", "ft_2")
+ukf_names ("ft_1_acc", "ft_2_acc")
 
 [GYROSCOPE]
 names ("ft_1_gyro", "ft_2_gyro")
 frames ("ft_1", "ft_2")
+ukf_names ("ft_1_gyro", "ft_2_gyro")

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_measurement.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_measurement.ini
@@ -16,14 +16,14 @@ torque_constant (0.047, 0.047, 0.047, 0.047)
 dynamic_model "MotorCurrentMeasurementDynamics"
 
 [FT_1]
-name "ft_1"
+name "ft_1_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-8, 1e-8, 1e-8, 1e-8, 1e-8, 1e-8)
 use_bias 0
 dynamic_model "ConstantMeasurementModel"
 
 [FT_2]
-name "ft_2"
+name "ft_2_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-8, 1e-8, 1e-8, 1e-8, 1e-8, 1e-8)
 use_bias 0

--- a/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_state.ini
+++ b/src/Estimators/tests/RobotDynamicsEstimator/config/ukf/ukf_state.ini
@@ -1,4 +1,4 @@
-dynamics_list ("JOINT_VELOCITY", "MOTOR_TORQUE", "FRICTION_TORQUE", "FT_1", "FT_2", "CONTACT_1", "CONTACT_2")
+dynamics_list ("JOINT_VELOCITY", "MOTOR_TORQUE", "FRICTION_TORQUE", "FT_1", "FT_2", "CONTACT_1")
 
 [JOINT_VELOCITY]
 name "ds"
@@ -20,34 +20,28 @@ elements ("joint_1", "joint_2", "joint_3", "joint_4")
 covariance (1e-2, 1e-2, 1e-2, 1e-2)
 initial_covariance (1e-2, 1e-2, 1e-2, 1e-2)
 dynamic_model "FrictionTorqueStateDynamics"
-friction_k0 (3.0, 4.0, 4.5, 6.2)
-friction_k1 (5.1, 7.1, 1.1, 2.1)
-friction_k2 (2.5, 2.0, 1.0, 1.5)
+friction_k0 (0.1, 0.1, 0.1, 0.1)
+friction_k1 (0.1, 0.1, 0.1, 0.1)
+friction_k2 (0.1, 0.1, 0.1, 0.1)
 
 [FT_1]
-name "ft_1"
+name "ft_1_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-1, 1e-1, 1e-1, 1e-3, 1e-3, 1e-3)
 initial_covariance (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-2)
 dynamic_model "ZeroVelocityStateDynamics"
 
 [FT_2]
-name "ft_2"
+name "ft_2_ft"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-1, 1e-1, 1e-1, 1e-3, 1e-3, 1e-3)
 initial_covariance (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-2)
 dynamic_model "ZeroVelocityStateDynamics"
 
 [CONTACT_1]
-name "link_2"
+name "ft_1_contact"
 elements ("fx", "fy", "fz", "mx", "my", "mz")
 covariance (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-2)
 initial_covariance (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-2)
-dynamic_model "ZeroVelocityStateDynamics"
-
-[CONTACT_2]
-name "link_5"
-elements ("fx", "fy", "fz", "mx", "my", "mz")
-covariance (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-2)
-initial_covariance (1e-2, 1e-2, 1e-2, 1e-2, 1e-2, 1e-2)
+k (1e-1, 1e-1, 1e-1, 1e-1, 1e-1, 1e-1)
 dynamic_model "ZeroVelocityStateDynamics"


### PR DESCRIPTION
This PR introduced a process model for the external contacts defined as 

$$
\dot{f} = -k f 
$$

In addition, the PR changes the logic to define a name for the dynamics. Indeed, the name of the dynamics has to match the name `ukf_name` defined in the `model` configuration file. This solves the problem described in https://github.com/ami-iit/bipedal-locomotion-framework/issues/760 which was causing a segmentation fault when using the ft frame as the external contact frame. 

cc @GiulioRomualdi @S-Dafarra 