### PR TITLE
CI: Bump vcpkg-robotology to v0.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,8 @@ jobs:
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
+              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DYARP_COMPILE_GUIS:BOOL=OFF \
+              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL -j${{env.NUM_CORES_FOR_CMAKE_BUILD}}
         # Workaround for https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports/issues/3
         export IPOPT_DIR=${VCPKG_INSTALLATION_ROOT}/installed/x64-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  vcpkg_robotology_TAG: v0.10.1
+  vcpkg_robotology_TAG: v0.20.0
   YCM_TAG: v0.14.2
   YARP_TAG: v3.7.0
   iDynTree_TAG: v8.0.0
@@ -88,15 +88,9 @@ jobs:
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/robotology/vcpkg
         # that has been used to create the pre-compiled archive
         cd C:/
-        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${env:vcpkg_robotology_TAG}/vcpkg-robotology-with-gazebo.zip
-        unzip vcpkg-robotology-with-gazebo.zip -d C:/
-        rm vcpkg-robotology-with-gazebo.zip
-        # Also re-bootstrap to avoid problems
-        cd C:/robotology/vcpkg
-        ./bootstrap-vcpkg.bat
-
-        # Install tomlplusplus
-        ./vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports install tomlplusplus:x64-windows
+        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${env:vcpkg_robotology_TAG}/vcpkg-robotology.zip
+        unzip vcpkg-robotology.zip -d C:/
+        rm vcpkg-robotology.zip
 
     - name: Fixup brew [macOS]
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 env:
   vcpkg_robotology_TAG: v0.11.0
   YCM_TAG: v0.14.2
-  YARP_TAG: v3.7.0
+  YARP_TAG: v3.8.0
   iDynTree_TAG: v8.0.0
   CasADi_TAG: 3.5.5.2
   manif_TAG: 0.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  vcpkg_robotology_TAG: v0.20.0
+  vcpkg_robotology_TAG: v0.11.0
   YCM_TAG: v0.14.2
   YARP_TAG: v3.7.0
   iDynTree_TAG: v8.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   vcpkg_robotology_TAG: v0.11.0
-  YCM_TAG: v0.14.2
+  YCM_TAG: v0.15.3
   YARP_TAG: v3.8.0
   iDynTree_TAG: v8.0.0
   CasADi_TAG: 3.5.5.2


### PR DESCRIPTION
Fix https://github.com/ami-iit/bipedal-locomotion-framework/issues/769 . I do not think it make sense to document this change in the changelog.