### PR TITLE
Restructure ML component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to this project are documented in this file.
 ## [unreleased]
 ### Added
 - Implement `ContactList::getNextContact` and `ContactList::getActiveContact` in `Contact` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/764)
+- Implement `MANN::generateDummyMANNOutput` and `MANN::generateDummyMANNInput` in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/771)
+- Add `MANNAutoregressive` and `MANNTrajectoryGenerator` examples (https://github.com/ami-iit/bipedal-locomotion-framework/pull/771)
 
 ### Changed
 - Restructure of the `CentroidalMPC` class in `ReducedModelControllers` component. Specifically, the `CentroidalMPC` now provides a contact phase list instead of indicating the next active contact. Additionally, users can now switch between `ipopt` and `sqpmethod` to solve the optimization problem. Furthermore, the update allows for setting the warm-start for the non-linear solver. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/766)
 - Restructured the swing foot planner to handle corners case that came out while testing DNN-MPC integration (https://github.com/ami-iit/bipedal-locomotion-framework/pull/765)
 - Avoid returning internal references for `get_next_contact` `get_present_contact` and `get_active_contact` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/765)
 - Introducing Metadata Support for `VectorsCollection` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/767)
+- Restructure `MANNAutoregressive` to effectively manage resets (https://github.com/ami-iit/bipedal-locomotion-framework/pull/771)
+- Restructure `MANNTrajectoryGenerator` to remove the need for foot positions in `setInitialState` and enhanced reset capabilities. Corrected position and time scaling for precise CoM, base, and feet positioning (https://github.com/ami-iit/bipedal-locomotion-framework/pull/771)
 
 ### Fixed
 

--- a/bindings/python/ML/src/MANNAutoregressive.cpp
+++ b/bindings/python/ML/src/MANNAutoregressive.cpp
@@ -52,16 +52,10 @@ void CreateMANNAutoregressive(pybind11::module& module)
                                    ML::MANNAutoregressiveOutput>>(module, "MANNAutoregressive")
         .def(py::init())
         .def("reset",
-             py::overload_cast<const ML::MANNInput&,
-                               const Contacts::EstimatedContact&,
-                               const Contacts::EstimatedContact&,
-                               const manif::SE3d&,
-                               const manif::SE3Tangentd&>(&ML::MANNAutoregressive::reset),
-             py::arg("input"),
-             py::arg("left_foot"),
-             py::arg("right_foot"),
-             py::arg("base_pose"),
-             py::arg("base_velocity"))
+             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>, const manif::SE3d&>(
+                 &ML::MANNAutoregressive::reset),
+             py::arg("joint_positions"),
+             py::arg("base_pose"))
         .def("set_robot_model", [](ML::MANNAutoregressive& impl, ::pybind11::object& obj) {
             iDynTree::Model* cls = py::detail::swig_wrapped_pointer_to_pybind<iDynTree::Model>(obj);
 

--- a/bindings/python/ML/src/MANNTrajectoryGenerator.cpp
+++ b/bindings/python/ML/src/MANNTrajectoryGenerator.cpp
@@ -37,11 +37,13 @@ void CreateMANNTrajectoryGenerator(pybind11::module& module)
 
     py::class_<ML::MANNTrajectoryGeneratorOutput>(module, "MANNTrajectoryGeneratorOutput")
         .def(py::init())
+        .def_readwrite("timestamps", &ML::MANNTrajectoryGeneratorOutput::timestamps)
         .def_readwrite("joint_positions", &ML::MANNTrajectoryGeneratorOutput::jointPositions)
-        .def_readwrite("base_pose", &ML::MANNTrajectoryGeneratorOutput::basePoses)
+        .def_readwrite("base_poses", &ML::MANNTrajectoryGeneratorOutput::basePoses)
         .def_readwrite("phase_list", &ML::MANNTrajectoryGeneratorOutput::phaseList)
-        .def_readwrite("com_trajectory" , &ML::MANNTrajectoryGeneratorOutput::comTrajectory)
-        .def_readwrite("angular_momentum_trajectory" , &ML::MANNTrajectoryGeneratorOutput::angularMomentumTrajectory);
+        .def_readwrite("com_trajectory", &ML::MANNTrajectoryGeneratorOutput::comTrajectory)
+        .def_readwrite("angular_momentum_trajectory",
+                       &ML::MANNTrajectoryGeneratorOutput::angularMomentumTrajectory);
 
     BipedalLocomotion::bindings::System::CreateAdvanceable<ML::MANNTrajectoryGeneratorInput, //
                                                            ML::MANNTrajectoryGeneratorOutput> //
@@ -54,10 +56,7 @@ void CreateMANNTrajectoryGenerator(pybind11::module& module)
         .def("set_initial_state",
              &ML::MANNTrajectoryGenerator::setInitialState,
              py::arg("joint_positions"),
-             py::arg("left_foot"),
-             py::arg("right_foot"),
-             py::arg("base_pose"),
-             py::arg("time"))
+             py::arg("base_pose"))
         .def("set_robot_model", [](ML::MANNTrajectoryGenerator& impl, ::pybind11::object& obj) {
             iDynTree::Model* cls = py::detail::swig_wrapped_pointer_to_pybind<iDynTree::Model>(obj);
 

--- a/examples/MANN/MANNAutoregressive.ipynb
+++ b/examples/MANN/MANNAutoregressive.ipynb
@@ -131,18 +131,13 @@
    "outputs": [],
    "source": [
     "# Initial joint positions configuration. The serialization is specified in the config file\n",
-    "joint_positions = np.array([-0.10922017141063572, 0.05081325960010118, 0.06581966291990003, -0.0898053099824925, -0.09324922528169599, -0.05110058859172172,\n",
-    "                            -0.11021232812838086, 0.054291515925228385,0.0735575862560208, -0.09509332143185895, -0.09833823347493076, -0.05367281245082792,\n",
-    "                            +0.1531558711397399, -0.001030634273454133, 0.0006584764419034815,\n",
-    "                            -0.0016821925351926288, -0.004284529460797688, 0.030389771690123243,\n",
-    "                            -0.040592118429752494, -0.1695472679986807, -0.20799422095574033, 0.045397975984119654,\n",
-    "                            -0.03946672931050908, -0.16795588539580256, -0.20911090583076936, 0.0419854257806720])\n",
+    "joint_positions = params_network.get_parameter_vector_float(\"initial_joints_configuration\")\n",
     "\n",
     "# Initial base pose. This pose makes the robot stand on the ground with the feet flat\n",
-    "initial_base_height = 0.7748\n",
     "base_pose = manif.SE3.Identity()\n",
-    "quat = np.array([ 0, -0.0399893, 0, 0.9992001])\n",
-    "quat = quat / np.linalg.norm(quat)\n",
+    "initial_base_height = params_network.get_parameter_float(\"initial_base_height\")\n",
+    "quat = params_network.get_parameter_vector_float(\"initial_base_quaternion\")\n",
+    "quat = quat / np.linalg.norm(quat) # Normalize the quaternion\n",
     "base_pose = manif.SE3([0, 0, initial_base_height], quat)"
    ]
   },
@@ -211,6 +206,13 @@
     "                                   mann_output.base_pose.rotation(),\n",
     "                                   mann_output.joint_positions)\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/MANN/MANNAutoregressive.ipynb
+++ b/examples/MANN/MANNAutoregressive.ipynb
@@ -7,7 +7,7 @@
     "# MANNAutoregressive\n",
     "This notebook contains the code showing how to use MANNAutoregressive to plan a waking trajectory for ergoCub humanoid robot. \n",
     "\n",
-    "If you are interested in some details of the algorithm, please refer to the paper: [ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots](https://github.com/ami-iit/paper_viceconte_2021_ral_adherent)\n",
+    "If you are interested in some details of the algorithm, please refer to the paper: [ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots](https://github.com/ami-iit/paper_viceconte_2021_ral_adherent).\n",
     "\n",
     "## Import all the required packages\n",
     "In this section we import all the required packages. In particular, we need `iDynTree` to correctly visualize the robot, `numpy` to perform some basic operations, `manifpy` to perform some basic operations on manifolds, `resolve_robotics_uri_py` to correctly locate the `ergoCub` model. Finally `bipedal_locomotion_framework` implements the MANN network."

--- a/examples/MANN/MANNAutoregressive.ipynb
+++ b/examples/MANN/MANNAutoregressive.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MANNAutoregressive\n",
+    "This notebook contains the code showing how to use MANNAutoregressive to plan a waking trajectory for ergoCub humanoid robot. \n",
+    "\n",
+    "If you are interested in some details of the algorithm, please refer to the paper: [ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots](https://github.com/ami-iit/paper_viceconte_2021_ral_adherent)\n",
+    "\n",
+    "## Import all the required packages\n",
+    "In this section we import all the required packages. In particular, we need `iDynTree` to correctly visualize the robot, `numpy` to perform some basic operations, `manifpy` to perform some basic operations on manifolds, `resolve_robotics_uri_py` to correctly locate the `ergoCub` model. Finally `bipedal_locomotion_framework` implements the MANN network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e357295-6730-47d6-9119-bd09ed598e45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from idyntree.visualize import MeshcatVisualizer\n",
+    "import idyntree.bindings as idyn\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import manifpy as manif\n",
+    "import bipedal_locomotion_framework as blf\n",
+    "import resolve_robotics_uri_py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare the ingredients\n",
+    "To correctly run the notebook, we need to prepare the ingredients. In particular, we need to:\n",
+    "- Get the network model: In this case we use the model trained on the ergoCub robot. The model is available [here](https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx).\n",
+    "- Load the configuration file: The configuration file contains all the parameters needed to correctly run the network and generate a proper set of input the the network. In detail we have two sets of configuration files:\n",
+    "    - `config_mann.toml`: This file contains the parameters needed to correctly load and run the network\n",
+    "    - `config_joypad.toml`: This file contains the parameters needed to correctly generate the input for the network. In particular, it contains the parameters needed to correctly map a joypad input to the network input.\n",
+    "- Load the robot model: In this case we use the `ergoCub` model. We load the model only to correctly visualize the robot.\n",
+    "\n",
+    "### Get the network model\n",
+    "What we need to do is to download the network model and save it in the `config` folder. The model is available [here](https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx). \n",
+    "Moreover we load the parameters needed to correctly run the network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08029010-6814-4101-af0f-ac2940560eac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We use urllib to download the onnx model from huggingface\n",
+    "import urllib.request\n",
+    "import os\n",
+    "url = \"https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx\"\n",
+    "urllib.request.urlretrieve(url, \"./config/ergocubSN000_26j_49e.onnx\")\n",
+    "\n",
+    "# Get the configuration files\n",
+    "config_path = Path(\"__file__\").parent / \"config\" / \"config_mann.toml\"\n",
+    "params_network = blf.parameters_handler.TomlParametersHandler()\n",
+    "params_network.set_from_file(str(config_path))\n",
+    "\n",
+    "joypad_config_path = Path(\"__file__\").parent / \"config\" / \"config_joypad.toml\"\n",
+    "params_joypad = blf.parameters_handler.TomlParametersHandler()\n",
+    "params_joypad.set_from_file(str(joypad_config_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load ergoCub model\n",
+    "We load the `ergoCub` model to correctly visualize the robot.\n",
+    "The model is loaded using `iDynTree` and `resolve_robotics_uri_py` to correctly locate the model. Please notice that the model is loaded specifying the same joint order used to train the network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3817e56-9e8d-464e-9f0b-6577a2c0f2fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the path of the robot model\n",
+    "robot_model_path = str(resolve_robotics_uri_py.resolve_robotics_uri(\"package://ergoCub/robots/ergoCubSN001/model.urdf\"))\n",
+    "ml = idyn.ModelLoader()\n",
+    "ml.loadReducedModelFromFile(robot_model_path, params_network.get_parameter_vector_string(\"joints_list\"))\n",
+    "viz = MeshcatVisualizer()\n",
+    "viz.load_model(ml.model())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Network initialization\n",
+    "In this section we initialize the network. In particular we first instantiate the network and then we load the parameters. The parameters are loaded from the `config_mann.toml` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the trajectory generator\n",
+    "mann_trajectory_generator = blf.ml.MANNAutoregressive()\n",
+    "assert mann_trajectory_generator.set_robot_model(ml.model())\n",
+    "assert mann_trajectory_generator.initialize(params_network)\n",
+    "\n",
+    "# Create the input builder\n",
+    "input_builder = blf.ml.MANNAutoregressiveInputBuilder()\n",
+    "assert input_builder.initialize(params_joypad)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now need to reset the network to the initial state. In particular, we need to reset  the joint state and the base pose in a given configuration already seen by the network during traning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initial joint positions configuration. The serialization is specified in the config file\n",
+    "joint_positions = np.array([-0.10922017141063572, 0.05081325960010118, 0.06581966291990003, -0.0898053099824925, -0.09324922528169599, -0.05110058859172172,\n",
+    "                            -0.11021232812838086, 0.054291515925228385,0.0735575862560208, -0.09509332143185895, -0.09833823347493076, -0.05367281245082792,\n",
+    "                            +0.1531558711397399, -0.001030634273454133, 0.0006584764419034815,\n",
+    "                            -0.0016821925351926288, -0.004284529460797688, 0.030389771690123243,\n",
+    "                            -0.040592118429752494, -0.1695472679986807, -0.20799422095574033, 0.045397975984119654,\n",
+    "                            -0.03946672931050908, -0.16795588539580256, -0.20911090583076936, 0.0419854257806720])\n",
+    "\n",
+    "# Initial base pose. This pose makes the robot stand on the ground with the feet flat\n",
+    "initial_base_height = 0.7748\n",
+    "base_pose = manif.SE3.Identity()\n",
+    "quat = np.array([ 0, -0.0399893, 0, 0.9992001])\n",
+    "quat = quat / np.linalg.norm(quat)\n",
+    "base_pose = manif.SE3([0, 0, initial_base_height], quat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We finally ask the input build to generate an input that mimics a joypad input. In particular, we ask the input builder to generate an input that mimics a joypad input with the axes moved to the following values:\n",
+    "- `left_stick_x`: 1.0\n",
+    "- `left_stick_y`: 0.0\n",
+    "- `right_stick_x`: 1.0\n",
+    "- `right_stick_y`: 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_builder_input = blf.ml.MANNDirectionalInput()\n",
+    "input_builder_input.motion_direction = np.array([1, 0])\n",
+    "input_builder_input.facing_direction = np.array([1, 0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Network execution\n",
+    "We now visualize the robot in the viewer and we run the network for 150 steps. In particular, we run the network for 150 steps and we visualize the robot at each step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz.jupyter_cell()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reset the trajectory generator\n",
+    "mann_trajectory_generator.reset(joint_positions, base_pose)\n",
+    "for _ in range(150):\n",
+    "\n",
+    "    # Set the input to the builder and\n",
+    "    input_builder.set_input(input_builder_input)\n",
+    "    assert input_builder.advance()\n",
+    "    assert input_builder.is_output_valid()\n",
+    "\n",
+    "    # Set the input to the trajectory generator\n",
+    "    mann_trajectory_generator.set_input(input_builder.get_output())\n",
+    "    assert mann_trajectory_generator.advance()\n",
+    "    assert mann_trajectory_generator.is_output_valid()\n",
+    "\n",
+    "    # Get the output of the trajectory generator and update the visualization\n",
+    "    mann_output = mann_trajectory_generator.get_output()\n",
+    "    viz.set_multibody_system_state(mann_output.base_pose.translation(),\n",
+    "                                   mann_output.base_pose.rotation(),\n",
+    "                                   mann_output.joint_positions)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/MANN/MANNAutoregressive.ipynb
+++ b/examples/MANN/MANNAutoregressive.ipynb
@@ -36,7 +36,7 @@
     "## Prepare the ingredients\n",
     "To correctly run the notebook, we need to prepare the ingredients. In particular, we need to:\n",
     "- Get the network model: In this case we use the model trained on the ergoCub robot. The model is available [here](https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx).\n",
-    "- Load the configuration file: The configuration file contains all the parameters needed to correctly run the network and generate a proper set of input the the network. In detail we have two sets of configuration files:\n",
+    "- Load the configuration file: The configuration file contains all the parameters needed to correctly run the network and generate a proper set of inputs for the network. In detail we have two configuration files:\n",
     "    - `config_mann.toml`: This file contains the parameters needed to correctly load and run the network\n",
     "    - `config_joypad.toml`: This file contains the parameters needed to correctly generate the input for the network. In particular, it contains the parameters needed to correctly map a joypad input to the network input.\n",
     "- Load the robot model: In this case we use the `ergoCub` model. We load the model only to correctly visualize the robot.\n",

--- a/examples/MANN/MANNAutoregressive.ipynb
+++ b/examples/MANN/MANNAutoregressive.ipynb
@@ -204,15 +204,8 @@
     "    mann_output = mann_trajectory_generator.get_output()\n",
     "    viz.set_multibody_system_state(mann_output.base_pose.translation(),\n",
     "                                   mann_output.base_pose.rotation(),\n",
-    "                                   mann_output.joint_positions)\n"
+    "                                   mann_output.joint_positions)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/MANN/MANNAutoregressive.ipynb
+++ b/examples/MANN/MANNAutoregressive.ipynb
@@ -145,7 +145,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We finally ask the input build to generate an input that mimics a joypad input. In particular, we ask the input builder to generate an input that mimics a joypad input with the axes moved to the following values:\n",
+    "We finally ask the input builder to generate an input that mimics a joypad input. In particular, we ask the input builder to generate an input that mimics a joypad input with the axes moved to the following values:\n",
     "- `left_stick_x`: 1.0\n",
     "- `left_stick_y`: 0.0\n",
     "- `right_stick_x`: 1.0\n",

--- a/examples/MANN/MANNAutoregressive.ipynb
+++ b/examples/MANN/MANNAutoregressive.ipynb
@@ -168,7 +168,7 @@
    "metadata": {},
    "source": [
     "## Network execution\n",
-    "We now visualize the robot in the viewer and we run the network for 150 steps. In particular, we run the network for 150 steps and we visualize the robot at each step."
+    "We now visualize the robot in the viewer and we run the network for 150 steps. In particular, we run the network for 150 steps and we visualize the resulting robot motion at each step."
    ]
   },
   {

--- a/examples/MANN/MANNAutoregressive.ipynb
+++ b/examples/MANN/MANNAutoregressive.ipynb
@@ -37,7 +37,7 @@
     "To correctly run the notebook, we need to prepare the ingredients. In particular, we need to:\n",
     "- Get the network model: In this case we use the model trained on the ergoCub robot. The model is available [here](https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx).\n",
     "- Load the configuration file: The configuration file contains all the parameters needed to correctly run the network and generate a proper set of inputs for the network. In detail we have two configuration files:\n",
-    "    - `config_mann.toml`: This file contains the parameters needed to correctly load and run the network\n",
+    "    - `config_mann.toml`: This file contains the parameters needed to correctly load and run the network.\n",
     "    - `config_joypad.toml`: This file contains the parameters needed to correctly generate the input for the network. In particular, it contains the parameters needed to correctly map a joypad input to the network input.\n",
     "- Load the robot model: In this case we use the `ergoCub` model. We load the model only to correctly visualize the robot.\n",
     "\n",

--- a/examples/MANN/MANNAutoregressive.ipynb
+++ b/examples/MANN/MANNAutoregressive.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# MANNAutoregressive\n",
-    "This notebook contains the code showing how to use MANNAutoregressive to plan a waking trajectory for ergoCub humanoid robot. \n",
+    "This notebook contains the code showing how to use MANNAutoregressive to generate a walking trajectory for the ergoCub humanoid robot. \n",
     "\n",
     "If you are interested in some details of the algorithm, please refer to the paper: [ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots](https://github.com/ami-iit/paper_viceconte_2021_ral_adherent).\n",
     "\n",

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -157,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We finally ask the input build to generate an input that mimics a joypad input. In particular, we ask the input builder to generate an input that mimics a joypad input with the axes moved to the following values:\n",
+    "We finally ask the input builder to generate an input that mimics a joypad input. In particular, we ask the input builder to generate an input that mimics a joypad input corresponding to a forward walking, i.e. a joypad input with the axes moved to the following values:\n",
     "- `left_stick_x`: 1.0\n",
     "- `left_stick_y`: 0.0\n",
     "- `right_stick_x`: 1.0\n",

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -98,7 +98,7 @@
     "viz.load_box(0.2, 0.1, 0.001, \"left1\", [219/255.0, 68/255.0, 55/255.0, 1])\n",
     "viz.load_box(0.2, 0.1, 0.001, \"left2\", [219/255.0, 68/255.0, 55/255.0, 1])\n",
     "viz.load_box(0.2, 0.1, 0.001, \"right1\", [219/255.0, 68/255.0, 55/255.0, 1])\n",
-    "viz.load_box(0.2, 0.1, 0.001, \"right2\", [219/255.0, 68/255.0, 55/255.0, 1])\n"
+    "viz.load_box(0.2, 0.1, 0.001, \"right2\", [219/255.0, 68/255.0, 55/255.0, 1])"
    ]
   },
   {
@@ -256,15 +256,8 @@
     "                                           mann_output.joint_positions[i],\n",
     "                                           \"ghost\")\n",
     "\n",
-    "    mann_trajectory_generator_input.merge_point_index = 5\n"
+    "    mann_trajectory_generator_input.merge_point_index = 5"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -39,7 +39,7 @@
     "To correctly run the notebook, we need to prepare the ingredients. In particular, we need to:\n",
     "- Get the network model: In this case we use the model trained on the ergoCub robot. The model is available [here](https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx).\n",
     "- Load the configuration file: The configuration file contains all the parameters needed to correctly run the network and generate a proper set of inputs for the network. In detail we have two configuration files:\n",
-    "    - `config_mann.toml`: This file contains the parameters needed to correctly load and run the network\n",
+    "    - `config_mann.toml`: This file contains the parameters needed to correctly load and run the network.\n",
     "    - `config_joypad.toml`: This file contains the parameters needed to correctly generate the input for the network. In particular, it contains the parameters needed to correctly map a joypad input to the network input.\n",
     "- Load the robot model: In this case we use the `ergoCub` model. We load the model only to correctly visualize the robot.\n",
     "\n",

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -182,7 +182,7 @@
     "## Network execution\n",
     "We now visualize the robot in the viewer and we run the network for 50 steps. In particular, we run the trajectory generator for 50 steps and we visualize the result in the viewer. For each step we show:\n",
     "- The entire future trajectory of the robot\n",
-    "- The sampled contacts\n",
+    "- The sampled contacts.\n",
     "- The robot at the merge point. The merge point is the point from which the network starts to generate the trajectory at the next iteration."
    ]
   },

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -143,18 +143,13 @@
    "outputs": [],
    "source": [
     "# Initial joint positions configuration. The serialization is specified in the config file\n",
-    "joint_positions = np.array([-0.10922017141063572, 0.05081325960010118, 0.06581966291990003, -0.0898053099824925, -0.09324922528169599, -0.05110058859172172,\n",
-    "                            -0.11021232812838086, 0.054291515925228385,0.0735575862560208, -0.09509332143185895, -0.09833823347493076, -0.05367281245082792,\n",
-    "                            +0.1531558711397399, -0.001030634273454133, 0.0006584764419034815,\n",
-    "                            -0.0016821925351926288, -0.004284529460797688, 0.030389771690123243,\n",
-    "                            -0.040592118429752494, -0.1695472679986807, -0.20799422095574033, 0.045397975984119654,\n",
-    "                            -0.03946672931050908, -0.16795588539580256, -0.20911090583076936, 0.0419854257806720])\n",
+    "joint_positions = params_network.get_parameter_vector_float(\"initial_joints_configuration\")\n",
     "\n",
     "# Initial base pose. This pose makes the robot stand on the ground with the feet flat\n",
-    "initial_base_height = 0.7748\n",
     "base_pose = manif.SE3.Identity()\n",
-    "quat = np.array([ 0, -0.0399893, 0, 0.9992001])\n",
-    "quat = quat / np.linalg.norm(quat)\n",
+    "initial_base_height = params_network.get_parameter_float(\"initial_base_height\")\n",
+    "quat = params_network.get_parameter_vector_float(\"initial_base_quaternion\")\n",
+    "quat = quat / np.linalg.norm(quat) # Normalize the quaternion\n",
     "base_pose = manif.SE3([0, 0, initial_base_height], quat)"
    ]
   },
@@ -263,6 +258,13 @@
     "\n",
     "    mann_trajectory_generator_input.merge_point_index = 5\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# MANNTrajectoryGenerator\n",
-    "This notebook contains the code showing how to use MANNTrajectoryGenerator to plan a waking trajectory for ergoCub humanoid robot. \n",
+    "This notebook contains the code showing how to use MANNTrajectoryGenerator to generate a walking trajectory for the ergoCub humanoid robot. \n",
     "\n",
     "If you are interested in some details of the algorithm, please refer to the paper: [ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots](https://github.com/ami-iit/paper_viceconte_2021_ral_adherent)\n",
     "\n",

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "## Network execution\n",
     "We now visualize the robot in the viewer and we run the network for 50 steps. In particular, we run the trajectory generator for 50 steps and we visualize the result in the viewer. For each step we show:\n",
-    "- The entire future trajectory of the robot\n",
+    "- The entire future trajectory of the robot.\n",
     "- The sampled contacts.\n",
     "- The robot at the merge point. The merge point is the point from which the network starts to generate the trajectory at the next iteration."
    ]

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -7,7 +7,7 @@
     "# MANNTrajectoryGenerator\n",
     "This notebook contains the code showing how to use MANNTrajectoryGenerator to generate a walking trajectory for the ergoCub humanoid robot. \n",
     "\n",
-    "If you are interested in some details of the algorithm, please refer to the paper: [ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots](https://github.com/ami-iit/paper_viceconte_2021_ral_adherent)\n",
+    "If you are interested in some details of the algorithm, please refer to the paper: [ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots](https://github.com/ami-iit/paper_viceconte_2021_ral_adherent).\n",
     "\n",
     "Differently from the `MANNAutoregressive`, `MANNTrajectoryGenerator` class can be used to plan a trajectory that can be fed into an MPC. Indeed it is possible to sample the contact and extract a `ContactPhaseList` that can be used to initialize the MPC. Moreover the `MANNTrajectoryGenerator` can be reset to any point of the trajectory, allowing to replan at will.\n",
     "\n",

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -1,0 +1,289 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MANNTrajectoryGenerator\n",
+    "This notebook contains the code showing how to use MANNTrajectoryGenerator to plan a waking trajectory for ergoCub humanoid robot. \n",
+    "\n",
+    "If you are interested in some details of the algorithm, please refer to the paper: [ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots](https://github.com/ami-iit/paper_viceconte_2021_ral_adherent)\n",
+    "\n",
+    "Differently from the `MANNAutoregressive`, `MANNTrajectoryGenerator` class can be used to plan a trajectory that can be feed into an MPC. Indeed it is possible to sample the contact and extract a `ContactPhaseList` that can be used to initialize the MPC. Moreover the `MANNTrajectoryGenerator` can be reset to any point of the trajectory, allowing to replan at will.\n",
+    "\n",
+    "## Import all the required packages\n",
+    "In this section we import all the required packages. In particular, we need `iDynTree` to correctly visualize the robot, `numpy` to perform some basic operations, `manifpy` to perform some basic operations on manifolds, `resolve_robotics_uri_py` to correctly locate the `ergoCub` model. Finally `bipedal_locomotion_framework` implements the MANN network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e357295-6730-47d6-9119-bd09ed598e45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from idyntree.visualize import MeshcatVisualizer\n",
+    "import idyntree.bindings as idyn\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import manifpy as manif\n",
+    "import bipedal_locomotion_framework as blf\n",
+    "import resolve_robotics_uri_py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare the ingredients\n",
+    "To correctly run the notebook, we need to prepare the ingredients. In particular, we need to:\n",
+    "- Get the network model: In this case we use the model trained on the ergoCub robot. The model is available [here](https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx).\n",
+    "- Load the configuration file: The configuration file contains all the parameters needed to correctly run the network and generate a proper set of input the the network. In detail we have two sets of configuration files:\n",
+    "    - `config_mann.toml`: This file contains the parameters needed to correctly load and run the network\n",
+    "    - `config_joypad.toml`: This file contains the parameters needed to correctly generate the input for the network. In particular, it contains the parameters needed to correctly map a joypad input to the network input.\n",
+    "- Load the robot model: In this case we use the `ergoCub` model. We load the model only to correctly visualize the robot.\n",
+    "\n",
+    "### Get the network model\n",
+    "What we need to do is to download the network model and save it in the `config` folder. The model is available [here](https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx). \n",
+    "Moreover we load the parameters needed to correctly run the network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08029010-6814-4101-af0f-ac2940560eac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We use urllib to download the onnx model from huggingface\n",
+    "import urllib.request\n",
+    "import os\n",
+    "url = \"https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx\"\n",
+    "urllib.request.urlretrieve(url, \"./config/ergocubSN000_26j_49e.onnx\")\n",
+    "\n",
+    "# Get the configuration files\n",
+    "config_path = Path(\"__file__\").parent / \"config\" / \"config_mann.toml\"\n",
+    "params_network = blf.parameters_handler.TomlParametersHandler()\n",
+    "params_network.set_from_file(str(config_path))\n",
+    "\n",
+    "joypad_config_path = Path(\"__file__\").parent / \"config\" / \"config_joypad.toml\"\n",
+    "params_joypad = blf.parameters_handler.TomlParametersHandler()\n",
+    "params_joypad.set_from_file(str(joypad_config_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load ergoCub model\n",
+    "We load the `ergoCub` model to correctly visualize the robot.\n",
+    "The model is loaded using `iDynTree` and `resolve_robotics_uri_py` to correctly locate the model. Please notice that the model is loaded specifying the same joint order used to train the network.\n",
+    "Moreover we load a set of boxes to correctly visualize the contact points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3817e56-9e8d-464e-9f0b-6577a2c0f2fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the path of the robot model\n",
+    "robot_model_path = str(resolve_robotics_uri_py.resolve_robotics_uri(\"package://ergoCub/robots/ergoCubSN001/model.urdf\"))\n",
+    "ml = idyn.ModelLoader()\n",
+    "ml.loadReducedModelFromFile(robot_model_path, params_network.get_parameter_vector_string(\"joints_list\"))\n",
+    "viz = MeshcatVisualizer()\n",
+    "viz.load_model(ml.model(), \"real\", 0.3)\n",
+    "viz.load_model(ml.model(), \"ghost\", 0.8)\n",
+    "viz.load_box(0.2, 0.1, 0.001, \"left1\", [219/255.0, 68/255.0, 55/255.0, 1])\n",
+    "viz.load_box(0.2, 0.1, 0.001, \"left2\", [219/255.0, 68/255.0, 55/255.0, 1])\n",
+    "viz.load_box(0.2, 0.1, 0.001, \"right1\", [219/255.0, 68/255.0, 55/255.0, 1])\n",
+    "viz.load_box(0.2, 0.1, 0.001, \"right2\", [219/255.0, 68/255.0, 55/255.0, 1])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Network initialization\n",
+    "In this section we initialize the network. In particular we first instantiate the network and then we load the parameters. The parameters are loaded from the `config_mann.toml` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the trajectory generator\n",
+    "mann_trajectory_generator = blf.ml.MANNTrajectoryGenerator()\n",
+    "assert mann_trajectory_generator.set_robot_model(ml.model())\n",
+    "assert mann_trajectory_generator.initialize(params_network)\n",
+    "\n",
+    "# Create the input builder\n",
+    "input_builder = blf.ml.MANNAutoregressiveInputBuilder()\n",
+    "assert input_builder.initialize(params_joypad)\n",
+    "\n",
+    "# Create the input\n",
+    "mann_trajectory_generator_input = blf.ml.MANNTrajectoryGeneratorInput()\n",
+    "mann_trajectory_generator_input.merge_point_index = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now need to reset the network to the initial state. In particular, we need to reset  the joint state and the base pose in a given configuration already seen by the network during traning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initial joint positions configuration. The serialization is specified in the config file\n",
+    "joint_positions = np.array([-0.10922017141063572, 0.05081325960010118, 0.06581966291990003, -0.0898053099824925, -0.09324922528169599, -0.05110058859172172,\n",
+    "                            -0.11021232812838086, 0.054291515925228385,0.0735575862560208, -0.09509332143185895, -0.09833823347493076, -0.05367281245082792,\n",
+    "                            +0.1531558711397399, -0.001030634273454133, 0.0006584764419034815,\n",
+    "                            -0.0016821925351926288, -0.004284529460797688, 0.030389771690123243,\n",
+    "                            -0.040592118429752494, -0.1695472679986807, -0.20799422095574033, 0.045397975984119654,\n",
+    "                            -0.03946672931050908, -0.16795588539580256, -0.20911090583076936, 0.0419854257806720])\n",
+    "\n",
+    "# Initial base pose. This pose makes the robot stand on the ground with the feet flat\n",
+    "initial_base_height = 0.7748\n",
+    "base_pose = manif.SE3.Identity()\n",
+    "quat = np.array([ 0, -0.0399893, 0, 0.9992001])\n",
+    "quat = quat / np.linalg.norm(quat)\n",
+    "base_pose = manif.SE3([0, 0, initial_base_height], quat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We finally ask the input build to generate an input that mimics a joypad input. In particular, we ask the input builder to generate an input that mimics a joypad input with the axes moved to the following values:\n",
+    "- `left_stick_x`: 1.0\n",
+    "- `left_stick_y`: 0.0\n",
+    "- `right_stick_x`: 1.0\n",
+    "- `right_stick_y`: 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_builder_input = blf.ml.MANNDirectionalInput()\n",
+    "input_builder_input.motion_direction = np.array([1, 0])\n",
+    "input_builder_input.facing_direction = np.array([1, 0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Network execution\n",
+    "We now visualize the robot in the viewer and we run the network for 50 steps. In particular, we run the trajectory generator for 50 steps and we visualize the result in the viewer. For each step we show:\n",
+    "- The entire future trajectory of the robot\n",
+    "- The sampled contacts\n",
+    "- The robot at the merge point. The merge point is the point from which the network starts to generate the trajectory at the next iteration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz.jupyter_cell()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reset the trajectory generator\n",
+    "far_position = np.array([1e5, 1e5, 1e5])\n",
+    "identity = np.eye(3)\n",
+    "mann_trajectory_generator.set_initial_state(joint_positions, base_pose)\n",
+    "\n",
+    "for _ in range(50):\n",
+    "\n",
+    "    # Set the input to the builder and\n",
+    "    input_builder.set_input(input_builder_input)\n",
+    "    assert input_builder.advance()\n",
+    "    assert input_builder.is_output_valid()\n",
+    "\n",
+    "    mann_trajectory_generator_input.desired_future_base_trajectory = input_builder.get_output().desired_future_base_trajectory\n",
+    "    mann_trajectory_generator_input.desired_future_base_velocities = input_builder.get_output().desired_future_base_velocities\n",
+    "    mann_trajectory_generator_input.desired_future_facing_directions = input_builder.get_output().desired_future_facing_directions\n",
+    "\n",
+    "    # Set the input to the trajectory generator\n",
+    "    mann_trajectory_generator.set_input(mann_trajectory_generator_input)\n",
+    "    assert mann_trajectory_generator.advance()\n",
+    "    assert mann_trajectory_generator.is_output_valid()\n",
+    "\n",
+    "    # Get the output of the trajectory generator and update the visualization\n",
+    "    mann_output = mann_trajectory_generator.get_output()\n",
+    "\n",
+    "    # Move the feet to a far position\n",
+    "    for i in range(1,3):\n",
+    "        viz.set_primitive_geometry_transform(far_position, identity, \"left\" + str(i))\n",
+    "        viz.set_primitive_geometry_transform(far_position, identity, \"right\" + str(i))\n",
+    "\n",
+    "    # Show the contact sampled by the trajectory generator\n",
+    "    contact_map = mann_output.phase_list.lists()\n",
+    "    i = 1\n",
+    "    for contact in contact_map[\"left_foot\"]:\n",
+    "        viz.set_primitive_geometry_transform(contact.pose.translation(), contact.pose.rotation(), \"left\" + str(i))\n",
+    "        i += 1\n",
+    "\n",
+    "    i = 1\n",
+    "    for contact in contact_map[\"right_foot\"]:\n",
+    "        viz.set_primitive_geometry_transform(contact.pose.translation(), contact.pose.rotation(), \"right\" + str(i))\n",
+    "        i += 1   \n",
+    "\n",
+    "    # Show the trajectory\n",
+    "    for i in range(len(mann_output.joint_positions)):\n",
+    "        viz.set_multibody_system_state(mann_output.base_poses[i].translation(),\n",
+    "                                       mann_output.base_poses[i].rotation(),\n",
+    "                                       mann_output.joint_positions[i],\n",
+    "                                       \"real\")\n",
+    "\n",
+    "        # Show the robot at the merge point\n",
+    "        if i == mann_trajectory_generator_input.merge_point_index:\n",
+    "            viz.set_multibody_system_state(mann_output.base_poses[i].translation(),\n",
+    "                                           mann_output.base_poses[i].rotation(),\n",
+    "                                           mann_output.joint_positions[i],\n",
+    "                                           \"ghost\")\n",
+    "\n",
+    "    mann_trajectory_generator_input.merge_point_index = 5\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -38,7 +38,7 @@
     "## Prepare the ingredients\n",
     "To correctly run the notebook, we need to prepare the ingredients. In particular, we need to:\n",
     "- Get the network model: In this case we use the model trained on the ergoCub robot. The model is available [here](https://huggingface.co/ami-iit/mann/resolve/main/ergocubSN000_26j_49e.onnx).\n",
-    "- Load the configuration file: The configuration file contains all the parameters needed to correctly run the network and generate a proper set of input the the network. In detail we have two sets of configuration files:\n",
+    "- Load the configuration file: The configuration file contains all the parameters needed to correctly run the network and generate a proper set of inputs for the network. In detail we have two configuration files:\n",
     "    - `config_mann.toml`: This file contains the parameters needed to correctly load and run the network\n",
     "    - `config_joypad.toml`: This file contains the parameters needed to correctly generate the input for the network. In particular, it contains the parameters needed to correctly map a joypad input to the network input.\n",
     "- Load the robot model: In this case we use the `ergoCub` model. We load the model only to correctly visualize the robot.\n",

--- a/examples/MANN/MANNTrajectoryGenerator.ipynb
+++ b/examples/MANN/MANNTrajectoryGenerator.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "If you are interested in some details of the algorithm, please refer to the paper: [ADHERENT: Learning Human-like Trajectory Generators for Whole-body Control of Humanoid Robots](https://github.com/ami-iit/paper_viceconte_2021_ral_adherent)\n",
     "\n",
-    "Differently from the `MANNAutoregressive`, `MANNTrajectoryGenerator` class can be used to plan a trajectory that can be feed into an MPC. Indeed it is possible to sample the contact and extract a `ContactPhaseList` that can be used to initialize the MPC. Moreover the `MANNTrajectoryGenerator` can be reset to any point of the trajectory, allowing to replan at will.\n",
+    "Differently from the `MANNAutoregressive`, `MANNTrajectoryGenerator` class can be used to plan a trajectory that can be fed into an MPC. Indeed it is possible to sample the contact and extract a `ContactPhaseList` that can be used to initialize the MPC. Moreover the `MANNTrajectoryGenerator` can be reset to any point of the trajectory, allowing to replan at will.\n",
     "\n",
     "## Import all the required packages\n",
     "In this section we import all the required packages. In particular, we need `iDynTree` to correctly visualize the robot, `numpy` to perform some basic operations, `manifpy` to perform some basic operations on manifolds, `resolve_robotics_uri_py` to correctly locate the `ergoCub` model. Finally `bipedal_locomotion_framework` implements the MANN network."

--- a/examples/MANN/README.md
+++ b/examples/MANN/README.md
@@ -2,7 +2,7 @@
 
 This tutorial aims to give the user a receipt that can be followed to use the `MANNAutoregressive` and `MANNTrajectoryGenerator` classes to generate a trajectory for the `ergoCub` robot.
 
-The tutorial requires the following python package installed:
+The tutorial requires the following Python package installed:
 - `bipedal_locomotion_framework` to use MANN network;
 - [`iDynTree`](https://github.com/robotology/idyntree) for visualization and to execute dynamics algorithms;
 - [`manifpy`](https://github.com/artivis/manif) that is in charge handle rotation matrices and homogeneous transformations;
@@ -23,7 +23,12 @@ Then you can run the notebooks by typing the following command in a terminal:
     ```console
     jupyter notebook MANNTrajectoryGenerator.ipynb
     ```
+
+    https://github.com/ami-iit/bipedal-locomotion-framework/assets/16744101/b3b921b9-efc8-4090-9f75-178cd0f9d119
+
 2. `MANNAutoregressive`
     ```console
     jupyter notebook MANNAutoregressive.ipynb
     ```
+
+    https://github.com/ami-iit/bipedal-locomotion-framework/assets/16744101/7ba65d66-68f9-4bd9-aede-a8edd00d82d5

--- a/examples/MANN/README.md
+++ b/examples/MANN/README.md
@@ -1,0 +1,29 @@
+# 🤖 MANN
+
+This tutorial aims to give the user a receipt that can be followed to use the `MANNAutoregressive` and `MANNTrajectoryGenerator` classes to generate a trajectory for the `ergoCub` robot.
+
+The tutorial requires the following python package installed:
+- `bipedal_locomotion_framework` to use MANN network;
+- [`iDynTree`](https://github.com/robotology/idyntree) for visualization and to execute dynamics algorithms;
+- [`manifpy`](https://github.com/artivis/manif) that is in charge handle rotation matrices and homogeneous transformations;
+- [`ergocub-software`](https://github.com/icub-tech-iit/ergocub-software) to load the model of the `ergoCub` robot;
+- [`resolve_robotics_uri_py`](https://github.com/ami-iit/resolve-robotics-uri-py) to correctly load the `ergoCub` model.
+
+If you installed `bipedal-locomotion-framework` with the [`robotology-superbuild`](https://github.com/robotology/robotology-superbuild) you should have all the dependencies already satisfied.
+
+In case you do want to run this tutorial without compiling `bipedal-locomotion-framework` we suggest installing the dependencies with `conda` as follows
+```console
+mamba create -n blf-mann-tutorial
+mamba activate blf-mann-tutorial
+mamba install -c conda-forge -c robotology bipedal-locomotion-framework meshcat-python notebook resolve_robotics_uri_py ergocub-software
+```
+
+Then you can run the notebooks by typing the following command in a terminal:
+1. `MANNTrajectoryGenerator`
+    ```console
+    jupyter notebook MANNTrajectoryGenerator.ipynb
+    ```
+2. `MANNAutoregressive`
+    ```console
+    jupyter notebook MANNAutoregressive.ipynb
+    ```

--- a/examples/MANN/config/config_joypad.toml
+++ b/examples/MANN/config/config_joypad.toml
@@ -1,0 +1,10 @@
+base_vel_norm = 0.4
+ellipsoid_forward_axis = 1.0
+ellipsoid_side_axis = 0.9
+ellipsoid_backward_axis = 0.6
+ellipsoid_scaling_factor = 0.4
+max_facing_direction_angle_forward = 0.20
+max_facing_direction_angle_backward = 0.1
+max_facing_direction_angle_side_opposite_sign = 0.26
+max_facing_direction_angle_side_same_sign = 0.17
+number_of_knots = 7

--- a/examples/MANN/config/config_mann.toml
+++ b/examples/MANN/config/config_mann.toml
@@ -1,0 +1,44 @@
+
+joints_list = ['l_hip_pitch', 'l_hip_roll', 'l_hip_yaw', 'l_knee', 'l_ankle_pitch', 'l_ankle_roll',  # left leg
+               'r_hip_pitch', 'r_hip_roll', 'r_hip_yaw', 'r_knee', 'r_ankle_pitch', 'r_ankle_roll',  # right leg
+               'torso_pitch', 'torso_roll', 'torso_yaw',  # torso
+               'neck_pitch', 'neck_roll', 'neck_yaw', # neck
+               'l_shoulder_pitch', 'l_shoulder_roll', 'l_shoulder_yaw', 'l_elbow', # left arm
+               'r_shoulder_pitch', 'r_shoulder_roll', 'r_shoulder_yaw', 'r_elbow'] # right arm
+
+root_link_frame_name = "root_link"
+chest_link_frame_name = "chest"
+left_foot_frame_name = "l_sole"
+right_foot_frame_name = "r_sole"
+sampling_time = 0.02
+time_horizon = 2.0
+slow_down_factor = 5
+forward_direction = "x"
+scaling_factor = 1.0
+
+[LEFT_FOOT]
+number_of_corners = 4
+corner_0  = [0.08, 0.03, 0.0]
+corner_1  = [0.08, -0.03, 0.0]
+corner_2  = [-0.08, -0.03, 0.0]
+corner_3  = [-0.08, 0.03, 0.0]
+on_threshold = 0.02
+off_threshold = 0.02
+switch_on_after = 0.02
+switch_off_after = 0.02
+
+
+[RIGHT_FOOT]
+number_of_corners = 4
+corner_0  = [0.08, 0.03, 0.0]
+corner_1  = [0.08, -0.03, 0.0]
+corner_2  = [-0.08, -0.03, 0.0]
+corner_3  = [-0.08, 0.03, 0.0]
+on_threshold = 0.02
+off_threshold = 0.02
+switch_on_after = 0.02
+switch_off_after = 0.02
+
+[MANN]
+projected_base_horizon = 12
+onnx_model_path = "./config/ergocubSN000_26j_49e.onnx"

--- a/examples/MANN/config/config_mann.toml
+++ b/examples/MANN/config/config_mann.toml
@@ -25,6 +25,8 @@ time_horizon = 1.0
 slow_down_factor = 5.0
 forward_direction = "x"
 scaling_factor = 1.0
+mocap_frame_rate = 50 # Hz
+past_projected_base_horizon = 1.0
 
 [LEFT_FOOT]
 number_of_corners = 4
@@ -50,5 +52,5 @@ switch_on_after = 0.02
 switch_off_after = 0.02
 
 [MANN]
-projected_base_horizon = 12
+projected_base_datapoints = 12
 onnx_model_path = "./config/ergocubSN000_26j_49e.onnx"

--- a/examples/MANN/config/config_mann.toml
+++ b/examples/MANN/config/config_mann.toml
@@ -11,8 +11,8 @@ chest_link_frame_name = "chest"
 left_foot_frame_name = "l_sole"
 right_foot_frame_name = "r_sole"
 sampling_time = 0.02
-time_horizon = 2.0
-slow_down_factor = 5
+time_horizon = 1.0
+slow_down_factor = 5.0
 forward_direction = "x"
 scaling_factor = 1.0
 

--- a/examples/MANN/config/config_mann.toml
+++ b/examples/MANN/config/config_mann.toml
@@ -1,10 +1,20 @@
-
 joints_list = ['l_hip_pitch', 'l_hip_roll', 'l_hip_yaw', 'l_knee', 'l_ankle_pitch', 'l_ankle_roll',  # left leg
                'r_hip_pitch', 'r_hip_roll', 'r_hip_yaw', 'r_knee', 'r_ankle_pitch', 'r_ankle_roll',  # right leg
                'torso_pitch', 'torso_roll', 'torso_yaw',  # torso
                'neck_pitch', 'neck_roll', 'neck_yaw', # neck
                'l_shoulder_pitch', 'l_shoulder_roll', 'l_shoulder_yaw', 'l_elbow', # left arm
                'r_shoulder_pitch', 'r_shoulder_roll', 'r_shoulder_yaw', 'r_elbow'] # right arm
+
+# the joints are ordered as in the joints_list
+initial_joints_configuration = [-0.10922017141063572, 0.05081325960010118, 0.06581966291990003, -0.0898053099824925, -0.09324922528169599, -0.05110058859172172, # left leg
+                                -0.11021232812838086, 0.054291515925228385,0.0735575862560208, -0.09509332143185895, -0.09833823347493076, -0.05367281245082792, # right leg
+                                +0.1531558711397399, -0.001030634273454133, 0.0006584764419034815, # torso
+                                -0.0016821925351926288, -0.004284529460797688, 0.030389771690123243, # neck
+                                -0.040592118429752494, -0.1695472679986807, -0.20799422095574033, 0.045397975984119654, # left arm
+                                -0.03946672931050908, -0.16795588539580256, -0.20911090583076936, 0.0419854257806720] # right arm
+
+initial_base_height = 0.7748
+initial_base_quaternion =  [0.0, -0.0399893, 0.0, 0.9992001] # [x, y, z, w]
 
 root_link_frame_name = "root_link"
 chest_link_frame_name = "chest"

--- a/src/ML/include/BipedalLocomotion/ML/MANN.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANN.h
@@ -51,7 +51,10 @@ struct MANNInput
      * @param jointPositions vector containing the joint position in radians.
      * @param projectedBaseHorizon number of samples of the base horizon considered in the neural
      * network.
-     * @return the MANNInput.
+     * @return a dummy MANNInput.
+     * @note A dummy MANNInput is generated assuming zero joint velocities and zero
+     * basePositionTrajectory, zero baseVelocitiesTrajectory. and facingDirectionTrajectory with the
+     * first row equal to one and the second to zero.
      * @warning the function assumes that the robot is not moving and facing forward.
      */
     static MANNInput generateDummyMANNInput(Eigen::Ref<const Eigen::VectorXd> jointPositions,
@@ -90,7 +93,10 @@ struct MANNOutput
      * @param jointPositions vector containing the joint positions in radians.
      * @param futureProjectedBaseHorizon number of samples of the base horizon generated as output
      * by the neural network.
-     * @return the MANNOutput.
+     * @return a dummy MANNOutput.
+     * @note A dummy MANNOutput is generated assuming zero joint velocities, zero
+     * futureBasePositionTrajectory, zero futureBaseVelocitiesTrajectory, and
+     * futureFacingDirectionTrajectory with the first row equal to one and the second to zero.
      * @warning the function assumes that the robot is not moving and facing forward.
      */
     static MANNOutput generateDummyMANNOutput(Eigen::Ref<const Eigen::VectorXd> jointPositions,

--- a/src/ML/include/BipedalLocomotion/ML/MANN.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANN.h
@@ -87,7 +87,7 @@ struct MANNOutput
 
     /**
      * Generate a dummy MANNOutput from a given joint configuration
-     * @param jointPositions vector containing the joint position in radians.
+     * @param jointPositions vector containing the joint positions in radians.
      * @param futureProjectedBaseHorizon number of samples of the base horizon generated as output
      * by the neural network.
      * @return the MANNOutput.

--- a/src/ML/include/BipedalLocomotion/ML/MANN.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANN.h
@@ -27,8 +27,8 @@ namespace ML
  * The base position trajectory, facing direction trajectory and base velocity trajectories are
  * written in a bidimensional local reference frame L in which we assume all the quantities related
  * to the ground-projected base trajectory in xi and yi to be expressed. At each step ti,
- * L is defined to have its origin in the current ground-projected robot base position and orientation defined
- * by the current facing direction (along with its orthogonal vector).
+ * L is defined to have its origin in the current ground-projected robot base position and
+ * orientation defined by the current facing direction (along with its orthogonal vector).
  */
 struct MANNInput
 {
@@ -45,6 +45,17 @@ struct MANNInput
     Eigen::VectorXd jointPositions; /**< Vector containing the actual joint position in radians. */
     Eigen::VectorXd jointVelocities; /**< Vector containing the actual joint velocity in radians per
                                         seconds. */
+
+    /**
+     * Generate a dummy MANNInput from a given joint configuration
+     * @param jointPositions vector containing the joint position in radians.
+     * @param projectedBaseHorizon number of samples of the base horizon considered in the neural
+     * network.
+     * @return the MANNInput.
+     * @warning the function assumes that the robot is not moving and facing forward.
+     */
+    static MANNInput generateDummyMANNInput(Eigen::Ref<const Eigen::VectorXd> jointPositions,
+                                            std::size_t projectedBaseHorizon);
 };
 
 /**
@@ -73,6 +84,17 @@ struct MANNOutput
     Eigen::VectorXd jointVelocities; /**< Vector containing the next joint velocity in radians per
                                         seconds */
     manif::SE2Tangentd projectedBaseVelocity; /**< Velocity of the base projected on the ground */
+
+    /**
+     * Generate a dummy MANNOutput from a given joint configuration
+     * @param jointPositions vector containing the joint position in radians.
+     * @param futureProjectedBaseHorizon number of samples of the base horizon generated as output
+     * by the neural network.
+     * @return the MANNOutput.
+     * @warning the function assumes that the robot is not moving and facing forward.
+     */
+    static MANNOutput generateDummyMANNOutput(Eigen::Ref<const Eigen::VectorXd> jointPositions,
+                                              std::size_t futureProjectedBaseHorizon);
 };
 
 /**
@@ -96,6 +118,7 @@ public:
      */
     ~MANN();
 
+    // clang-format off
     /**
      * Initialize the network.
      * @param paramHandler pointer to the parameters handler.
@@ -108,6 +131,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+    // clang-format on
 
     /**
      * Set the input of the network
@@ -135,7 +159,6 @@ public:
     bool isOutputValid() const override;
 
 private:
-
     /** Private implementation */
     struct Impl;
     std::unique_ptr<Impl> m_pimpl;

--- a/src/ML/include/BipedalLocomotion/ML/MANN.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANN.h
@@ -129,11 +129,11 @@ public:
      * Initialize the network.
      * @param paramHandler pointer to the parameters handler.
      * @note the following parameters are required by the class
-     * |      Parameter Name      |       Type       |                          Description                                | Mandatory |
-     * |:------------------------:|:----------------:|:-------------------------------------------------------------------:|:---------:|
-     * |    `onnx_model_path`     |      `string`    |  Path to the `onnx` model that will be loaded to perform inference  |    Yes    |
-     * |   `number_of_joints`     |       `int`      |         Number of robot joints considered in the model              |    Yes    |
-     * | `projected_base_horizon` |       `int`      |    Number of samples of the base horizon considered in the model    |    Yes    |
+     * |        Parameter Name       |       Type       |                                       Description                                              | Mandatory |
+     * |:---------------------------:|:----------------:|:----------------------------------------------------------------------------------------------:|:---------:|
+     * |       `onnx_model_path`     |      `string`    |          Path to the `onnx` model that will be loaded to perform inference                     |    Yes    |
+     * |     `number_of_joints`      |       `int`      |               Number of robot joints considered in the model                                   |    Yes    |
+     * | `projected_base_datapoints` |       `int`      |    Number of samples of the base horizon considered in the model (it must be an even number)   |    Yes    |
      * @return True in case of success, false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;

--- a/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
@@ -45,7 +45,10 @@ struct MANNFootState
      * @param footName name of the foot.
      * @param footIndex index of the foot in the model. This is required to compute the foot
      * position with the KinDynComputations object.
-     * @return a dummy foot state.
+     * @return a dummy MANNFootState.
+     * @note a dummy MANNFootState is generated assuming that the foot is in contact with the ground
+     * and the Math::SchmittTriggerState is in the on state (i.e., the foot is in contact). Moreover
+     * a dummy MANNFootState is generated setting to zero the switch time of the Schmitt trigger.
      * @warning This function assumes that the foot is in contact with the ground and the
      * Math::SchmittTriggerState is in the on state (i.e., the foot is in contact).
      */
@@ -169,9 +172,12 @@ public:
          * @param I_H_B SE(3) transformation of the base respect to the inertial frame.
          * @param leftFootState left foot state.
          * @param rightFootState right foot state.
-         * @return A dummy autoregressive state.
-         * @warning the autoregressive state is generated assuming that the robot is not moving
-         * and facing forward.
+         * @return A dummy AutoregressiveState.
+         * @note A dummy AutoregressiveState is generated zeroing the
+         * projectedContactPositionInWorldFrame, zeroing the pastProjectedBasePositions and
+         * pastProjectedBaseVelocity. On the other hand, the pastFacingDirection is generated with
+         * the first row equal to one and the second to zero. The dummy AutoregressiveState set the
+         * time to zero.
          */
         static AutoregressiveState
         generateDummyAutoregressiveState(const MANNInput& input,

--- a/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
@@ -172,6 +172,9 @@ public:
          * @param I_H_B SE(3) transformation of the base respect to the inertial frame.
          * @param leftFootState left foot state.
          * @param rightFootState right foot state.
+         * @param mocapFrameRate frame rate of the mocap data.
+         * @param pastProjectedBaseHorizon number of samples of the past base horizon considered in
+         * the neural network.
          * @return A dummy AutoregressiveState.
          * @note A dummy AutoregressiveState is generated zeroing the
          * projectedContactPositionInWorldFrame, zeroing the pastProjectedBasePositions and
@@ -184,7 +187,9 @@ public:
                                          const MANNOutput& output,
                                          const manif::SE3d& I_H_B,
                                          const MANNFootState& leftFootState,
-                                         const MANNFootState& rightFootState);
+                                         const MANNFootState& rightFootState,
+                                         int mocapFrameRate,
+                                         const std::chrono::nanoseconds& pastProjectedBaseHorizon);
     };
 
     /**
@@ -218,6 +223,8 @@ public:
      * | `right_foot_frame_name`  | `string` |                                 Name of of the right foot frame in the model.                                 |    Yes    |
      * |  `left_foot_frame_name`  | `string` |                                  Name of of the left foot frame in the model.                                 |    Yes    |
      * |    `forward_direction`   | `string` |  String containing 'x', 'y' or 'z' representing the foot link forward axis. Currently, only 'x' is supported. |    Yes    |
+     * |    `mocap_frame_rate`    |   `int`  |                                       Frame rate of the mocap data.                                           |    Yes    |
+     * | `past_projected_horizon` | `double` |                    Number of seconds of the past base horizon considered in the neural network.               |    Yes    |
      * It is also required to define two groups `LEFT_FOOT` and `RIGHT_FOOT` that contains the following parameter
      * |    Parameter Name    |       Type       |                                                        Description                                                           | Mandatory |
      * |:--------------------:|:----------------:|:----------------------------------------------------------------------------------------------------------------------------:|:---------:|
@@ -228,10 +235,10 @@ public:
      * |   `switch_on_after`  |     `double`     |     Seconds to wait for before switching to activate from deactivate contact. Ensure it's greater than sampling time.        |    Yes    |
      * |  `switch_off_after`  |     `double`     |     Seconds to wait for before switching to deactivate from activate contact. Ensure it's greater than sampling time.        |    Yes    |
      * Finally it also required to define a group named `MANN` that contains the following parameter
-     * |      Parameter Name      |   Type   |                          Description                                | Mandatory |
-     * |:------------------------:|:--------:|:-------------------------------------------------------------------:|:---------:|
-     * |    `onnx_model_path`     | `string` |  Path to the `onnx` model that will be loaded to perform inference. |    Yes    |
-     * | `projected_base_horizon` |  `int`   |    Number of samples of the base horizon considered in the model.   |    Yes    |
+     * |          Parameter Name         |   Type   |                                         Description                                         | Mandatory |
+     * |:-------------------------------:|:--------:|:-------------------------------------------------------------------------------------------:|:---------:|
+     * |        `onnx_model_path`        | `string` |         Path to the `onnx` model that will be loaded to perform inference.                  |    Yes    |
+     * |   `projected_base_datapoints`   |  `int`   | Number of samples of the base horizon considered in the model (It must be an even number).  |    Yes    |
      * @return True in case of success, false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;

--- a/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
@@ -37,7 +37,7 @@ struct MANNFootState
     std::vector<Eigen::Vector3d> corners; /**< Corners of the foot */
 
     /**
-     * Generate a dummy foot state.
+     * Generate a foot state.
      * @param kindyn an instance of KinDynComputations used to compute the foot position.
      * @param corners Vector containing the corners of the foot expressed in the foot frame (i.e., a
      * frame attached to the foot sole with the x axis pointing forward, the y axis pointing to the
@@ -290,7 +290,7 @@ public:
     const AutoregressiveState& getAutoregressiveState() const;
 
     /**
-     * Get the autoregressive state required to rest MANNAutoregressive.
+     * Get the autoregressive state required to reset MANNAutoregressive.
      * @param jointPositions joint position
      * @param basePose base pose
      * @param state autoregressive state that will be populated

--- a/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANNAutoregressive.h
@@ -28,6 +28,34 @@ namespace ML
 {
 
 /**
+ * MANNFootState contains the state of a foot in contact with the ground.
+ */
+struct MANNFootState
+{
+    Contacts::EstimatedContact contact; /**< Contact state */
+    Math::SchmittTriggerState schmittTriggerState; /**< Schmitt trigger state */
+    std::vector<Eigen::Vector3d> corners; /**< Corners of the foot */
+
+    /**
+     * Generate a dummy foot state.
+     * @param kindyn an instance of KinDynComputations used to compute the foot position.
+     * @param corners Vector containing the corners of the foot expressed in the foot frame (i.e., a
+     * frame attached to the foot sole with the x axis pointing forward, the y axis pointing to the
+     * left and the z axis pointing upward).
+     * @param footName name of the foot.
+     * @param footIndex index of the foot in the model. This is required to compute the foot
+     * position with the KinDynComputations object.
+     * @return a dummy foot state.
+     * @warning This function assumes that the foot is in contact with the ground and the
+     * Math::SchmittTriggerState is in the on state (i.e., the foot is in contact).
+     */
+    static MANNFootState generateFootState(iDynTree::KinDynComputations& kindyn,
+                                           const std::vector<Eigen::Vector3d>& corners,
+                                           const std::string& footName,
+                                           int footIndex);
+};
+
+/**
  * MANNAutoregressiveInput contains the unput to MANN network when used in autoregressive fashion.
  * The base position trajectory, facing direction trajectory and base velocity trajectories are
  * written in a bidimensional local reference frame L in which we assume all the quantities related
@@ -60,15 +88,14 @@ struct MANNAutoregressiveOutput
     Eigen::VectorXd jointsPosition; /**< Joint positions in radians */
     manif::SE3d basePose; /**< Base pose with respect to the inertial frame, i.e., \f${}^I H_B\f$ */
     manif::SE3d::Tangent baseVelocity; /**< Base velocity in mixed representation */
-    Eigen::Vector3d comPosition;
-    Eigen::Vector3d angularMomentum;
+    Eigen::Vector3d comPosition; /**< Position of the CoM with respect to the inertial frame */
+    Eigen::Vector3d angularMomentum; /**< Centroidal angular momentum */
     Contacts::EstimatedContact leftFoot; /**< Left foot contact */
-    Math::SchmittTriggerState leftFootSchmittTriggerState;
     Contacts::EstimatedContact rightFoot; /**< Right foot contact */
-    Math::SchmittTriggerState rightFootSchmittTriggerState;
     std::chrono::nanoseconds currentTime; /**< Current time stored in the advanceable */
 };
 
+// clang-format off
 /**
  * MANNAutoregressive is a class that allows to perform autoregressive inference with Mode-Adaptive
  * Neural Networks (MANN).
@@ -82,10 +109,21 @@ struct MANNAutoregressiveOutput
  * in IEEE Robotics and Automation Letters, vol. 7, no. 2, pp. 2779-2786, April 2022,
  * doi: 10.1109/LRA.2022.3141658." https://doi.org/10.1109/LRA.2022.3141658
  */
+// clang-format on
 class MANNAutoregressive
     : public System::Advanceable<MANNAutoregressiveInput, MANNAutoregressiveOutput>
 {
 public:
+    /**
+     * SupportFoot is an enum that contains the support foot considered by the MANN network.
+     */
+    enum class SupportFoot
+    {
+        Left, /**< Left foot */
+        Right, /**< Right foot */
+        Unknown /**< This is useful to detect unexpected behaviour */
+    };
+
     /**
      * AutoregressiveState contains all quantities required to reset the Advanceable
      * The base position trajectory, facing direction trajectory and base velocity trajectories are
@@ -96,7 +134,9 @@ public:
      */
     struct AutoregressiveState
     {
-        MANNInput previousMannInput; /**< Mann Input at the previous time instant */
+        MANNOutput previousMANNOutput; /**< Output of the MANN network generated at the previous
+                                          iteration */
+        MANNInput previousMANNInput; /**< Input to the MANN network at previous iteration */
         manif::SE2d I_H_FD; /**< SE(2) transformation of the facing direction respect to the
                                inertial frame*/
 
@@ -111,6 +151,34 @@ public:
         /** Past projected base velocity, Each element of the deque contains the x and y velocity
          * projected into the ground. */
         std::deque<Eigen::Vector2d> pastProjectedBaseVelocity;
+
+        MANNFootState leftFootState; /**< Left foot state */
+        MANNFootState rightFootState; /**< Right foot state */
+        manif::SE3d I_H_B; /**< SE(3) transformation of the base respect to the inertial frame */
+        SupportFoot supportFoot{SupportFoot::Unknown}; /**< Support foot */
+        Eigen::Vector3d projectedContactPositionInWorldFrame; /**< Projected contact position in
+                                                                 world frame */
+        int supportCornerIndex{-1}; /**< Index of the support corner */
+
+        std::chrono::nanoseconds time; /**< Current time stored in the advanceable */
+
+        /**
+         * Generate a dummy autoregressive state from the input.
+         * @param input input to the autoregressive model.
+         * @param output output of the autoregressive model.
+         * @param I_H_B SE(3) transformation of the base respect to the inertial frame.
+         * @param leftFootState left foot state.
+         * @param rightFootState right foot state.
+         * @return A dummy autoregressive state.
+         * @warning the autoregressive state is generated assuming that the robot is not moving
+         * and facing forward.
+         */
+        static AutoregressiveState
+        generateDummyAutoregressiveState(const MANNInput& input,
+                                         const MANNOutput& output,
+                                         const manif::SE3d& I_H_B,
+                                         const MANNFootState& leftFootState,
+                                         const MANNFootState& rightFootState);
     };
 
     /**
@@ -131,6 +199,7 @@ public:
      */
     bool setRobotModel(const iDynTree::Model& model);
 
+    // clang-format off
     /**
      * Initialize the network.
      * @param paramHandler pointer to the parameters handler.
@@ -142,14 +211,14 @@ public:
      * | `chest_link_frame_name`  | `string` |                                 Name of of the chest link frame in the model.                                 |    Yes    |
      * | `right_foot_frame_name`  | `string` |                                 Name of of the right foot frame in the model.                                 |    Yes    |
      * |  `left_foot_frame_name`  | `string` |                                  Name of of the left foot frame in the model.                                 |    Yes    |
-     * |    `forward_direction`   | `string` | String cointaining 'x', 'y' or 'z' representing the foot link forward axis. Currently, only 'x' is supported. |    Yes    |
+     * |    `forward_direction`   | `string` |  String containing 'x', 'y' or 'z' representing the foot link forward axis. Currently, only 'x' is supported. |    Yes    |
      * It is also required to define two groups `LEFT_FOOT` and `RIGHT_FOOT` that contains the following parameter
      * |    Parameter Name    |       Type       |                                                        Description                                                           | Mandatory |
      * |:--------------------:|:----------------:|:----------------------------------------------------------------------------------------------------------------------------:|:---------:|
      * |  `number_of_corners` |       `int`      |                                        Number of corners associated to the foot                                              |    Yes    |
-     * |      `corner_<i>`    | `vector<double>` |               Position of the corner expressed in the foot frame. It must be from 0 to number_of_corners - 1.                 |    Yes    |
+     * |      `corner_<i>`    | `vector<double>` |               Position of the corner expressed in the foot frame. It must be from 0 to number_of_corners - 1.                |    Yes    |
      * |     `on_threshold`   |     `double`     |  Distance between the foot and the ground used as on threshold of the trigger to activate the contact. It must be positive.  |    Yes    |
-     * |    `off_threshold`   |     `double`     | Distance between the foot and the ground used as off threshold of the trigger to deactivate the contact. It must be positive. |    Yes    |
+     * |    `off_threshold`   |     `double`     | Distance between the foot and the ground used as off threshold of the trigger to deactivate the contact. It must be positive.|    Yes    |
      * |   `switch_on_after`  |     `double`     |     Seconds to wait for before switching to activate from deactivate contact. Ensure it's greater than sampling time.        |    Yes    |
      * |  `switch_off_after`  |     `double`     |     Seconds to wait for before switching to deactivate from activate contact. Ensure it's greater than sampling time.        |    Yes    |
      * Finally it also required to define a group named `MANN` that contains the following parameter
@@ -160,6 +229,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+    // clang-format on
 
     /**
      * Set the input to the autoregressive model.
@@ -176,43 +246,24 @@ public:
 
     /**
      * Reset the autoregressive model
-     * @param input raw mann input.
-     * @param leftFoot state of the left foot.
-     * @param rightFoot state of the right foot.
-     * @param basePosition current base position.
-     * @param baseVelocity current base velocity expressed in mixed representation.
+     * @param jointPositions joint position.
+     * @param basePose base pose.
      * @return true in case of success, false otherwise.
-     * @note please call this function the before calling MANNAutoregressive::advance the first time
-     * time.
+     * @note Please call this function before calling MANNAutoregressive::advance the first time.
+     * @warning This function assumes that both the feet are in contact with the ground, the joint
+     * and base velocities equal to zero.
+     * @warning This function reset also the internal time to zero.
      */
-    bool reset(const MANNInput& input,
-               const Contacts::EstimatedContact& leftFoot,
-               const Contacts::EstimatedContact& rightFoot,
-               const manif::SE3d& basePose,
-               const manif::SE3Tangentd& baseVelocity);
+    bool reset(Eigen::Ref<const Eigen::VectorXd> jointPositions, const manif::SE3d& basePose);
 
     /**
      * Reset the autoregressive model
-     * @param input raw mann input.
-     * @param leftFoot state of the left foot.
-     * @param rightFoot state of the right foot.
-     * @param basePosition current base position.
-     * @param baseVelocity current base velocity expressed in mixed representation.
      * @param autoregressiveState the autoregressive state at which you want to reset your model.
-     * @param time time used to reset the system
      * @return true in case of success, false otherwise.
-     * @note please call this function the before calling MANNAutoregressive::advance the first time
+     * @note Please call this function the before calling MANNAutoregressive::advance the first time
      * time.
      */
-    bool reset(const MANNInput& input,
-               const Contacts::EstimatedContact& leftFoot,
-               const Math::SchmittTriggerState& leftFootSchimittTriggerState,
-               const Contacts::EstimatedContact& rightFoot,
-               const Math::SchmittTriggerState& rightFootSchimittTriggerState,
-               const manif::SE3d& basePosition,
-               const manif::SE3Tangentd& baseVelocity,
-               const AutoregressiveState& autoregressiveState,
-               const std::chrono::nanoseconds& time);
+    bool reset(const AutoregressiveState& autoregressiveState);
 
     /**
      * Check if the output is valid.
@@ -237,6 +288,19 @@ public:
      * @return the AutoregressiveState
      */
     const AutoregressiveState& getAutoregressiveState() const;
+
+    /**
+     * Get the autoregressive state required to rest MANNAutoregressive.
+     * @param jointPositions joint position
+     * @param basePose base pose
+     * @param state autoregressive state that will be populated
+     * @return true in case of success, false otherwise.
+     * @note This function assumes that both the feet are in contact with the ground, the joint
+     * and base velocities equal to zero.
+     */
+    bool populateInitialAutoregressiveState(Eigen::Ref<const Eigen::VectorXd> jointPositions,
+                                            const manif::SE3d& basePose,
+                                            MANNAutoregressive::AutoregressiveState& state);
 
 private:
     struct Impl;

--- a/src/ML/include/BipedalLocomotion/ML/MANNTrajectoryGenerator.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANNTrajectoryGenerator.h
@@ -44,6 +44,9 @@ struct MANNTrajectoryGeneratorOutput
 
     std::vector<Eigen::VectorXd> jointPositions; /**< Joints position in radians */
     std::vector<manif::SE3d> basePoses; /**< Vector containing the base pose for each instant. */
+
+    std::vector<std::chrono::nanoseconds> timestamps; /**< Vector containing the time stamps. */
+
     Contacts::ContactPhaseList phaseList; /**< List of the contact phases */
 };
 
@@ -96,6 +99,7 @@ public:
      */
     bool setRobotModel(const iDynTree::Model& model);
 
+    // clang-format off
     /**
      * Initialize the trajectory planner.
      * @param paramHandler pointer to the parameters handler.
@@ -108,8 +112,9 @@ public:
      * | `chest_link_frame_name`  | `string` |                                 Name of of the chest link frame in the model.                                 |    Yes    |
      * | `right_foot_frame_name`  | `string` |                                 Name of of the right foot frame in the model.                                 |    Yes    |
      * |  `left_foot_frame_name`  | `string` |                                  Name of of the left foot frame in the model.                                 |    Yes    |
-     * |    `forward_direction`   | `string` | String cointaining 'x', 'y' or 'z' representing the foot link forward axis. Currently, only 'x' is supported. |    Yes    |
-     * |    `slow_down_factor`    |   `int`  |      The `horizon` will be `horizon * slow_down_factor`. Same for the `sampling_time` (default value 1).      |    No     |
+     * |    `forward_direction`   | `string` |  String containing 'x', 'y' or 'z' representing the foot link forward axis. Currently, only 'x' is supported. |    Yes    |
+     * |    `slow_down_factor`    | `double` |         The `horizon` will be `horizon * slow_down_factor`. Same for the `sampling_time`.                     |    Yes    |
+     * |     `scaling_factor`     | `double` |     Scaling factor considered in the generation of the CoM, base and contact points locations                 |    Yes    |
      * It is also required to define two groups `LEFT_FOOT` and `RIGHT_FOOT` that contains the following parameter
      * |      Parameter Name      |        Type       |                                        Description                                             | Mandatory |
      * |:------------------------:|:-----------------:|:----------------------------------------------------------------------------------------------:|:---------:|
@@ -123,6 +128,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;
+    // clang-format on
 
     /**
      * Set the input to the planner model.
@@ -157,11 +163,8 @@ public:
      * @param basePose pose of the base.
      * @param time initial time of the planner.
      */
-    void setInitialState(Eigen::Ref<const Eigen::VectorXd> jointPositions,
-                         const Contacts::EstimatedContact& leftFoot,
-                         const Contacts::EstimatedContact& rightFoot,
-                         const manif::SE3d& basePose,
-                         const std::chrono::nanoseconds& time);
+    bool setInitialState(Eigen::Ref<const Eigen::VectorXd> jointPositions, //
+                         const manif::SE3d& basePose);
 
 private:
     struct Impl;

--- a/src/ML/src/MANN.cpp
+++ b/src/ML/src/MANN.cpp
@@ -177,13 +177,13 @@ bool MANN::initialize(
         return true;
     };
 
-    int numberOfJoints, projectedBaseHorizon;
+    int numberOfJoints, projectedBaseDatapoints;
     std::string networkModelPath;
     bool ok = loadParam("number_of_joints", numberOfJoints);
-    ok = ok && loadParam("projected_base_horizon", projectedBaseHorizon);
+    ok = ok && loadParam("projected_base_datapoints", projectedBaseDatapoints);
     ok = ok && loadParam("onnx_model_path", networkModelPath);
 
-    if (projectedBaseHorizon % 2 != 0)
+    if (projectedBaseDatapoints % 2 != 0)
     {
         log()->error("{} Project base horizon must be an even number. This is required by mann.",
                      logPrefix);
@@ -213,13 +213,13 @@ bool MANN::initialize(
     }
 
     // the input of the network is composed by
-    const std::size_t inputSize = 2 * projectedBaseHorizon // position of the base on x and y
-                                                           // coordinate in the horizon
-                                  + 2 * projectedBaseHorizon // facing direction on x and y
-                                                             // coordinate in the horizon (equal to
-                                                             // projectedBaseHorizon)
-                                  + 2 * projectedBaseHorizon // velocity of the base on x and y
-                                                             // coordinate in the horizon
+    const std::size_t inputSize = 2 * projectedBaseDatapoints // position of the base on x and y
+                                                              // coordinate in the horizon
+                                  + 2 * projectedBaseDatapoints // facing direction on x and y
+                                                                // coordinate in the horizon (equal
+                                                                // to projectedBaseHorizon)
+                                  + 2 * projectedBaseDatapoints // velocity of the base on x and y
+                                                                // coordinate in the horizon
                                   + numberOfJoints // joints positions
                                   + numberOfJoints; // joints velocities
 
@@ -238,20 +238,20 @@ bool MANN::initialize(
 
     // populate variable handler related to the input
     // the serialization matters
-    m_pimpl->structuredInput.handler.addVariable("base_positions", 2 * projectedBaseHorizon);
-    m_pimpl->structuredInput.handler.addVariable("facing_directions", 2 * projectedBaseHorizon);
-    m_pimpl->structuredInput.handler.addVariable("base_velocities", 2 * projectedBaseHorizon);
+    m_pimpl->structuredInput.handler.addVariable("base_positions", 2 * projectedBaseDatapoints);
+    m_pimpl->structuredInput.handler.addVariable("facing_directions", 2 * projectedBaseDatapoints);
+    m_pimpl->structuredInput.handler.addVariable("base_velocities", 2 * projectedBaseDatapoints);
     m_pimpl->structuredInput.handler.addVariable("joint_positions", numberOfJoints);
     m_pimpl->structuredInput.handler.addVariable("joint_velocities", numberOfJoints);
 
     // populate the output
-    const std::size_t outputSize = 2 * projectedBaseHorizon / 2 // position of the base on x and y
+    const std::size_t outputSize = 2 * projectedBaseDatapoints / 2 // position of the base on x and y
                                                                 // coordinate in the future horizon
-                                   + 2 * projectedBaseHorizon / 2 // facing direction on x and y
+                                   + 2 * projectedBaseDatapoints / 2 // facing direction on x and y
                                                                   // coordinate in the future
                                                                   // horizon (equal to
                                                                   // projectedBaseHorizon)
-                                   + 2 * projectedBaseHorizon / 2 // velocity of the base on x and y
+                                   + 2 * projectedBaseDatapoints / 2 // velocity of the base on x and y
                                                                   // coordinate in the future
                                                                   // horizon
                                    + numberOfJoints // joints positions
@@ -273,19 +273,19 @@ bool MANN::initialize(
     // populate variable handler related to the output
     // the serialization matters
     m_pimpl->structuredOutput.handler.addVariable("future_base_positions",
-                                                  2 * projectedBaseHorizon / 2);
+                                                  2 * projectedBaseDatapoints / 2);
     m_pimpl->structuredOutput.handler.addVariable("future_facing_directions",
-                                                  2 * projectedBaseHorizon / 2);
+                                                  2 * projectedBaseDatapoints / 2);
     m_pimpl->structuredOutput.handler.addVariable("future_base_velocities",
-                                                  2 * projectedBaseHorizon / 2);
+                                                  2 * projectedBaseDatapoints / 2);
     m_pimpl->structuredOutput.handler.addVariable("joint_positions", numberOfJoints);
     m_pimpl->structuredOutput.handler.addVariable("joint_velocities", numberOfJoints);
     m_pimpl->structuredOutput.handler.addVariable("base_velocity", 3);
 
     // resize the output
-    m_pimpl->output.futureBasePositionTrajectory.resize(2, projectedBaseHorizon / 2);
-    m_pimpl->output.futureFacingDirectionTrajectory.resize(2, projectedBaseHorizon / 2);
-    m_pimpl->output.futureBaseVelocitiesTrajectory.resize(2, projectedBaseHorizon / 2);
+    m_pimpl->output.futureBasePositionTrajectory.resize(2, projectedBaseDatapoints / 2);
+    m_pimpl->output.futureFacingDirectionTrajectory.resize(2, projectedBaseDatapoints / 2);
+    m_pimpl->output.futureBaseVelocitiesTrajectory.resize(2, projectedBaseDatapoints / 2);
     m_pimpl->output.jointPositions.resize(numberOfJoints);
     m_pimpl->output.jointVelocities.resize(numberOfJoints);
     m_pimpl->output.projectedBaseVelocity = manif::SE2Tangentd::Zero();

--- a/src/ML/src/MANNTrajectoryGenerator.cpp
+++ b/src/ML/src/MANNTrajectoryGenerator.cpp
@@ -49,7 +49,6 @@ struct MANNTrajectoryGenerator::Impl
 
     MANNTrajectoryGeneratorOutput output;
     std::chrono::nanoseconds horizon;
-    int projectedBaseHorizonSize;
 
     iDynTree::KinDynComputations kinDyn;
     Eigen::Vector3d gravity;
@@ -286,10 +285,6 @@ bool MANNTrajectoryGenerator::initialize(
     ok = ok && getParameter(paramHandler, "sampling_time", m_pimpl->dT);
     ok = ok && getFrameIndex(paramHandler, "left_foot_frame_name", m_pimpl->leftFootIndex);
     ok = ok && getFrameIndex(paramHandler, "right_foot_frame_name", m_pimpl->rightFootIndex);
-    ok = ok
-         && getParameter(paramHandler.lock()->getGroup("MANN"),
-                         "projected_base_horizon",
-                         m_pimpl->projectedBaseHorizonSize);
 
     if (!ok)
     {

--- a/src/ML/src/MANNTrajectoryGenerator.cpp
+++ b/src/ML/src/MANNTrajectoryGenerator.cpp
@@ -15,47 +15,65 @@
 #include <iDynTree/Model/Model.h>
 #include <manif/SE3.h>
 
+#include <iDynTree/Core/EigenHelpers.h>
+
 using namespace BipedalLocomotion::ML;
 using namespace BipedalLocomotion;
 
 struct MANNTrajectoryGenerator::Impl
 {
-    struct MergePointState
+    template <typename T> struct ScalingState
     {
-        MANNInput input;
-        Contacts::EstimatedContact leftFoot;
-        Math::SchmittTriggerState leftFootSchmittTriggerState;
-        Contacts::EstimatedContact rightFoot;
-        Math::SchmittTriggerState rightFootSchmittTriggerState;
-        manif::SE3d basePosition;
-        manif::SE3Tangentd baseVelocity;
-        MANNAutoregressive::AutoregressiveState autoregressiveState;
-        std::chrono::nanoseconds time;
+        T previous;
+        T previousScaled;
     };
 
-    MANNAutoregressive mann;
+    struct MANNTrajectoryGeneratorState
+    {
+        MANNAutoregressive::AutoregressiveState MANNAutoregressiveState;
+        ScalingState<Eigen::Vector3d> com;
+        ScalingState<Eigen::Vector3d> basePosition;
+    };
+
+    MANNAutoregressive mannAutoregressive;
     MANNAutoregressiveInput mannAutoregressiveInput;
-    std::vector<MergePointState> mergePointStates;
+    std::vector<MANNTrajectoryGeneratorState> mergePointStates;
+    std::unordered_map<std::string, std::vector<ScalingState<Eigen::Vector3d>>> footState;
+
     std::chrono::nanoseconds dT;
     bool isOutputValid{false};
-    int slowDownFactor{1};
+    double slowDownFactor{1.0};
+    double scalingFactor{1.0};
 
     Contacts::ContactListMap contactListMap;
+
     MANNTrajectoryGeneratorOutput output;
     std::chrono::nanoseconds horizon;
     int projectedBaseHorizonSize;
 
-    bool updateContactList(const std::string& footName,
-                           const std::chrono::nanoseconds& currentTime,
-                           const Contacts::EstimatedContact& estimatedContact);
+    iDynTree::KinDynComputations kinDyn;
+    Eigen::Vector3d gravity;
+    int leftFootIndex;
+    int rightFootIndex;
 
-    bool resetContactList(const Contacts::EstimatedContact& estimatedContact,
-                          const std::string& contactName);
+    /**
+     * Reset the contact list given an estimated contact from mann autorergressive.
+     */
+    bool resetContactList(const std::string& contactName,
+                          const Contacts::EstimatedContact& estimatedContact,
+                          const std::chrono::nanoseconds& time);
 
-    static double extactYawAngle(const Eigen::Ref<const Eigen::Matrix3d>& R);
+    /**
+     * Update the contact list given an estimated contact from mann autorergressive.
+     */
+    bool updateContactList(const std::string& contactName,
+                           const Contacts::EstimatedContact& estimatedContact,
+                           const std::chrono::nanoseconds& time);
+
+    static double extractYawAngle(const Eigen::Ref<const Eigen::Matrix3d>& R);
 };
 
-double MANNTrajectoryGenerator::Impl::extactYawAngle(const Eigen::Ref<const Eigen::Matrix3d>& R)
+double MANNTrajectoryGenerator::Impl::extractYawAngle(const Eigen::Ref<const Eigen::Matrix3d>& R)
 {
     if (R(2, 0) < 1.0)
     {
@@ -74,89 +92,121 @@ double MANNTrajectoryGenerator::Impl::extactYawAngle(const Eigen::Ref<const Eige
 }
 
 bool MANNTrajectoryGenerator::Impl::resetContactList(
-    const Contacts::EstimatedContact& estimatedContact, const std::string& contactName)
+    const std::string& contactName,
+    const Contacts::EstimatedContact& estimatedContact,
+    const std::chrono::nanoseconds& time)
 {
-    // if the contact is not active we do not have to add in the contact list
+    auto& contactList = this->contactListMap[contactName];
+
+    constexpr auto logPrefix = "[MANNTrajectoryGenerator::Impl::resetContactList]";
+
+    // if the contact is not active we store the previous valid contact in the contact list
     if (!estimatedContact.isActive)
     {
-        return true;
+        // if the contact is not active we keep the previous contact in the contact list
+        const auto latestActiveContact = contactList.getPresentContact(time);
+
+        if (latestActiveContact == contactList.cend())
+        {
+            log()->error("[MANNTrajectoryGenerator::Impl::resetContactList] Unable to find the "
+                         "latest active contact for the contact named {}. Time {}.",
+                         contactName,
+                         std::chrono::duration_cast<std::chrono::milliseconds>(time));
+
+            for (const auto& contact : contactList)
+            {
+                log()->error("[MANNTrajectoryGenerator::Impl::resetContactList] Contact {} is "
+                             "active between {} and {}.",
+                             contact.name,
+                             std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 contact.activationTime),
+                             std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 contact.deactivationTime));
+            }
+            return false;
+        }
+
+        const Contacts::PlannedContact temp = *latestActiveContact;
+        this->contactListMap[contactName].clear();
+        return this->contactListMap[contactName].addContact(temp);
     }
+
+    // if the contact is active we add a new contact to the list
     Contacts::PlannedContact temp;
-    temp.activationTime = estimatedContact.switchTime * slowDownFactor;
+    temp.activationTime = estimatedContact.switchTime;
     temp.deactivationTime = std::chrono::nanoseconds::max();
     temp.index = estimatedContact.index;
     temp.name = estimatedContact.name;
 
-    const double yaw = this->extactYawAngle(estimatedContact.pose.quat().toRotationMatrix());
-    const Eigen::Vector3d position = estimatedContact.pose.translation();
-    temp.pose.translation({position[0], position[1], 0.0});
+    // Here we assume that the ground is flat. Therefore, we can set the z to zero
+    const double yaw = this->extractYawAngle(estimatedContact.pose.quat().toRotationMatrix());
+    temp.pose.translation(
+        {estimatedContact.pose.translation()[0], estimatedContact.pose.translation()[1], 0.0});
     temp.pose.quat(Eigen::AngleAxis(yaw, Eigen::Vector3d::UnitZ()));
-
     temp.type = Contacts::ContactType::FULL;
+
+    this->contactListMap[contactName].clear();
     return this->contactListMap[contactName].addContact(temp);
 }
 
 bool MANNTrajectoryGenerator::Impl::updateContactList(
-    const std::string& footName,
-    const std::chrono::nanoseconds& currentTime,
-    const Contacts::EstimatedContact& estimatedContact)
+    const std::string& contactName,
+    const Contacts::EstimatedContact& estimatedContact,
+    const std::chrono::nanoseconds& time)
 {
-
     constexpr auto logPrefix = "[MANNTrajectoryGenerator::Impl::updateContactList]";
 
-    auto contactListIt = contactListMap.find(footName);
-    if (contactListIt == contactListMap.end())
+    auto contactListIt = this->contactListMap.find(contactName);
+    if (contactListIt == this->contactListMap.end())
     {
         log()->error("{} Unable to find the contact named {} in the dictionary.",
                      logPrefix,
-                     footName);
+                     contactName);
         return false;
     }
     Contacts::ContactList& contactList = contactListIt->second;
 
     // if the contact list map is empty then this is the first contact that we have to add to the
-    // list read it as
+    // list read it as (or)
     // 1. if contact is active and the list is empty means that the foot just touched the ground
     // 2. if contact is active and the last contact is not active means that the foot just touched
     // the ground
     if (estimatedContact.isActive
-        && (contactList.size() == 0
-            || !contactList.lastContact()->isContactActive(currentTime * this->slowDownFactor)))
+        && (contactList.size() == 0 || !contactList.lastContact()->isContactActive(time)))
     {
         Contacts::PlannedContact temp;
-        temp.activationTime = estimatedContact.switchTime * this->slowDownFactor;
+        temp.activationTime = estimatedContact.switchTime;
         temp.deactivationTime = std::chrono::nanoseconds::max();
         temp.index = estimatedContact.index;
         temp.name = estimatedContact.name;
 
-        // force the foot to be attached to a flat terrain
-        const double yaw = Impl::extactYawAngle(estimatedContact.pose.quat().toRotationMatrix());
+        // Here we assume that the ground is flat. Therefore, we can set the z to zero
+        const double yaw = Impl::extractYawAngle(estimatedContact.pose.quat().toRotationMatrix());
         temp.pose.translation(
             {estimatedContact.pose.translation()[0], estimatedContact.pose.translation()[1], 0.0});
         temp.pose.quat(Eigen::AngleAxis(yaw, Eigen::Vector3d::UnitZ()));
-
         temp.type = Contacts::ContactType::FULL;
         if (!contactList.addContact(temp))
         {
             log()->error("{} Unable to update the contact list for the contact named '{}",
                          logPrefix,
-                         footName);
+                         contactName);
             return false;
         }
     }
     // In this case the contact ended so we have to set the deactivation time
     else if (!estimatedContact.isActive && contactList.size() != 0
-             && contactList.lastContact()->isContactActive(currentTime * this->slowDownFactor))
+             && contactList.lastContact()->isContactActive(time))
     {
         // we cannot update the status of the last contact. We need to remove it and add it again
-        Contacts::PlannedContact lastContact = *(contactListMap[footName].lastContact());
-        lastContact.deactivationTime = currentTime * this->slowDownFactor;
+        Contacts::PlannedContact lastContact = *(contactListMap[contactName].lastContact());
+        lastContact.deactivationTime = time;
         contactList.removeLastContact();
         if (!contactList.addContact(lastContact))
         {
             log()->error("{} Unable to update the contact list for the contact named '{}",
                          logPrefix,
-                         footName);
+                         contactName);
             return false;
         }
     }
@@ -173,7 +223,8 @@ MANNTrajectoryGenerator::~MANNTrajectoryGenerator() = default;
 
 bool MANNTrajectoryGenerator::setRobotModel(const iDynTree::Model& model)
 {
-    return m_pimpl->mann.setRobotModel(model);
+    return m_pimpl->mannAutoregressive.setRobotModel(model)
+           && m_pimpl->kinDyn.loadRobotModel(model);
 }
 
 bool MANNTrajectoryGenerator::initialize(
@@ -200,11 +251,41 @@ bool MANNTrajectoryGenerator::initialize(
         return true;
     };
 
-    // this parameter is optional
-    getParameter(paramHandler, "slow_down_factor", m_pimpl->slowDownFactor);
+    // the following lambda function is useful to get the name of the indexes of all the frames
+    // required by the class
+    auto getFrameIndex
+        = [this,
+           getParameter,
+           logPrefix](std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
+                      const std::string& frameParamName,
+                      int& frameIndex) -> bool {
+        std::string frameName;
+        if (!getParameter(handler, frameParamName, frameName))
+        {
+            log()->error("{} Unable to find the parameter named '{}'.", logPrefix, frameParamName);
+            return false;
+        }
 
-    bool ok = getParameter(paramHandler, "time_horizon", m_pimpl->horizon);
+        iDynTree::FrameIndex tmp = this->m_pimpl->kinDyn.model().getFrameIndex(frameName);
+        if (tmp == iDynTree::LINK_INVALID_INDEX)
+        {
+            log()->error("{} Unable to find the frame named '{}' in the model.",
+                         logPrefix,
+                         frameName);
+            return false;
+        }
+
+        frameIndex = tmp;
+
+        return true;
+    };
+
+    bool ok = getParameter(paramHandler, "slow_down_factor", m_pimpl->slowDownFactor);
+    ok = ok && getParameter(paramHandler, "scaling_factor", m_pimpl->scalingFactor);
+    ok = ok && getParameter(paramHandler, "time_horizon", m_pimpl->horizon);
     ok = ok && getParameter(paramHandler, "sampling_time", m_pimpl->dT);
+    ok = ok && getFrameIndex(paramHandler, "left_foot_frame_name", m_pimpl->leftFootIndex);
+    ok = ok && getFrameIndex(paramHandler, "right_foot_frame_name", m_pimpl->rightFootIndex);
     ok = ok
          && getParameter(paramHandler.lock()->getGroup("MANN"),
                          "projected_base_horizon",
@@ -221,60 +302,82 @@ bool MANNTrajectoryGenerator::initialize(
     m_pimpl->output.jointPositions.resize(m_pimpl->horizon / m_pimpl->dT);
     m_pimpl->output.angularMomentumTrajectory.resize(m_pimpl->horizon / m_pimpl->dT);
     m_pimpl->output.comTrajectory.resize(m_pimpl->horizon / m_pimpl->dT);
+    m_pimpl->output.timestamps.resize(m_pimpl->horizon / m_pimpl->dT);
 
-    return m_pimpl->mann.initialize(paramHandler);
+    m_pimpl->gravity.setZero();
+    m_pimpl->gravity(2) = -BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+    return m_pimpl->mannAutoregressive.initialize(paramHandler);
 }
 
-void MANNTrajectoryGenerator::setInitialState(Eigen::Ref<const Eigen::VectorXd> jointPositions,
-                                              const Contacts::EstimatedContact& leftFoot,
-                                              const Contacts::EstimatedContact& rightFoot,
-                                              const manif::SE3d& basePose,
-                                              const std::chrono::nanoseconds& time)
+bool MANNTrajectoryGenerator::setInitialState(Eigen::Ref<const Eigen::VectorXd> jointPositions,
+                                              const manif::SE3d& basePose)
 {
-    Impl::MergePointState temp;
-    temp.input.jointPositions = jointPositions;
-    temp.input.jointVelocities = Eigen::VectorXd::Zero(jointPositions.size());
-    temp.input.basePositionTrajectory = Eigen::MatrixXd::Zero(2, m_pimpl->projectedBaseHorizonSize);
-    temp.input.baseVelocitiesTrajectory
-        = Eigen::MatrixXd::Zero(2, m_pimpl->projectedBaseHorizonSize);
-    temp.input.facingDirectionTrajectory.resize(2, m_pimpl->projectedBaseHorizonSize);
-    for (int i = 0; i < m_pimpl->projectedBaseHorizonSize; i++)
-    {
-        temp.input.facingDirectionTrajectory.col(i) << 1.0, 0.0;
-    }
-    temp.basePosition = basePose;
-    temp.baseVelocity = manif::SE3Tangentd::Zero();
-    temp.leftFoot = leftFoot;
-    temp.rightFoot = rightFoot;
-    temp.time = time;
+    constexpr auto logPrefix = "[MANNTrajectoryGenerator::setInitialState]";
 
-    // 51 is the length of 1 second of past trajectory stored in the autoregressive state. Since the
-    // original mocap data are collected at 50 Hz, and therefore the trajectory generation is
-    // assumed to proceed at 50 Hz, we need 50 datapoints to store the past second of trajectory.
-    // Along with the present datapoint, they sum up to 51!
-    constexpr size_t lengthOfPresentPlusPastTrajectory = 51;
-    temp.autoregressiveState.pastProjectedBasePositions
-        = std::deque<Eigen::Vector2d>{lengthOfPresentPlusPastTrajectory, Eigen::Vector2d{0.0, 0.0}};
-    temp.autoregressiveState.pastProjectedBaseVelocity
-        = std::deque<Eigen::Vector2d>{lengthOfPresentPlusPastTrajectory, Eigen::Vector2d{0.0, 0.0}};
-    temp.autoregressiveState.pastFacingDirection
-        = std::deque<Eigen::Vector2d>{lengthOfPresentPlusPastTrajectory, Eigen::Vector2d{1.0, 0.0}};
-    temp.autoregressiveState.I_H_FD = manif::SE2d::Identity();
-    temp.autoregressiveState.previousMannInput = temp.input;
-    temp.leftFootSchmittTriggerState.state = leftFoot.isActive;
-    temp.rightFootSchmittTriggerState.state = rightFoot.isActive;
+    Impl::MANNTrajectoryGeneratorState trajectoryGeneratorState;
+    if (!m_pimpl->mannAutoregressive
+             .populateInitialAutoregressiveState(jointPositions,
+                                                 basePose,
+                                                 trajectoryGeneratorState.MANNAutoregressiveState))
+    {
+        log()->error("{} Unable to populate the initial autoregressive state.", logPrefix);
+        return false;
+    }
+
+    // compute the CoM position
+    Eigen::Matrix<double, 6, 1> baseVelocity;
+    baseVelocity.setZero();
+    const Eigen::VectorXd jointVelocities = Eigen::VectorXd::Zero(jointPositions.size());
+    if (!m_pimpl->kinDyn.setRobotState(basePose.transform(),
+                                       jointPositions,
+                                       baseVelocity,
+                                       jointVelocities,
+                                       m_pimpl->gravity))
+    {
+        log()->error("{} Unable to reset the kindyncomputations object.", logPrefix);
+        return false;
+    }
+
+    // at the beginning the scaled and the unscaled position are the same
+    trajectoryGeneratorState.com.previous
+        = iDynTree::toEigen(m_pimpl->kinDyn.getCenterOfMassPosition());
+    trajectoryGeneratorState.com.previousScaled = trajectoryGeneratorState.com.previous;
+
+    trajectoryGeneratorState.basePosition.previous = basePose.translation();
+    trajectoryGeneratorState.basePosition.previousScaled
+        = trajectoryGeneratorState.basePosition.previous;
+
+    // reset the contact list
+    m_pimpl->footState.clear();
+
+    // add the first contact
+    Impl::ScalingState<Eigen::Vector3d> leftScalingState;
+    leftScalingState.previous
+        = trajectoryGeneratorState.MANNAutoregressiveState.leftFootState.contact.pose.translation();
+    leftScalingState.previousScaled = leftScalingState.previous;
+    m_pimpl->footState[trajectoryGeneratorState.MANNAutoregressiveState.leftFootState.contact.name]
+        .push_back(std::move(leftScalingState));
+
+    Impl::ScalingState<Eigen::Vector3d> rightScalingState;
+    rightScalingState.previous
+        = trajectoryGeneratorState.MANNAutoregressiveState.rightFootState.contact.pose.translation();
+    rightScalingState.previousScaled = rightScalingState.previous;
+    m_pimpl->footState[trajectoryGeneratorState.MANNAutoregressiveState.rightFootState.contact.name]
+        .push_back(std::move(rightScalingState));
 
     for (auto& state : m_pimpl->mergePointStates)
     {
-        state = temp;
+        state = trajectoryGeneratorState;
     }
+
+    return true;
 }
 
 bool MANNTrajectoryGenerator::setInput(const Input& input)
 {
     constexpr auto logPrefix = "[MANNTrajectoryGenerator::setInput]";
 
-    if (input.mergePointIndex > m_pimpl->mergePointStates.size())
+    if (input.mergePointIndex >= m_pimpl->mergePointStates.size())
     {
         log()->error("{} The index of the merge point is greater than the entire trajectory.  The "
                      "trajectory lasts {}. I cannot attach a new trajectory at {}.",
@@ -285,31 +388,53 @@ bool MANNTrajectoryGenerator::setInput(const Input& input)
     }
 
     m_pimpl->mannAutoregressiveInput = input;
+    const Impl::MANNTrajectoryGeneratorState& mergePointState
+        = m_pimpl->mergePointStates[input.mergePointIndex];
 
-    const auto& mergePointState = m_pimpl->mergePointStates[input.mergePointIndex];
+    m_pimpl->mergePointStates[0].com = mergePointState.com;
+    m_pimpl->mergePointStates[0].basePosition = mergePointState.basePosition;
 
-
-    if (!m_pimpl->mann.reset(mergePointState.input,
-                             mergePointState.leftFoot,
-                             mergePointState.leftFootSchmittTriggerState,
-                             mergePointState.rightFoot,
-                             mergePointState.rightFootSchmittTriggerState,
-                             mergePointState.basePosition,
-                             mergePointState.baseVelocity,
-                             mergePointState.autoregressiveState,
-                             mergePointState.time))
+    // reset the MANN
+    if (!m_pimpl->mannAutoregressive.reset(mergePointState.MANNAutoregressiveState))
     {
         log()->error("{} Unable to reset MANN.", logPrefix);
         return false;
     }
 
-    // clean the contact list map this will also create the two values in the dictionary
-    m_pimpl->contactListMap["left_foot"].clear();
-    m_pimpl->contactListMap["right_foot"].clear();
+    const auto& time = mergePointState.MANNAutoregressiveState.time;
+    for (const auto& [contactName, contactList] : m_pimpl->contactListMap)
+    {
+        std::size_t contactIndex = 0;
+        auto contactIt = contactList.getActiveContact(time);
+        if (contactIt != contactList.cend())
+        {
+            contactIndex = std::distance(contactList.cbegin(), contactIt);
+        } else
+        {
+            contactIt = contactList.getNextContact(time);
+            if (contactIt != contactList.cend())
+            {
+                contactIndex = std::distance(contactList.cbegin(), contactIt);
+            } else
+            {
+                contactIndex = contactList.size();
+            }
+        }
+
+        Impl::ScalingState<Eigen::Vector3d> scalingState
+            = m_pimpl->footState[contactName][contactIndex];
+        m_pimpl->footState[contactName].clear();
+        m_pimpl->footState[contactName].push_back(std::move(scalingState));
+    }
 
     // add the first contact if needed
-    return m_pimpl->resetContactList(mergePointState.leftFoot, "left_foot")
-           && m_pimpl->resetContactList(mergePointState.rightFoot, "right_foot");
+    return m_pimpl->resetContactList("left_foot",
+                                     mergePointState.MANNAutoregressiveState.leftFootState.contact,
+                                     mergePointState.MANNAutoregressiveState.time)
+           && m_pimpl
+                  ->resetContactList("right_foot",
+                                     mergePointState.MANNAutoregressiveState.rightFootState.contact,
+                                     mergePointState.MANNAutoregressiveState.time);
 }
 
 bool MANNTrajectoryGenerator::advance()
@@ -319,40 +444,49 @@ bool MANNTrajectoryGenerator::advance()
     // invalidate the output
     m_pimpl->isOutputValid = false;
 
+    Eigen::Vector3d tempPosition;
+    Eigen::Vector2d tempContactPositionScaled;
+
     for (int i = 0; i < m_pimpl->mergePointStates.size(); i++)
     {
-        if (!m_pimpl->mann.setInput(m_pimpl->mannAutoregressiveInput))
+        // we need to get the autoregressive state from the MANNAutoregressive before setting the
+        // input and advancing the system. Indeed the autoregressive state at time t is the one
+        // that will be used to generate the output at time t
+        m_pimpl->mergePointStates[i].MANNAutoregressiveState
+            = m_pimpl->mannAutoregressive.getAutoregressiveState();
+
+        if (!m_pimpl->mannAutoregressive.setInput(m_pimpl->mannAutoregressiveInput))
         {
-            log()->error("{} Unable to set the input to MANN.", logPrefix);
+            log()->error("{} Unable to set the input of MANN at iteration number {}.",
+                         logPrefix,
+                         i);
             return false;
         }
 
-        if (!m_pimpl->mann.advance())
+        if (!m_pimpl->mannAutoregressive.advance())
         {
             log()->error("{} Unable to perform the iteration number {} of MANN.", logPrefix, i);
             return false;
         }
 
-        const auto& MANNOutput = m_pimpl->mann.getOutput();
-
-        // store the status required to reset the system
-        m_pimpl->mergePointStates[i].basePosition = MANNOutput.basePose;
-        m_pimpl->mergePointStates[i].autoregressiveState = m_pimpl->mann.getAutoregressiveState();
-        m_pimpl->mergePointStates[i].baseVelocity = MANNOutput.baseVelocity;
-        m_pimpl->mergePointStates[i].input = m_pimpl->mann.getMANNInput();
-        m_pimpl->mergePointStates[i].leftFoot = MANNOutput.leftFoot;
-        m_pimpl->mergePointStates[i].leftFootSchmittTriggerState = MANNOutput.leftFootSchmittTriggerState;
-        m_pimpl->mergePointStates[i].rightFoot = MANNOutput.rightFoot;
-        m_pimpl->mergePointStates[i].rightFootSchmittTriggerState = MANNOutput.rightFootSchmittTriggerState;
-        m_pimpl->mergePointStates[i].time = MANNOutput.currentTime;
+        if (!m_pimpl->mannAutoregressive.isOutputValid())
+        {
+            log()->error("{} The output of MANN is not valid at iteration number {}.",
+                         logPrefix,
+                         i);
+            return false;
+        }
+        const auto& MANNOutput = m_pimpl->mannAutoregressive.getOutput();
 
         // populate the output of the trajectory generator
-        m_pimpl->output.basePoses[i] = MANNOutput.basePose;
         m_pimpl->output.jointPositions[i] = MANNOutput.jointsPosition;
         m_pimpl->output.angularMomentumTrajectory[i] = MANNOutput.angularMomentum;
+        m_pimpl->output.basePoses[i] = MANNOutput.basePose;
         m_pimpl->output.comTrajectory[i] = MANNOutput.comPosition;
+        m_pimpl->output.timestamps[i] = MANNOutput.currentTime;
 
-        if (!m_pimpl->updateContactList("left_foot", MANNOutput.currentTime, MANNOutput.leftFoot))
+        // update the contacts lists
+        if (!m_pimpl->updateContactList("left_foot", MANNOutput.leftFoot, MANNOutput.currentTime))
         {
             log()->error("{} Unable to update the contact list for the left_foot at iteration "
                          "number {}.",
@@ -360,8 +494,7 @@ bool MANNTrajectoryGenerator::advance()
                          i);
             return false;
         }
-
-        if (!m_pimpl->updateContactList("right_foot", MANNOutput.currentTime, MANNOutput.rightFoot))
+        if (!m_pimpl->updateContactList("right_foot", MANNOutput.rightFoot, MANNOutput.currentTime))
         {
             log()->error("{} Unable to update the contact list for the right_foot at iteration "
                          "number {}.",
@@ -369,10 +502,105 @@ bool MANNTrajectoryGenerator::advance()
                          i);
             return false;
         }
+
+        // the next previous position is the current position
+        if (i < m_pimpl->mergePointStates.size() - 1)
+        {
+            m_pimpl->mergePointStates[i + 1].com.previous = MANNOutput.comPosition;
+            m_pimpl->mergePointStates[i + 1].basePosition.previous
+                = MANNOutput.basePose.translation();
+        }
     }
 
-    // populate the phase list
-    m_pimpl->output.phaseList.setLists(m_pimpl->contactListMap);
+    // The following code is required to scale the output of the trajectory generator
+    // In particular we need to scale the following quantities:
+    // - angular momentum
+    // - com trajectory
+    // - base position
+    // - contact position
+    // - the time stamps
+
+    // scale the com trajectory, the base position, the angular momentum nad the time stamps
+    // To scale the CoM and the base position we use the following formula:
+    //      x_scaled = x_previous_scaled + scaling_factor * (x - x_previous)
+    for (int i = 0; i < m_pimpl->mergePointStates.size(); i++)
+    {
+        // scale the time stamps associated to the signal vectors.
+        // The time stamps are scaled using the following formula
+        // t_scaled = t * slow_down_factor
+        m_pimpl->output.timestamps[i] *= m_pimpl->slowDownFactor;
+
+        // scale the angular momentum trajectory considering the time slow down factor
+        // h_scaled = h / slow_down_factor
+        // if the slow down factor is equal to 1.0 then the angular momentum is not scaled
+        // if the slow down factor is greater than 1.0 then the angular momentum is scaled
+        m_pimpl->output.angularMomentumTrajectory[i] /= m_pimpl->slowDownFactor;
+
+        // evaluate the com scaled
+        m_pimpl->output.comTrajectory[i] = m_pimpl->mergePointStates[i].com.previousScaled
+                                           + m_pimpl->scalingFactor
+                                                 * (m_pimpl->output.comTrajectory[i]
+                                                    - m_pimpl->mergePointStates[i].com.previous);
+
+        // evaluate the base position scaled
+        const Eigen::Vector3d scaledBasePosition
+            = m_pimpl->mergePointStates[i].basePosition.previousScaled
+              + m_pimpl->scalingFactor
+                    * (m_pimpl->output.basePoses[i].translation()
+                       - m_pimpl->mergePointStates[i].basePosition.previous);
+        m_pimpl->output.basePoses[i].translation(scaledBasePosition);
+
+        // update the previous position considering that the next previous is the current
+        if (i < m_pimpl->mergePointStates.size() - 1)
+        {
+            m_pimpl->mergePointStates[i + 1].com.previousScaled = m_pimpl->output.comTrajectory[i];
+
+            m_pimpl->mergePointStates[i + 1].basePosition.previousScaled
+                = m_pimpl->output.basePoses[i].translation();
+        }
+    }
+
+    // scaled contact list map
+    Contacts::ContactListMap scaledContactListMap;
+    for (const auto& [contactName, contactList] : m_pimpl->contactListMap)
+    {
+        for (int i = 0; i < contactList.size(); i++)
+        {
+            // create the scaled contact (we need to scale the activation and deactivation time)
+            Contacts::PlannedContact scaledContact = contactList[i];
+            scaledContact.activationTime *= m_pimpl->slowDownFactor;
+            if (scaledContact.deactivationTime != std::chrono::nanoseconds::max())
+            {
+                scaledContact.deactivationTime *= m_pimpl->slowDownFactor;
+            }
+
+            // scale the position
+            const Eigen::Vector3d scaledPosition
+                = m_pimpl->footState[contactName][i].previousScaled
+                  + m_pimpl->scalingFactor
+                        * (contactList[i].pose.translation()
+                           - m_pimpl->footState[contactName][i].previous);
+            scaledContact.pose.translation(scaledPosition);
+
+            // add the contact to the scaled contact list
+            if (!scaledContactListMap[contactName].addContact(scaledContact))
+            {
+                log()->error("{} Unable to add the contact named {} to the scaled contact list.",
+                             logPrefix,
+                             contactName);
+                return false;
+            }
+
+            // update the previous position considering that the next previous is the current
+            Impl::ScalingState<Eigen::Vector3d> scaledContactState;
+            scaledContactState.previousScaled = scaledPosition;
+            scaledContactState.previous = contactList[i].pose.translation();
+            m_pimpl->footState[contactName].push_back(std::move(scaledContactState));
+        }
+    }
+
+    // populate the phase list with the scaled contact list map
+    m_pimpl->output.phaseList.setLists(scaledContactListMap);
 
     m_pimpl->isOutputValid = true;
 

--- a/src/ML/tests/MANNTest.cpp
+++ b/src/ML/tests/MANNTest.cpp
@@ -24,7 +24,7 @@ TEST_CASE("MANN")
 
     auto handler = std::make_shared<StdImplementation>();
     handler->setParameter("number_of_joints", 26);
-    handler->setParameter("projected_base_horizon", 12);
+    handler->setParameter("projected_base_datapoints", 12);
     handler->setParameter("onnx_model_path", getMANNModelPath());
 
     REQUIRE(mann.initialize(handler));

--- a/src/ML/tests/MANNTrajectoryGeneratorTest.cpp
+++ b/src/ML/tests/MANNTrajectoryGeneratorTest.cpp
@@ -52,6 +52,8 @@ TEST_CASE("MANNTrajectoryGenerator")
     handler->setParameter("slow_down_factor", 1.0);
     handler->setParameter("scaling_factor", 1.0);
     handler->setParameter("forward_direction", "x");
+    handler->setParameter("mocap_frame_rate", 50);
+    handler->setParameter("past_projected_base_horizon", 1s);
 
     auto leftFootGroup = std::make_shared<StdImplementation>();
     leftFootGroup->setParameter("number_of_corners", 4);
@@ -76,7 +78,7 @@ TEST_CASE("MANNTrajectoryGenerator")
     rightFootGroup->setParameter("switch_off_after", 40ms);
 
     auto mannGroup = std::make_shared<StdImplementation>();
-    mannGroup->setParameter("projected_base_horizon", 12);
+    mannGroup->setParameter("projected_base_datapoints", 12);
     mannGroup->setParameter("onnx_model_path", getMANNModelPath());
 
     handler->setGroup("LEFT_FOOT", leftFootGroup);

--- a/src/ML/tests/MANNTrajectoryGeneratorTest.cpp
+++ b/src/ML/tests/MANNTrajectoryGeneratorTest.cpp
@@ -49,7 +49,8 @@ TEST_CASE("MANNTrajectoryGenerator")
     handler->setParameter("right_foot_frame_name", "r_sole");
     handler->setParameter("sampling_time", 20ms);
     handler->setParameter("time_horizon", 10s);
-    handler->setParameter("slow_down_factor", 1);
+    handler->setParameter("slow_down_factor", 1.0);
+    handler->setParameter("scaling_factor", 1.0);
     handler->setParameter("forward_direction", "x");
 
     auto leftFootGroup = std::make_shared<StdImplementation>();
@@ -97,18 +98,6 @@ TEST_CASE("MANNTrajectoryGenerator")
         generatorInput.desiredFutureBaseVelocities.col(i) << 0.4, 0;
     }
 
-    EstimatedContact leftFoot, rightFoot;
-    leftFoot.isActive = true;
-    leftFoot.name = "left_foot";
-    leftFoot.index = ml.model().getFrameIndex("l_sole");
-    leftFoot.switchTime = 0s;
-    leftFoot.pose = manif::SE3d(Eigen::Vector3d{0, 0.08, 0}, manif::SO3d::Identity());
-
-    rightFoot.isActive = true;
-    rightFoot.name = "right_foot";
-    rightFoot.index = ml.model().getFrameIndex("r_sole");
-    rightFoot.switchTime = 0s;
-    rightFoot.pose = manif::SE3d(Eigen::Vector3d{0, -0.08, 0}, manif::SO3d::Identity());
     const manif::SE3d basePose = manif::SE3d(Eigen::Vector3d{0, 0, 0.7748},
                                              Eigen::AngleAxis(0.0, Eigen::Vector3d::UnitY()));
 
@@ -124,7 +113,7 @@ TEST_CASE("MANNTrajectoryGenerator")
     MANNTrajectoryGenerator generator;
     REQUIRE(generator.setRobotModel(ml.model()));
     REQUIRE(generator.initialize(handler));
-    generator.setInitialState(jointPositions, leftFoot, rightFoot, basePose, 0s);
+    REQUIRE(generator.setInitialState(jointPositions, basePose));
     REQUIRE(generator.setInput(generatorInput));
     REQUIRE(generator.advance());
 
@@ -150,5 +139,4 @@ TEST_CASE("MANNTrajectoryGenerator")
     REQUIRE(std::abs(finalCoMPosition[0] - initialCoMPosition[0]) > forwardTolerance);
     REQUIRE(std::abs(finalCoMPosition[1] - initialCoMPosition[1]) < lateralTolerance);
     REQUIRE(std::abs(finalCoMPosition[2] - initialCoMPosition[2]) < verticalTolerance);
-
 }


### PR DESCRIPTION
This PR is the outcome of the refactoring carried out with @paolo-viceconte 
In detail, we implemented `MANN::generateDummyMANNOutput` and `MANN::generateDummyMANNInput` in the `ML` component. Additionally, we restructured `MANNAutoregressive` for improved reset handling by introducing the `MANNFootState` class and consolidating reset-related quantities in `MANNAutoregressive::AutoregressiveState`. This simplifies the generation of the initial `AutoregressiveState` required to start trajectory generation. Concurrently, we restructured `MANNTrajectoryGenerator` by eliminating the need to pass foot positions in setInitialState. We enhanced `MANNTrajectoryGenerator` with reset capabilities similar to `MANNAutoregressive` and corrected the position and time scaling to ensure accurate scaling of the CoM, base, and feet positions. The Python bindings have been updated accordingly.

Last but not least I added two examples that show how to use `MANNAutoregressive` and `MANNTrajectoryGenerator`


### MANNAutoregressive

[MANNAutoregressive](https://github.com/ami-iit/bipedal-locomotion-framework/assets/16744101/161651c2-04f1-47a7-bcad-4ae8279bb2ef)


### MANNTrajectoryGenerator

[MANNTrajectoryGenerator](https://github.com/ami-iit/bipedal-locomotion-framework/assets/16744101/5f64087a-a735-4baa-9b31-309ad805616b)
