### PR TITLE
Add the possibility to resample the contact in a given contact list and force the MPC to required correctly sampled contacts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project are documented in this file.
 - 🤖 Modify the `YarpRobotLoggerDevice` of `ergoCubSN001` to be compliant with the latest [robots-configuration files](https://github.com/robotology/robots-configuration/pull/598) (https://github.com/ami-iit/bipedal-locomotion-framework/pull/772)
 - Modify the `balancing-position-control` application to be compliant with the new implementation of the spline and the `VectorsCollectionServer` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/776)
 - Add the joint tracking error plot in joint-position-tracking script (https://github.com/ami-iit/bipedal-locomotion-framework/pull/775/)
-- Force the MPC to required correctly time sampled contacts (https://github.com/ami-iit/bipedal-locomotion-framework/pull/788)
+- Force the MPC to require correctly time-sampled contacts (https://github.com/ami-iit/bipedal-locomotion-framework/pull/788)
 
 ### Removed
 - Remove the latex dependency in the joint-position-tracking script (https://github.com/ami-iit/bipedal-locomotion-framework/pull/775/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 - Implement `LinearSpline` in `Math` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/782)
 - Add the support of QP problems with no constraint in `QPInverseKinematics` and `QPTSID` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/784)
 - Implement `blf-joints-grid-position-tracking` application in `utilities` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/787)
+- Add the possibility to resample the contact in a given contact list (https://github.com/ami-iit/bipedal-locomotion-framework/pull/788)
 
 ### Changed
 - Restructure of the `CentroidalMPC` class in `ReducedModelControllers` component. Specifically, the `CentroidalMPC` now provides a contact phase list instead of indicating the next active contact. Additionally, users can now switch between `ipopt` and `sqpmethod` to solve the optimization problem. Furthermore, the update allows for setting the warm-start for the non-linear solver. (https://github.com/ami-iit/bipedal-locomotion-framework/pull/766)
@@ -28,6 +29,7 @@ All notable changes to this project are documented in this file.
 - 🤖 Modify the `YarpRobotLoggerDevice` of `ergoCubSN001` to be compliant with the latest [robots-configuration files](https://github.com/robotology/robots-configuration/pull/598) (https://github.com/ami-iit/bipedal-locomotion-framework/pull/772)
 - Modify the `balancing-position-control` application to be compliant with the new implementation of the spline and the `VectorsCollectionServer` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/776)
 - Add the joint tracking error plot in joint-position-tracking script (https://github.com/ami-iit/bipedal-locomotion-framework/pull/775/)
+- Force the MPC to required correctly time sampled contacts (https://github.com/ami-iit/bipedal-locomotion-framework/pull/788)
 
 ### Removed
 - Remove the latex dependency in the joint-position-tracking script (https://github.com/ami-iit/bipedal-locomotion-framework/pull/775/)

--- a/bindings/python/Contacts/src/Contacts.cpp
+++ b/bindings/python/Contacts/src/Contacts.cpp
@@ -28,29 +28,6 @@ namespace bindings
 namespace Contacts
 {
 
-std::string toString(const BipedalLocomotion::Contacts::PlannedContact& contact)
-{
-    const Eigen::IOFormat FormatEigenVector //
-        (Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ", "", "", "[", "]");
-
-    const auto& position = contact.pose.coeffs().segment<3>(0);
-    const auto& quaternion = contact.pose.coeffs().segment<4>(3);
-
-    std::stringstream pose;
-    pose << "SE3 (position = " << position.format(FormatEigenVector)
-         << ", quaternion = " << quaternion.format(FormatEigenVector) << ")";
-
-    std::stringstream description;
-    description << "Contact (name = " << contact.name << ", pose = " << pose.str()
-                << std::setprecision(7) << ", activation_time = "
-                << std::chrono::duration<double>(contact.activationTime).count()
-                << ", deactivation_time = "
-                << std::chrono::duration<double>(contact.deactivationTime).count()
-                << ", type = " << static_cast<int>(contact.type) << ")";
-
-    return description.str();
-}
-
 void CreateContact(pybind11::module& module)
 {
     namespace py = ::pybind11;
@@ -71,7 +48,7 @@ void CreateContact(pybind11::module& module)
         .def(py::init())
         .def_readwrite("activation_time", &PlannedContact::activationTime)
         .def_readwrite("deactivation_time", &PlannedContact::deactivationTime)
-        .def("__repr__", &toString)
+        .def("__repr__", &PlannedContact::toString)
         .def("__eq__", &PlannedContact::operator==, py::is_operator())
         .def("__ne__", &PlannedContact::operator!=, py::is_operator())
         .def("is_contact_active", &PlannedContact::isContactActive);
@@ -209,7 +186,9 @@ void CreateContactList(pybind11::module& module)
                 }
                 return *ptr;
             },
-            py::return_value_policy::reference_internal);
+            py::return_value_policy::reference_internal)
+        .def("force_sample_time", &ContactList::forceSampleTime, py::arg("dt"))
+        .def("are_contacts_sampled", &ContactList::areContactsSampled, py::arg("dt"));
 }
 
 void CreateContactPhase(pybind11::module& module)

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactList.h
@@ -271,8 +271,8 @@ public:
      * @brief Force the sample time of the contact list.
      * @param dt The new sample time.
      * @return true if the contact list has been correctly resampled.
-     * @note the activation time is round down to the nearest multiple of dt, while the
-     * deactivation time is round up to the nearest multiple of dt.
+     * @note the activation time is rounded down to the nearest multiple of dt, while the
+     * deactivation time is rounded up to the nearest multiple of dt.
      * @note If the deactivation time of a contact in the list is equal to
      * `std::chrono::nanoseconds::max()` it will not be rounded up.
      * @warning This will change the sample time of all the contacts in the list. All the

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactList.h
@@ -266,6 +266,28 @@ public:
      * @return A string containing the information of the contact list.
      */
     [[nodiscard]] std::string toString() const;
+
+    /**
+     * @brief Force the sample time of the contact list.
+     * @param dt The new sample time.
+     * @return true if the contact list has been correctly resampled.
+     * @note the activation time is round down to the nearest multiple of dt, while the
+     * deactivation time is round up to the nearest multiple of dt.
+     * @note If the deactivation time of a contact in the list is equal to
+     * `std::chrono::nanoseconds::max()` it will not be rounded up.
+     * @warning This will change the sample time of all the contacts in the list. All the
+     * iterators to the contacts will be invalidated.
+     */
+    bool forceSampleTime(const std::chrono::nanoseconds& dt);
+
+    /**
+     * @brief Check if the contacts are sampled with the given sample time.
+     * @param dt The sample time.
+     * @return true if the contacts are sampled with the given sample time.
+     * @note If the deactivation time of a contact in the list is equal to
+     * `std::chrono::nanoseconds::max()` it will consider it as sampled with the given sample time.
+     */
+    [[nodiscard]] bool areContactsSampled(const std::chrono::nanoseconds& dt) const;
 };
 
 /**

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
@@ -209,6 +209,18 @@ public:
      * @return A string containing the information of the contact phase list.
      */
     [[nodiscard]] std::string toString() const;
+
+    /**
+     * @brief Force the sample time of the contact lust stored in the contact phase list.
+     * @param dt The new sample time.
+     * @return true if the contact lists has been correctly resampled.
+     * @note the activation time is round down to the nearest multiple of dt, while the
+     * deactivation time is round up to the nearest multiple of dt.
+     * @note If the deactivation time of a contact in the lists is equal to
+     * `std::chrono::nanoseconds::max()` it will not be rounded up.
+     * @note The phases are recomputed after the resampling.
+     */
+    bool forceSampleTime(const std::chrono::nanoseconds& dt);
 };
 
 } // namespace Contacts

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
@@ -211,11 +211,11 @@ public:
     [[nodiscard]] std::string toString() const;
 
     /**
-     * @brief Force the sample time of the contact lust stored in the contact phase list.
+     * @brief Force the sample time of the contact list stored in the contact phase list.
      * @param dt The new sample time.
      * @return true if the contact lists has been correctly resampled.
-     * @note the activation time is round down to the nearest multiple of dt, while the
-     * deactivation time is round up to the nearest multiple of dt.
+     * @note the activation time is rounded down to the nearest multiple of dt, while the
+     * deactivation time is rounded up to the nearest multiple of dt.
      * @note If the deactivation time of a contact in the lists is equal to
      * `std::chrono::nanoseconds::max()` it will not be rounded up.
      * @note The phases are recomputed after the resampling.

--- a/src/Contacts/src/ContactPhaseList.cpp
+++ b/src/Contacts/src/ContactPhaseList.cpp
@@ -241,3 +241,35 @@ std::string ContactPhaseList::toString() const
     }
     return ss.str();
 }
+
+bool ContactPhaseList::forceSampleTime(const std::chrono::nanoseconds& dT)
+{
+    bool updatePhasesRequired = false;
+    for (auto& [key, list] : m_contactLists)
+    {
+        const bool resampleRequired = !list.areContactsSampled(dT);
+        if (!resampleRequired)
+        {
+            continue;
+        }
+
+        // if the list has not been resampled, we need to recompute the phases
+        updatePhasesRequired = true;
+        if (!list.forceSampleTime(dT))
+        {
+            log()->error("[ContactPhaseList::forceSampleTime] Unable to force the sample time of "
+                         "the list named: {}.",
+                         key);
+            return false;
+        }
+    }
+
+    // if at least one list has been resampled, we need to recompute the phases
+    if (!updatePhasesRequired)
+    {
+        return true;
+    }
+
+    createPhases();
+    return true;
+}

--- a/src/Contacts/tests/Contacts/ContactListTest.cpp
+++ b/src/Contacts/tests/Contacts/ContactListTest.cpp
@@ -122,6 +122,23 @@ TEST_CASE("ContactList")
         }
         REQUIRE(ok);
     }
+
+    SECTION("Resample")
+    {
+        constexpr std::chrono::nanoseconds dT = 70ms;
+        PlannedContact p3;
+        p3.activationTime = 1s + 800ms;
+        p3.deactivationTime = 2s + 400ms;
+
+        REQUIRE(list.addContact(p3));
+
+        REQUIRE_FALSE(list.areContactsSampled(dT));
+
+        REQUIRE(list.forceSampleTime(dT));
+
+        REQUIRE(list.areContactsSampled(dT));
+    }
+
 }
 
 TEST_CASE("ContactList JSON parser")

--- a/src/Planners/src/SwingFootPlanner.cpp
+++ b/src/Planners/src/SwingFootPlanner.cpp
@@ -186,8 +186,8 @@ bool SwingFootPlanner::setContactList(const ContactList& contactList)
                          "tolerance "
                          "{} m, admissible orientation tolerance {} rad. Current time {}.",
                          logPrefix,
-                         activeContact->pose.coeffs().transpose(),
-                         activeContactNewList->pose.coeffs().transpose(),
+                         activeContact->toString(),
+                         activeContactNewList->toString(),
                          (activeContactNewList->pose - activeContact->pose).coeffs().transpose(),
                          m_positionTolerance,
                          m_orientationTolerance,


### PR DESCRIPTION
While testing the integration of the MPC with MANN, we realized that the neural network was generating contacts whose activation and deactivation times weren't divisible by the MPC sampling time. This caused an issue when generating the internal vector of the MPC discretization. To overcome this limitation, we decided to implement a method in the ContactList to resample the contacts so that the activation and deactivation times are divisible with respect to a given sampling time.

Specifically, the activation time is decreased to ensure divisibility, while the deactivation time is increased. This way, we increase the overall contact duration.

Last but not least, the MPC checks that the contact timings are correctly sampled.