### PR TITLE
Add member function to set gravity vector in centroidal dynamics system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 - Add streaming of arm fts in YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/803)
 - 🤖  [ `ergoCubGazeboV1_1`] Add configuration files to log data with the `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/806, https://github.com/ami-iit/bipedal-locomotion-framework/pull/808)
 - Added a unit test code for the `UnicyclePlanner` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/815)
+- Added a member function to set the gravity vector of the `CentroidalDynamics` Continuous Dynamical System (https://github.com/ami-iit/bipedal-locomotion-framework/pull/821).
 
 ### Changed
 - 🤖 [ergoCubSN001] Add logging of the wrist and fix the name of the waist imu (https://github.com/ami-iit/bipedal-locomotion-framework/pull/810)

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h
@@ -157,7 +157,7 @@ public:
      * @param gravity the value of the gravity vector used in the system dynamics.
      * @return true in case of success, false otherwise.
      */
-    bool setGravityVector(const Eigen::Vector3d& gravity);
+    void setGravityVector(const Eigen::Ref<const Eigen::Vector3d>& gravity);
 };
 } // namespace ContinuousDynamicalSystem
 } // namespace BipedalLocomotion

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h
@@ -151,6 +151,13 @@ public:
      * @return true in case of success, false otherwise.
      */
     bool setControlInput(const Input& controlInput);
+
+    /**
+     * Set the gravity vector of the dynamical system.
+     * @param gravity the value of the gravity vector used in the system dynamics.
+     * @return true in case of success, false otherwise.
+     */
+    bool setGravityVector(const Eigen::Vector3d& gravity);
 };
 } // namespace ContinuousDynamicalSystem
 } // namespace BipedalLocomotion

--- a/src/ContinuousDynamicalSystem/src/CentroidalDynamics.cpp
+++ b/src/ContinuousDynamicalSystem/src/CentroidalDynamics.cpp
@@ -94,3 +94,9 @@ bool CentroidalDynamics::setControlInput(const Input& controlInput)
     m_controlInput = controlInput;
     return true;
 }
+
+bool CentroidalDynamics::setGravityVector(const Eigen::Vector3d& gravity)
+{
+    m_gravity = gravity;
+    return true;
+}

--- a/src/ContinuousDynamicalSystem/src/CentroidalDynamics.cpp
+++ b/src/ContinuousDynamicalSystem/src/CentroidalDynamics.cpp
@@ -95,8 +95,7 @@ bool CentroidalDynamics::setControlInput(const Input& controlInput)
     return true;
 }
 
-bool CentroidalDynamics::setGravityVector(const Eigen::Vector3d& gravity)
+void CentroidalDynamics::setGravityVector(const Eigen::Ref<const Eigen::Vector3d>& gravity)
 {
     m_gravity = gravity;
-    return true;
 }


### PR DESCRIPTION
This PR aims at providing a member function to set on the fly the gravity vector used in [CentroidalDynamics.h](https://github.com/ami-iit/bipedal-locomotion-framework/blob/master/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/CentroidalDynamics.h).

For example, when the reference frame is changed from the `world` one to a `local` one, and we want to write the centroidal dynamics in this new `local frame`, it might be needed to set a new gravity vector.