### PR TITLE
set gravity vector as an input argument of the CentroidalMPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project are documented in this file.
 - Require `iDynTree v10.0.0` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/832)
 - Refactor `YarpRobotControl::setReferences` function to include optional current joint values and avoid to switch control mode in `YarpRobotControl::setReferences` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/833)
 - Set the gravity vector as an input argument of the `CentroidalMPC` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/823)
-  
+
 ### Fixed
 - Fix the barrier logic for threads synchronization (https://github.com/ami-iit/bipedal-locomotion-framework/pull/811)
 - InstallBasicPackageFiles: Fix bug of OVERRIDE_MODULE_PATH that corrupt `CMAKE_MODULE_PATH` values set by blf transitive dependencies (https://github.com/ami-iit/bipedal-locomotion-framework/pull/827)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ All notable changes to this project are documented in this file.
 - Export the CoM velocity and the angular momentum trajectory in the `CentroidalMPC` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/818)
 - Require `iDynTree v10.0.0` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/832)
 - Refactor `YarpRobotControl::setReferences` function to include optional current joint values and avoid to switch control mode in `YarpRobotControl::setReferences` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/833)
-
+- Set the gravity vector as an input argument of the `CentroidalMPC` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/823)
+  
 ### Fixed
 - Fix the barrier logic for threads synchronization (https://github.com/ami-iit/bipedal-locomotion-framework/pull/811)
 - InstallBasicPackageFiles: Fix bug of OVERRIDE_MODULE_PATH that corrupt `CMAKE_MODULE_PATH` values set by blf transitive dependencies (https://github.com/ami-iit/bipedal-locomotion-framework/pull/827)

--- a/src/ReducedModelControllers/include/BipedalLocomotion/ReducedModelControllers/CentroidalMPC.h
+++ b/src/ReducedModelControllers/include/BipedalLocomotion/ReducedModelControllers/CentroidalMPC.h
@@ -142,6 +142,24 @@ public:
                   const Math::Wrenchd& externalWrench);
 
     /**
+     * Set the state of the centroidal dynamics.
+     * @param com position of the CoM expressed in the inertial frame.
+     * @param dcom velocity of the CoM expressed in a frame centered in the CoM and oriented as the
+     * inertial frame.
+     * @param angularMomentum centroidal angular momentum.
+     * @param externalWrench optional parameter used to represent an external wrench applied to the
+     * robot CoM.
+     * @param gravity gravity vector.
+     * @return True in case of success, false otherwise.
+     * @note This function needs to be called before advance.
+     */
+    bool setState(Eigen::Ref<const Eigen::Vector3d> com,
+                  Eigen::Ref<const Eigen::Vector3d> dcom,
+                  Eigen::Ref<const Eigen::Vector3d> angularMomentum,
+                  const Math::Wrenchd& externalWrench,
+                  Eigen::Ref<const Eigen::Vector3d> gravity);
+
+    /**
      * Set the reference trajectories for the CoM and the centroidal angular momentum.
      * @param com desired trajectory of the CoM. The rows contain the x, y and z coordinates while
      * the columns the position at each time instant.
@@ -155,6 +173,13 @@ public:
      */
     bool setReferenceTrajectory(const std::vector<Eigen::Vector3d>& com,
                                 const std::vector<Eigen::Vector3d>& angularMomentum);
+
+    /**
+     * Set the gravity vector used in the centroidal dynamics.
+     * @param gravity gravity vector.
+     * @return True in case of success, false otherwise.
+     */
+    bool setGravity(const Eigen::Ref<Eigen::Vector3d>& gravity);
 
     /**
      * Get the output of the controller

--- a/src/ReducedModelControllers/src/CentroidalMPC.cpp
+++ b/src/ReducedModelControllers/src/CentroidalMPC.cpp
@@ -222,6 +222,7 @@ struct CentroidalMPC::Impl
         casadi::MX angularMomentumCurrent;
         casadi::MX externalForce;
         casadi::MX externalTorque;
+        casadi::MX gravity;
     };
     OptimizationVariables optiVariables; /**< Optimization variables */
 
@@ -245,6 +246,7 @@ struct CentroidalMPC::Impl
         casadi::DM* angularMomentumCurrent;
         casadi::DM* externalForce;
         casadi::DM* externalTorque;
+        casadi::DM* gravity;
     };
     ControllerInputs controllerInputs; /**< The pointers will point to the vectorized input */
 
@@ -475,8 +477,7 @@ struct CentroidalMPC::Impl
         casadi::MX ddcom = casadi::MX::sym("ddcom", 3);
         casadi::MX angularMomentumDerivative = casadi::MX::sym("angular_momentum_derivative", 3);
 
-        casadi::DM gravity = casadi::DM::zeros(3);
-        gravity(2) = -BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+        casadi::MX gravity = casadi::MX::sym("gravity", 3);
 
         ddcom = gravity + externalForce / mass;
         angularMomentumDerivative = externalTorque;
@@ -487,6 +488,7 @@ struct CentroidalMPC::Impl
         input.push_back(com);
         input.push_back(dcom);
         input.push_back(angularMomentum);
+        input.push_back(gravity);
 
         for (const auto& [key, contact] : casadiContacts)
         {
@@ -560,13 +562,13 @@ struct CentroidalMPC::Impl
         this->output.angularMomentumTrajectory.resize(stateHorizon);
 
         // In case of no warmstart the variables are:
-        // - centroidalVariables = 7: external force + external torque + com current + dcom current
-        //                            + current angular momentum + com reference
+        // - centroidalVariables = 8: external force + external torque + com current + dcom current
+        //                            + current angular momentum + gravity + com reference
         //                            + angular momentum reference
         // - contactVariables = 6: for each contact we have current position + nominal position +
         //                         orientation + is enabled + upper limit in position
         //                         + lower limit in position
-        constexpr std::size_t centroidalVariables = 7;
+        constexpr std::size_t centroidalVariables = 8;
         constexpr std::size_t contactVariables = 6;
 
         std::size_t vectorizedOptiInputsSize = centroidalVariables + //
@@ -615,6 +617,9 @@ struct CentroidalMPC::Impl
 
         this->vectorizedOptiInputs.push_back(casadi::DM::zeros(vector3Size));
         this->controllerInputs.angularMomentumCurrent = &this->vectorizedOptiInputs.back();
+
+        this->vectorizedOptiInputs.push_back(casadi::DM::zeros(vector3Size));
+        this->controllerInputs.gravity = &this->vectorizedOptiInputs.back();
 
         this->vectorizedOptiInputs.push_back(casadi::DM::zeros(vector3Size, stateHorizon));
         this->controllerInputs.comReference = &this->vectorizedOptiInputs.back();
@@ -749,6 +754,7 @@ struct CentroidalMPC::Impl
                                                                  this->optiSettings.horizon);
         this->optiVariables.externalTorque = this->opti.parameter(vector3Size, //
                                                                   this->optiSettings.horizon);
+        this->optiVariables.gravity = this->opti.parameter(vector3Size);
     }
 
     /**
@@ -836,6 +842,7 @@ struct CentroidalMPC::Impl
         auto& angularMomentum = this->optiVariables.angularMomentum;
         auto& externalForce = this->optiVariables.externalForce;
         auto& externalTorque = this->optiVariables.externalTorque;
+        auto& gravity = this->optiVariables.gravity;
 
         // prepare the input of the ode
         std::vector<casadi::MX> odeInput;
@@ -844,6 +851,7 @@ struct CentroidalMPC::Impl
         odeInput.push_back(com(Sl(), Sl(0, -1)));
         odeInput.push_back(dcom(Sl(), Sl(0, -1)));
         odeInput.push_back(angularMomentum(Sl(), Sl(0, -1)));
+        odeInput.push_back(gravity);
         for (const auto& [key, contact] : this->optiVariables.contacts)
         {
             odeInput.push_back(contact.position(Sl(), Sl(0, -1)));
@@ -1018,6 +1026,7 @@ struct CentroidalMPC::Impl
         concatenateInput(this->optiVariables.comCurrent, "com_current");
         concatenateInput(this->optiVariables.dcomCurrent, "dcom_current");
         concatenateInput(this->optiVariables.angularMomentumCurrent, "angular_momentum_current");
+        concatenateInput(this->optiVariables.gravity, "gravity");
 
         concatenateInput(this->optiVariables.comReference, "com_reference");
         concatenateInput(this->optiVariables.angularMomentumReference,
@@ -1348,6 +1357,26 @@ bool CentroidalMPC::setReferenceTrajectory(const std::vector<Eigen::Vector3d>& c
     return true;
 }
 
+bool CentroidalMPC::setGravity(const Eigen::Ref<Eigen::Vector3d>& gravity)
+{
+    constexpr auto errorPrefix = "[CentroidalMPC::setGravity]";
+    assert(m_pimpl);
+
+    if (m_pimpl->fsm == Impl::FSM::Idle)
+    {
+        log()->error("{} The controller is not initialized please call initialize() method.",
+                     errorPrefix);
+        return false;
+    }
+
+    auto& inputs = m_pimpl->controllerInputs;
+
+    using namespace BipedalLocomotion::Conversions;
+    toEigen(*inputs.gravity) = gravity;
+
+    return true;
+};
+
 bool CentroidalMPC::setState(Eigen::Ref<const Eigen::Vector3d> com,
                              Eigen::Ref<const Eigen::Vector3d> dcom,
                              Eigen::Ref<const Eigen::Vector3d> angularMomentum)
@@ -1360,6 +1389,17 @@ bool CentroidalMPC::setState(Eigen::Ref<const Eigen::Vector3d> com,
                              Eigen::Ref<const Eigen::Vector3d> dcom,
                              Eigen::Ref<const Eigen::Vector3d> angularMomentum,
                              const Math::Wrenchd& externalWrench)
+{
+    Eigen::Vector3d gravity = Eigen::Vector3d::Zero();
+    gravity[2] = -BipedalLocomotion::Math::StandardAccelerationOfGravitation;
+    return this->setState(com, dcom, angularMomentum, externalWrench, gravity);
+}
+
+bool CentroidalMPC::setState(Eigen::Ref<const Eigen::Vector3d> com,
+                             Eigen::Ref<const Eigen::Vector3d> dcom,
+                             Eigen::Ref<const Eigen::Vector3d> angularMomentum,
+                             const Math::Wrenchd& externalWrench,
+                             Eigen::Ref<const Eigen::Vector3d> gravity)
 {
     constexpr auto errorPrefix = "[CentroidalMPC::setState]";
     assert(m_pimpl);
@@ -1383,6 +1423,8 @@ bool CentroidalMPC::setState(Eigen::Ref<const Eigen::Vector3d> com,
 
     toEigen(*inputs.externalForce).leftCols<1>() = externalWrench.force();
     toEigen(*inputs.externalTorque).leftCols<1>() = externalWrench.torque();
+
+    toEigen(*inputs.gravity) = gravity;
 
     return true;
 }


### PR DESCRIPTION
The goal of this PR is to expose the gravity vector as an input argument of the `CentroidalMPC`.

In this way, the user can pass it as other input arguments (like `currentCOM`, `externalWrench`, ...).

User can leverage the `setState` member function, or the `setGravity` one, to pass the gravity vector.

Moreover, if the user does not specify it, by default it is set to `[0, 0, -9.81]`.