### PR TITLE
Constraint pybind11 version to fix conda-forge Windows CI

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -38,10 +38,10 @@ jobs:
         # Dependencies
         # pybind11 constrained to be <=2.12.0 as a workaround for
         # https://github.com/ami-iit/bipedal-locomotion-framework/issues/829
-        mamba install cmake compilers make ninja pkg-config "pybind11<2.12.0" \
+        mamba install cmake compilers make ninja pkg-config \
                       "idyntree>=8.0.0" "yarp>=3.5.0" libmatio libmatio-cpp librobometry \
                       liblie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog \
-                      nlohmann_json manif manifpy numpy pytest scipy opencv pcl \
+                      nlohmann_json manif manifpy pybind11 numpy pytest scipy opencv pcl \
                       tomlplusplus libunicycle-footstep-planner "icub-models>=1.23.4" \
                       ros-humble-rclcpp onnxruntime-cpp libbayes-filters-lib
 
@@ -58,10 +58,9 @@ jobs:
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
-        # Compilation related dependencies
         mamba install vs2019_win-64
 
-    - name: Remove icub-models and pcl [Windows]
+    - name: Windows-workarounds [Windows]
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
@@ -69,6 +68,8 @@ jobs:
         # pcl is removed as a workaround for https://github.com/ami-iit/bipedal-locomotion-framework/pull/695#issuecomment-1632208836
         # pcl can be re-added once we have a ros humble build compatible with PCL 1.13.0
         mamba remove icub-models pcl
+        # pybind11 constrained as workaround for https://github.com/conda-forge/pybind11-feedstock/issues/95
+        mamba install "pybind11<2.12.0"
 
     - name: Print used environment
       shell: bash -l {0}

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -62,13 +62,13 @@ jobs:
 
     - name: Windows-workarounds [Windows]
       if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
+      shell: cmd /C CALL {0}
       run: |
-        # Due to this https://github.com/conda-forge/icub-models-feedstock/issues/18
-        # pcl is removed as a workaround for https://github.com/ami-iit/bipedal-locomotion-framework/pull/695#issuecomment-1632208836
-        # pcl can be re-added once we have a ros humble build compatible with PCL 1.13.0
+        :: Due to this https://github.com/conda-forge/icub-models-feedstock/issues/18
+        :: pcl is removed as a workaround for https://github.com/ami-iit/bipedal-locomotion-framework/pull/695#issuecomment-1632208836
+        :: pcl can be re-added once we have a ros humble build compatible with PCL 1.13.0
         mamba remove icub-models pcl
-        # pybind11 constrained as workaround for https://github.com/conda-forge/pybind11-feedstock/issues/95
+        :: pybind11 constrained as workaround for https://github.com/conda-forge/pybind11-feedstock/issues/95
         mamba install "pybind11<2.12.0"
 
     - name: Print used environment

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -41,7 +41,7 @@ jobs:
         mamba install cmake compilers make ninja pkg-config \
                       "idyntree>=8.0.0" "yarp>=3.5.0" libmatio libmatio-cpp librobometry \
                       liblie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog \
-                      nlohmann_json manif manifpy "pybind11<2.12.0" numpy pytest scipy opencv pcl \
+                      nlohmann_json manif manifpy 'pybind11<2.12.0' numpy pytest scipy opencv pcl \
                       tomlplusplus libunicycle-footstep-planner "icub-models>=1.23.4" \
                       ros-humble-rclcpp onnxruntime-cpp libbayes-filters-lib
 

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -36,10 +36,12 @@ jobs:
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
         # Dependencies
+        # pybind11 constrained to be <=2.12.0 as a workaround for
+        # https://github.com/ami-iit/bipedal-locomotion-framework/issues/829
         mamba install cmake compilers make ninja pkg-config \
                       "idyntree>=8.0.0" "yarp>=3.5.0" libmatio libmatio-cpp librobometry \
                       liblie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog \
-                      nlohmann_json manif manifpy pybind11 numpy pytest scipy opencv pcl \
+                      nlohmann_json manif manifpy "pybind11<2.12.0" numpy pytest scipy opencv pcl \
                       tomlplusplus libunicycle-footstep-planner "icub-models>=1.23.4" \
                       ros-humble-rclcpp onnxruntime-cpp libbayes-filters-lib
 

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -38,10 +38,10 @@ jobs:
         # Dependencies
         # pybind11 constrained to be <=2.12.0 as a workaround for
         # https://github.com/ami-iit/bipedal-locomotion-framework/issues/829
-        mamba install cmake compilers make ninja pkg-config \
+        mamba install cmake compilers make ninja pkg-config "pybind11<2.12.0" \
                       "idyntree>=8.0.0" "yarp>=3.5.0" libmatio libmatio-cpp librobometry \
                       liblie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog \
-                      nlohmann_json manif manifpy 'pybind11<2.12.0' numpy pytest scipy opencv pcl \
+                      nlohmann_json manif manifpy numpy pytest scipy opencv pcl \
                       tomlplusplus libunicycle-footstep-planner "icub-models>=1.23.4" \
                       ros-humble-rclcpp onnxruntime-cpp libbayes-filters-lib
 

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -36,8 +36,6 @@ jobs:
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
         # Dependencies
-        # pybind11 constrained to be <=2.12.0 as a workaround for
-        # https://github.com/ami-iit/bipedal-locomotion-framework/issues/829
         mamba install cmake compilers make ninja pkg-config \
                       "idyntree>=8.0.0" "yarp>=3.5.0" libmatio libmatio-cpp librobometry \
                       liblie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog \
@@ -67,9 +65,9 @@ jobs:
         :: Due to this https://github.com/conda-forge/icub-models-feedstock/issues/18
         :: pcl is removed as a workaround for https://github.com/ami-iit/bipedal-locomotion-framework/pull/695#issuecomment-1632208836
         :: pcl can be re-added once we have a ros humble build compatible with PCL 1.13.0
-        mamba remove icub-models pcl
         :: pybind11 constrained as workaround for https://github.com/conda-forge/pybind11-feedstock/issues/95
         mamba install "pybind11<2.12.0"
+        mamba remove icub-models pcl
 
     - name: Print used environment
       shell: bash -l {0}


### PR DESCRIPTION
Fix https://github.com/ami-iit/bipedal-locomotion-framework/issues/829, add workaround for https://github.com/conda-forge/pybind11-feedstock/issues/95 .