### PR TITLE
Refactor YarpRobotControl::setReferences function to include optional current joint values and avoid to switch control mode in YarpRobotControl::setReferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project are documented in this file.
 - 🤖 [ergoCubSN001] Add logging of the wrist and fix the name of the waist imu (https://github.com/ami-iit/bipedal-locomotion-framework/pull/810)
 - Export the CoM velocity and the angular momentum trajectory in the `CentroidalMPC` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/818)
 - Require `iDynTree v10.0.0` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/832)
+- Refactor `YarpRobotControl::setReferences` function to include optional current joint values and avoid to switch control mode in `YarpRobotControl::setReferences` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/833)
 
 ### Fixed
 - Fix the barrier logic for threads synchronization (https://github.com/ami-iit/bipedal-locomotion-framework/pull/811)

--- a/bindings/python/RobotInterface/src/RobotControl.cpp
+++ b/bindings/python/RobotInterface/src/RobotControl.cpp
@@ -5,6 +5,8 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <optional>
+
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -65,15 +67,20 @@ void CreateYarpRobotControl(pybind11::module& module)
              })
         .def("set_references",
              py::overload_cast<Eigen::Ref<const Eigen::VectorXd>,
-                               const std::vector<IRobotControl::ControlMode>&>(
+                               const std::vector<IRobotControl::ControlMode>&,
+                               std::optional<Eigen::Ref<const Eigen::VectorXd>>>(
                  &YarpRobotControl::setReferences),
-             py::arg("joints_value"),
-             py::arg("control_modes"))
+             py::arg("desired_joints_value"),
+             py::arg("control_modes"),
+             py::arg("current_joints_value") = std::nullopt)
         .def("set_references",
-             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>, const IRobotControl::ControlMode&>(
+             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>,
+                               const IRobotControl::ControlMode&,
+                               std::optional<Eigen::Ref<const Eigen::VectorXd>>>(
                  &YarpRobotControl::setReferences),
-             py::arg("joints_value"),
-             py::arg("control_mode"))
+             py::arg("desired_joints_value"),
+             py::arg("control_mode"),
+             py::arg("current_joints_value") = std::nullopt)
         .def("set_control_mode",
              py::overload_cast<const std::vector<IRobotControl::ControlMode>&>(
                  &YarpRobotControl::setControlMode),

--- a/bindings/python/RobotInterface/src/RobotControl.cpp
+++ b/bindings/python/RobotInterface/src/RobotControl.cpp
@@ -80,7 +80,7 @@ void CreateYarpRobotControl(pybind11::module& module)
                  &YarpRobotControl::setReferences),
              py::arg("desired_joints_value"),
              py::arg("control_mode"),
-             py::arg("current_joints_value") = std::nullopt)
+             py::arg("current_joint_values") = std::nullopt)
         .def("set_control_mode",
              py::overload_cast<const std::vector<IRobotControl::ControlMode>&>(
                  &YarpRobotControl::setControlMode),

--- a/bindings/python/RobotInterface/src/RobotControl.cpp
+++ b/bindings/python/RobotInterface/src/RobotControl.cpp
@@ -72,7 +72,7 @@ void CreateYarpRobotControl(pybind11::module& module)
                  &YarpRobotControl::setReferences),
              py::arg("desired_joints_value"),
              py::arg("control_modes"),
-             py::arg("current_joints_value") = std::nullopt)
+             py::arg("current_joint_values") = std::nullopt)
         .def("set_references",
              py::overload_cast<Eigen::Ref<const Eigen::VectorXd>,
                                const IRobotControl::ControlMode&,

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
@@ -10,6 +10,7 @@
 
 // std
 #include <memory>
+#include <optional>
 
 // Eigen
 #include <Eigen/Dense>
@@ -94,7 +95,7 @@ public:
 
     /**
      * Set the desired reference.
-     * @param jointValues desired joint values.
+     * @param desiredJointValues desired joint values.
      * @param controlModes vector containing the control mode for each joint.
      * @return True/False in case of success/failure.
      * @note In case of position control the values has to be expressed in rad, in case of velocity
@@ -103,12 +104,13 @@ public:
      * between -100 and 100.
      * @warning At the current stage only revolute joints are supported.
      */
-    bool setReferences(Eigen::Ref<const Eigen::VectorXd> jointValues,
-                       const std::vector<IRobotControl::ControlMode>& controlModes) final;
+    bool setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                       const std::vector<IRobotControl::ControlMode>& controlModes,
+                       std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {}) final;
 
     /**
      * Set the desired reference.
-     * @param jointValues desired joint values.
+     * @param desiredJointValues desired joint values.
      * @param controlMode a control mode for all the joints.
      * @return True/False in case of success/failure.
      * @note In case of position control the values has to be expressed in rad, in case of velocity
@@ -120,7 +122,8 @@ public:
      * std::vector<IRobotControl::ControlMode>&).
      */
     bool setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
-                       const IRobotControl::ControlMode& mode) final;
+                       const IRobotControl::ControlMode& mode,
+                       std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {}) final;
 
     /**
      * Get the list of the controlled joints

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -19,9 +19,9 @@
 #include <yarp/dev/ITorqueControl.h>
 #include <yarp/dev/IVelocityControl.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/os/Time.h>
 
 #include <BipedalLocomotion/RobotInterface/YarpRobotControl.h>
+#include <BipedalLocomotion/System/Clock.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
 
 using namespace BipedalLocomotion::RobotInterface;
@@ -63,7 +63,8 @@ struct YarpRobotControl::Impl
     std::vector<IRobotControl::ControlMode> controlModes; /**< Vector containing the map between the
                                                              joint and the current control mode */
     std::vector<yarp::conf::vocab32_t> controlModesYarp; /**< Vector containing the map between the
-                                                             joint and the current yarp control mode */
+                                                             joint and the current yarp control mode
+                                                          */
 
     std::vector<std::string> axesName; /**< List containing the mapping between the joints index and
                                           the their name */
@@ -74,10 +75,12 @@ struct YarpRobotControl::Impl
     std::vector<double> positionControlRefSpeeds; /**< Vector containing the ref speed in
                                                      deg/seconds for the position control joints. */
 
-    double positioningDuration{0.0}; /**< Duration of the trajectory generated when the joint is
-                                        controlled in position mode */
-    double startPositionControlInstant{0.0}; /**< Initial time instant of the trajectory generated
-                                                when the joint is controlled in position mode */
+    std::chrono::nanoseconds positioningDuration{0}; /**< Duration of the trajectory generated when
+                                                        the joint is controlled in position mode */
+    std::chrono::nanoseconds startPositionControlInstant{0}; /**< Initial time instant of the
+                                                                  trajectory generated when the
+                                                                  joint is controlled in position
+                                                                  mode */
     double positioningTolerance{0.0}; /**< Max Admissible error for position control joint [rad] */
     double positionDirectMaxAdmissibleError{0.0}; /**< Max admissible error for position direct
                                                      control joint [rad] */
@@ -217,9 +220,9 @@ struct YarpRobotControl::Impl
         }
 
         // resize the desired joint value vector associated to each control mode
-        for (const auto& [mode, indeces] : this->desiredJointValuesAndMode.index)
+        for (const auto& [mode, indices] : this->desiredJointValuesAndMode.index)
         {
-            this->desiredJointValuesAndMode.value[mode].resize(indeces.size());
+            this->desiredJointValuesAndMode.value[mode].resize(indices.size());
         }
 
         // resize the position control reference speed vector
@@ -370,9 +373,9 @@ struct YarpRobotControl::Impl
         }
 
         // resize the desired joint value vector associated to each control mode
-        for (const auto& [mode, indeces] : this->desiredJointValuesAndMode.index)
+        for (const auto& [mode, indices] : this->desiredJointValuesAndMode.index)
         {
-            this->desiredJointValuesAndMode.value[mode].resize(indeces.size());
+            this->desiredJointValuesAndMode.value[mode].resize(indices.size());
         }
 
         // resize the reference speed for the position control mode
@@ -387,8 +390,9 @@ struct YarpRobotControl::Impl
      * Return the the worst position error for the joint controlled in position direct.
      * The first value is the index while the second is the error in radians.
      */
-    std::pair<int, double> getWorstPositionDirectError(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
-                                                       Eigen::Ref<const Eigen::VectorXd> jointPositions) const
+    std::pair<int, double>
+    getWorstPositionDirectError(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                                Eigen::Ref<const Eigen::VectorXd> jointPositions) const
     {
         // clear the std::pair
         std::pair<int, double> worstError{0, 0.0};
@@ -461,44 +465,65 @@ struct YarpRobotControl::Impl
         return nullptr;
     }
 
-    bool setReferences(Eigen::Ref<const Eigen::VectorXd> jointValues)
+    bool setReferences(Eigen::Ref<const Eigen::VectorXd> jointValues,
+                       std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues)
     {
         constexpr auto errorPrefix = "[YarpRobotControl::Impl::setReferences]";
 
-        if(!this->getJointPos())
+        // the following checks are performed only if the robot is controlled in position direct or
+        // in position mode
+        if (!this->desiredJointValuesAndMode.index[IRobotControl::ControlMode::Position].empty()
+            || !this->desiredJointValuesAndMode.index[IRobotControl::ControlMode::PositionDirect]
+                    .empty())
         {
-            log()->error("{} Unable to get the joint position.", errorPrefix);
-            return  false;
+            if (currentJointValues.has_value())
+            {
+                this->positionFeedback = currentJointValues.value();
+            } else
+            {
+                if (!this->getJointPos())
+                {
+                    log()->error("{} Unable to get the joint position.", errorPrefix);
+                    return false;
+                }
+            }
+
+            const auto worstError = this->getWorstPositionDirectError(jointValues, //
+                                                                      this->positionFeedback);
+
+            if (worstError.second > this->positionDirectMaxAdmissibleError)
+            {
+                log()->error("{} The worst error between the current and the desired position of "
+                             "the "
+                             "joint named '{}' is greater than {} deg. Error = {} deg.",
+                             errorPrefix,
+                             this->axesName[worstError.first],
+                             180 / M_PI * this->positionDirectMaxAdmissibleError,
+                             180 / M_PI * worstError.second);
+                return false;
+            }
         }
 
-        const auto worstError = this->getWorstPositionDirectError(jointValues,
-                                                                  this->positionFeedback);
-
-        if (worstError.second > this->positionDirectMaxAdmissibleError)
+        for (const auto& [mode, indices] : this->desiredJointValuesAndMode.index)
         {
-            log()->error("{} The worst error between the current and the desired position of the "
-                         "joint named '{}' is greater than {} deg. Error = {} deg.",
-                         errorPrefix,
-                         this->axesName[worstError.first],
-                         180 / M_PI * this->positionDirectMaxAdmissibleError,
-                         180 / M_PI * worstError.second);
-            return false;
-        }
-
-        for (const auto& [mode, indeces] : this->desiredJointValuesAndMode.index)
-        {
-            // if indeces vector is empty no joint is controlled with this specific control mode
-            if (indeces.empty())
+            // if indices vector is empty no joint is controlled with this specific control mode
+            if (indices.empty())
+            {
                 continue;
+            }
 
             if (mode == IRobotControl::ControlMode::Idle)
+            {
                 continue;
+            }
 
             else if (mode == IRobotControl::ControlMode::Unknown)
             {
                 std::string joints = "";
-                for (const auto& index : indeces)
+                for (const auto& index : indices)
+                {
                     joints += " '" + this->axesName[index] + "'";
+                }
 
                 log()->error("{} The following joints does not have a specified control "
                              "mode:{}. Please set a feasible control mode.",
@@ -508,20 +533,22 @@ struct YarpRobotControl::Impl
 
             } else if (mode == IRobotControl::ControlMode::Position)
             {
-                for (int i = 0; i < indeces.size(); i++)
+                const double positioningDurationSeconds
+                    = std::chrono::duration<double>(this->positioningDuration).count();
+                for (int i = 0; i < indices.size(); i++)
                 {
-                    const auto jointError = std::abs(jointValues[indeces[i]]
-                                                     - this->positionFeedback[indeces[i]]);
+                    const auto jointError
+                        = std::abs(jointValues[indices[i]] - this->positionFeedback[indices[i]]);
 
                     constexpr double scaling = 180 / M_PI;
                     constexpr double minVelocityInDegPerSeconds = 3.0;
                     this->positionControlRefSpeeds[i]
                         = std::max(minVelocityInDegPerSeconds,
-                                   scaling * (jointError / this->positioningDuration));
+                                   scaling * (jointError / positioningDurationSeconds));
                 }
 
-                if (!this->positionInterface->setRefSpeeds(indeces.size(),
-                                                           indeces.data(),
+                if (!this->positionInterface->setRefSpeeds(indices.size(),
+                                                           indices.data(),
                                                            this->positionControlRefSpeeds.data()))
                 {
                     log()->error("{} Unable to set the reference speed for the position control "
@@ -530,22 +557,27 @@ struct YarpRobotControl::Impl
                     return false;
                 }
 
-                this->startPositionControlInstant = yarp::os::Time::now();
+                this->startPositionControlInstant = BipedalLocomotion::clock().now();
             }
 
             // Yarp wants the quantities in degrees
             double scaling = 180 / M_PI;
-            // if the control mode is torque or PWM it is not required to change the unit of
+            // if the control mode is torque or PWM current it is not required to change the unit of
             // measurement
-            if (mode == ControlMode::Torque || mode == ControlMode::PWM
+            if (mode == ControlMode::Torque //
+                || mode == ControlMode::PWM //
                 || mode == ControlMode::Current)
+            {
                 scaling = 1;
+            }
 
-            for (int i = 0; i < indeces.size(); i++)
-                this->desiredJointValuesAndMode.value[mode][i] = scaling * jointValues[indeces[i]];
+            for (int i = 0; i < indices.size(); i++)
+            {
+                this->desiredJointValuesAndMode.value[mode][i] = scaling * jointValues[indices[i]];
+            }
 
-            if (!this->control(mode)(indeces.size(),
-                                     indeces.data(),
+            if (!this->control(mode)(indices.size(),
+                                     indices.data(),
                                      this->desiredJointValuesAndMode.value[mode].data()))
 
             {
@@ -554,6 +586,18 @@ struct YarpRobotControl::Impl
             }
         }
         return true;
+    }
+
+    bool checkControlMode(const std::vector<IRobotControl::ControlMode>& controlModes) const
+    {
+        return controlModes == this->controlModes;
+    }
+
+    bool checkControlMode(const IRobotControl::ControlMode& mode) const
+    {
+        return std::all_of(this->controlModes.begin(),
+                           this->controlModes.end(),
+                           [&mode](const auto& m) { return m == mode; });
     }
 };
 
@@ -610,12 +654,14 @@ bool YarpRobotControl::initialize(std::weak_ptr<ParametersHandler::IParametersHa
     }
 
     // mandatory parameters
+    using namespace std::chrono_literals;
     bool ok = ptr->getParameter("positioning_duration", m_pimpl->positioningDuration)
-              && (m_pimpl->positioningDuration > 0);
+              && (m_pimpl->positioningDuration > 0s);
     ok = ok && ptr->getParameter("positioning_tolerance", m_pimpl->positioningTolerance)
          && (m_pimpl->positioningTolerance > 0);
-    ok = ok && ptr->getParameter("position_direct_max_admissible_error",
-                                 m_pimpl->positionDirectMaxAdmissibleError)
+    ok = ok
+         && ptr->getParameter("position_direct_max_admissible_error",
+                              m_pimpl->positionDirectMaxAdmissibleError)
          && (m_pimpl->positionDirectMaxAdmissibleError > 0);
 
     return ok;
@@ -623,58 +669,53 @@ bool YarpRobotControl::initialize(std::weak_ptr<ParametersHandler::IParametersHa
 
 bool YarpRobotControl::setControlMode(const std::vector<IRobotControl::ControlMode>& controlModes)
 {
-    if (controlModes != m_pimpl->controlModes)
+    if (!m_pimpl->setControlModes(controlModes))
     {
-        m_pimpl->controlModes = controlModes;
-        if (!m_pimpl->setControlModes(m_pimpl->controlModes))
-        {
-            log()->error("[YarpRobotControl::setControlMode] Unable to set the control modes.");
-            return false;
-        }
+        log()->error("[YarpRobotControl::setControlMode] Unable to set the control modes.");
+        return false;
     }
+
+    // if the control mode is set for all the joints, we can store it
+    m_pimpl->controlModes = controlModes;
 
     return true;
 }
 
 bool YarpRobotControl::setControlMode(const IRobotControl::ControlMode& mode)
 {
-    // check if all the joints are controlled in the desired control mode
-    if (!std::all_of(m_pimpl->controlModes.begin(),
-                     m_pimpl->controlModes.end(),
-                     [&mode](const auto& m) { return m == mode; }))
-    {
-        std::fill(m_pimpl->controlModes.begin(), m_pimpl->controlModes.end(), mode);
-        if (!m_pimpl->setControlModes(m_pimpl->controlModes))
-        {
-            log()->error("[YarpRobotControl::setControlMode] Unable to set the control modes.");
-            return false;
-        }
-    }
-    return true;
+    // create a vector containing the same control mode for all the joints
+    const std::vector<IRobotControl::ControlMode> controlModes(m_pimpl->actuatedDOFs, mode);
+    return this->setControlMode(controlModes);
 }
 
-bool YarpRobotControl::setReferences(Eigen::Ref<const Eigen::VectorXd> jointValues,
-                                     const std::vector<IRobotControl::ControlMode>& controlModes)
+bool YarpRobotControl::setReferences(
+    Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+    const std::vector<IRobotControl::ControlMode>& controlModes,
+    std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues)
 {
-   if (!this->setControlMode(controlModes))
-   {
-       log()->error("[YarpRobotControl::setReferences] Unable to set the control modes.");
-       return false;
-   }
-
-   return m_pimpl->setReferences(jointValues);
-}
-
-bool YarpRobotControl::setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
-                                     const IRobotControl::ControlMode& mode)
-{
-    if (!this->setControlMode(mode))
+    if (!m_pimpl->checkControlMode(controlModes))
     {
-        log()->error("[YarpRobotControl::setReferences] Unable to set the control mode.");
+        log()->error("[YarpRobotControl::setReferences] Control modes are not the expected one. "
+                     "Please call setControlMode before calling this function.");
         return false;
     }
 
-    return m_pimpl->setReferences(desiredJointValues);
+    return m_pimpl->setReferences(desiredJointValues, currentJointValues);
+}
+
+bool YarpRobotControl::setReferences(
+    Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+    const IRobotControl::ControlMode& mode,
+    std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues)
+{
+    if (!m_pimpl->checkControlMode(mode))
+    {
+        log()->error("[YarpRobotControl::setReferences] Control mode is not the expected one. "
+                     "Please call setControlMode before calling this function.");
+        return false;
+    }
+
+    return m_pimpl->setReferences(desiredJointValues, currentJointValues);
 }
 
 bool YarpRobotControl::checkMotionDone(bool& motionDone,
@@ -716,8 +757,9 @@ bool YarpRobotControl::checkMotionDone(bool& motionDone,
         }
     }
 
-    const double now = yarp::os::Time::now();
-    constexpr double timeTolerance = 1.0;
+    using namespace std::chrono_literals;
+    const std::chrono::nanoseconds now = BipedalLocomotion::clock().now();
+    constexpr std::chrono::nanoseconds timeTolerance{1s};
     if (now - m_pimpl->startPositionControlInstant > m_pimpl->positioningDuration + timeTolerance)
     {
         isTimeExpired = true;

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
@@ -9,6 +9,8 @@
 #define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_IROBOT_CONTROL_H
 
 #include <memory>
+#include <optional>
+#include <vector>
 
 #include <Eigen/Dense>
 
@@ -64,24 +66,29 @@ public:
      */
     virtual bool checkMotionDone(bool& motionDone,
                                  bool& isTimerExpired,
-                                 std::vector<std::pair<std::string, double>>& info) = 0;
+                                 std::vector<std::pair<std::string, double>>& info)
+        = 0;
 
     /**
      * Set the desired reference.
-     * @param jointValues desired joint values.
+     * @param desiredJointValues desired joint values.
      * @param controlModes vector containing the control mode for each joint.
+     * @param currentJointValues current joint values.
      * @return True/False in case of success/failure.
      * @note In case of position control the values has to be expressed in rad, in case of velocity
      * control in rad/s. If the robot is controlled in torques, the desired joint values are
      * expressed in Nm.
      */
-    virtual bool setReferences(Eigen::Ref<const Eigen::VectorXd> jointValues,
-                               const std::vector<IRobotControl::ControlMode>& controlModes) = 0;
+    virtual bool setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                               const std::vector<IRobotControl::ControlMode>& controlModes,
+                               std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {})
+        = 0;
 
     /**
      * Set the desired reference.
-     * @param jointValues desired joint values.
+     * @param desiredJointValues desired joint values.
      * @param controlMode a control mode for all the joints.
+     * @param currentJointValues current joint values.
      * @return True/False in case of success/failure.
      * @note In case of position control the values has to be expressed in rad, in case of velocity
      * control in rad/s. If the robot is controlled in torques, the desired joint values are
@@ -91,7 +98,9 @@ public:
      * std::vector<IRobotControl::ControlMode>&).
      */
     virtual bool setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
-                               const IRobotControl::ControlMode& controlMode) = 0;
+                               const IRobotControl::ControlMode& controlMode,
+                               std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {})
+        = 0;
 
     /**
      * Set the control mode.
@@ -126,7 +135,6 @@ public:
      * Destructor.
      */
     virtual ~IRobotControl() = default;
-
 };
 } // namespace RobotInterface
 } // namespace BipedalLocomotion

--- a/utilities/balancing-position-control/script/blf-balancing-position-control.py
+++ b/utilities/balancing-position-control/script/blf-balancing-position-control.py
@@ -475,7 +475,9 @@ def main():
 
         # send the joint pose
         if not robot_control.set_references(
-            desired_joint_positions, blf.robot_interface.YarpRobotControl.PositionDirect
+            desired_joint_positions,
+            blf.robot_interface.YarpRobotControl.PositionDirect,
+            joint_positions,
         ):
             raise RuntimeError("Unable to set the references")
 
@@ -487,9 +489,7 @@ def main():
         com_from_desired = kindyn.getCenterOfMassPosition().toNumPy()
         com_from_measured = kindyn_with_measured.getCenterOfMassPosition().toNumPy()
 
-        if not vectors_collection_server.prepare_data():
-            raise RuntimeError("Unable to prepare the data")
-
+        vectors_collection_server.prepare_data()
         vectors_collection_server.clear_data()
 
         vectors_collection_server.populate_data("zmp::desired_planner", desired_zmp)

--- a/utilities/balancing-torque-control/config/robots/ergoCubGazeboV1/blf-balancing-torque-control-options.ini
+++ b/utilities/balancing-torque-control/config/robots/ergoCubGazeboV1/blf-balancing-torque-control-options.ini
@@ -17,3 +17,4 @@ right_contact_frame      r_sole
 [include ROBOT_CONTROL "./blf_balancing_torque_control/robot_control.ini"]
 [include SENSOR_BRIDGE "./blf_balancing_torque_control/sensor_bridge.ini"]
 [include CONTACT_WRENCHES "./blf_balancing_torque_control/contact_wrenches.ini"]
+[include DATA_LOGGING "./blf_balancing_torque_control/data_logging.ini"]

--- a/utilities/balancing-torque-control/config/robots/ergoCubGazeboV1/blf_balancing_torque_control/data_logging.ini
+++ b/utilities/balancing-torque-control/config/robots/ergoCubGazeboV1/blf_balancing_torque_control/data_logging.ini
@@ -1,0 +1,1 @@
+remote "/balancing_torque_controller/logger"

--- a/utilities/balancing-torque-control/config/robots/ergoCubGazeboV1/blf_balancing_torque_control/tsid.ini
+++ b/utilities/balancing-torque-control/config/robots/ergoCubGazeboV1/blf_balancing_torque_control/tsid.ini
@@ -50,9 +50,8 @@ robot_acceleration_variable_name "robot_acceleration"
 frame_name                       "chest"
 kp_angular                       5.0
 kd_angular                       2.0
-
-priority                        1
-weight                          (5.0, 5.0, 5.0)
+priority                         1
+weight                           (5.0, 5.0, 5.0)
 
 [JOINT_REGULARIZATION_TASK]
 name                             joint_regularization_task
@@ -86,8 +85,8 @@ variable_name                    "lf_wrench"
 frame_name                       "l_sole"
 number_of_slices                 2
 static_friction_coefficient      0.3
-foot_limits_x                   (-0.1, 0.1)
-foot_limits_y                   (-0.05, 0.05)
+foot_limits_x                    (-0.1, 0.1)
+foot_limits_y                    (-0.05, 0.05)
 
 [RF_WRENCH_TASK]
 name                            "rf_feasibility_wrench_task"


### PR DESCRIPTION
This pull request restructures YarpRobotControl in the following manner:

- It avoids automatically switching the control mode when a reference is set via `YarpRobotControl::setReferences`. Refer to issue #820 for more details.
- Furthermore, setReference can now accept a vector of joints as input (optional). If provided, `YarpRobotControl::setReferences` avoids calling getEncoders from the interface to check if the maximum error is lower than the acceptable threshold.


Finally, it updates the utilities to work with the new modifications

> [!WARNING]  
> As previously mentioned in issue #820, upon merging this PR, several existing code instances will stop functioning. Users should update their code by calling `YarpRobotControl::setControlMode()` with the desired control mode once before entering the main control loop.
