### PR TITLE
InstallBasicPackageFiles: Fix OVERRIDE_MODULE_PATH with CMake >=3.29.1

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -125,4 +125,4 @@ jobs:
       run: |
         cd build
         cmake --install . --config ${{ matrix.build_type }}
-        cmake-package-check BipedalLocomotionFramework
+        cmake-package-check BipedalLocomotionFramework --targets BipedalLocomotion::Framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 - Fix the barrier logic for threads synchronization (https://github.com/ami-iit/bipedal-locomotion-framework/pull/811)
 - InstallBasicPackageFiles: Fix bug of OVERRIDE_MODULE_PATH that corrupt CMAKE_MODULE_PATH values set by blf transitive dependencies (https://github.com/ami-iit/bipedal-locomotion-framework/pull/827)
+- InstallBasicPackageFiles: Fix compatibility with CMake 3.29.1 ()
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 - Fix the barrier logic for threads synchronization (https://github.com/ami-iit/bipedal-locomotion-framework/pull/811)
 - InstallBasicPackageFiles: Fix bug of OVERRIDE_MODULE_PATH that corrupt CMAKE_MODULE_PATH values set by blf transitive dependencies (https://github.com/ami-iit/bipedal-locomotion-framework/pull/827)
-- InstallBasicPackageFiles: Fix compatibility with CMake 3.29.1 ()
+- InstallBasicPackageFiles: Fix compatibility with CMake 3.29.1 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/835)
 
 ### Removed
 

--- a/cmake/InstallBasicPackageFiles.cmake
+++ b/cmake/InstallBasicPackageFiles.cmake
@@ -376,7 +376,107 @@ function(INSTALL_BASIC_PACKAGE_FILES _Name)
     list(APPEND configure_package_config_file_extra_args NO_CHECK_REQUIRED_COMPONENTS_MACRO)
   endif()
 
+  # Prepare PACKAGE_DEPENDENCIES variable
+  set(_need_private_deps 0)
+  if(NOT BUILD_SHARED_LIBS)
+    set(_need_private_deps 1)
+  else()
+    foreach(_target ${_targets})
+      get_property(_type TARGET ${_target} PROPERTY TYPE)
+      if("${_type}" STREQUAL "STATIC_LIBRARY")
+        set(_need_private_deps 1)
+        break()
+      endif()
+    endforeach()
+  endif()
 
+  unset(PACKAGE_DEPENDENCIES)
+  set(_overridden_module_path_list "")
+  if(DEFINED _IBPF_DEPENDENCIES)
+    set(PACKAGE_DEPENDENCIES "#### Expanded from PACKAGE_DEPENDENCIES by install_basic_package_files() ####\n\ninclude(CMakeFindDependencyMacro)\n")
+
+    if (DEFINED _IBPF_OVERRIDE_MODULE_PATH)
+      foreach(_path ${_IBPF_OVERRIDE_MODULE_PATH})
+
+          if (IS_ABSOLUTE ${_path})
+              set(_absolute_module_path ${_path})
+          else()
+              set(_absolute_module_path "${CMAKE_CURRENT_SOURCE_DIR}/${_path}")
+          endif()
+
+          file(RELATIVE_PATH _relative_path ${CMAKE_INSTALL_PREFIX} ${_absolute_module_path})
+          string(APPEND _overridden_module_path_list ";@PACKAGE_CMAKE_INSTALL_PREFIX@/${_relative_path}")
+      endforeach()
+      string(APPEND PACKAGE_DEPENDENCIES "foreach(overridden_module_path ${_overridden_module_path_list})\n")
+      string(APPEND PACKAGE_DEPENDENCIES "    list(PREPEND CMAKE_MODULE_PATH \${overridden_module_path})\n")
+      string(APPEND PACKAGE_DEPENDENCIES "endforeach()\n")
+
+      # If OVERRIDE_MODULE_PATH is used, then if a dependency is not found find_dependency will
+      # halt the execution of the <package>config.cmake script, never restoring the original
+      # value of CMAKE_MODULE_PATH. For this reason, in this case we just use find_package
+      set(_IBPF_FIND_DEPENDENCY_COMMAND "find_package")
+    else()
+      set(_IBPF_FIND_DEPENDENCY_COMMAND "find_dependency")
+    endif()
+
+    # FIXME When CMake 3.9 or greater is required, remove this madness and just
+    #       use find_dependency
+    if (CMAKE_VERSION VERSION_LESS 3.9)
+      string(APPEND PACKAGE_DEPENDENCIES "
+set(_${_Name}_FIND_PARTS_REQUIRED)
+if (${_Name}_FIND_REQUIRED)
+  set(_${_Name}_FIND_PARTS_REQUIRED REQUIRED)
+endif()
+set(_${_Name}_FIND_PARTS_QUIET)
+if (${_Name}_FIND_QUIETLY)
+  set(_${_Name}_FIND_PARTS_QUIET QUIET)
+endif()
+")
+
+      foreach(_dep ${_IBPF_DEPENDENCIES})
+        if("${_dep}" MATCHES ".+ .+")
+            string(REPLACE " " ";" _dep_list "${_dep}")
+            list(INSERT _dep_list 1 \${_${_Name}_FIND_PARTS_QUIET} \${_${_Name}_FIND_PARTS_REQUIRED})
+            string(REPLACE ";" " " _depx "${_dep_list}")
+            string(APPEND PACKAGE_DEPENDENCIES "find_package(${_depx})\n")
+        else()
+          string(APPEND PACKAGE_DEPENDENCIES "${_IBPF_FIND_DEPENDENCY_COMMAND}(${_dep})\n")
+        endif()
+      endforeach()
+      if(_need_private_deps)
+        foreach(_dep ${_IBPF_PRIVATE_DEPENDENCIES})
+          if("${_dep}" MATCHES ".+ .+")
+            string(REPLACE " " ";" _dep_list "${_dep}")
+            list(INSERT _dep_list 1 \${_${_Name}_FIND_PARTS_QUIET} \${_${_Name}_FIND_PARTS_REQUIRED})
+            string(REPLACE ";" "\n       " _depx "${_dep_list}")
+            string(APPEND PACKAGE_DEPENDENCIES "find_package(${_depx})\n")
+          else()
+            string(APPEND PACKAGE_DEPENDENCIES "${_IBPF_FIND_DEPENDENCY_COMMAND}(${_dep})\n")
+          endif()
+          endforeach()
+      endif()
+
+    else()
+
+      foreach(_dep ${_IBPF_DEPENDENCIES})
+        string(APPEND PACKAGE_DEPENDENCIES "${_IBPF_FIND_DEPENDENCY_COMMAND}(${_dep})\n")
+      endforeach()
+      if(_need_private_deps)
+        foreach(_dep ${_IBPF_PRIVATE_DEPENDENCIES})
+          string(APPEND PACKAGE_DEPENDENCIES "${_IBPF_FIND_DEPENDENCY_COMMAND}(${_dep})\n")
+        endforeach()
+      endif()
+
+    endif()
+
+    if(DEFINED _IBPF_OVERRIDE_MODULE_PATH)
+      string(APPEND PACKAGE_DEPENDENCIES "foreach(overridden_module_path ${_overridden_module_path_list})\n")
+      string(APPEND PACKAGE_DEPENDENCIES "    list(REMOVE_ITEM CMAKE_MODULE_PATH \${overridden_module_path})\n")
+      string(APPEND PACKAGE_DEPENDENCIES "endforeach()\n")
+    endif()
+
+    set(PACKAGE_DEPENDENCIES "${PACKAGE_DEPENDENCIES}\n###############################################################################\n")
+  endif()
 
   # Set input file for config, and ensure that _IBPF_UPPERCASE_FILENAMES
   # and _IBPF_LOWERCASE_FILENAMES are set correctly
@@ -460,6 +560,10 @@ function(INSTALL_BASIC_PACKAGE_FILES _Name)
     set(_targets_filename ${_name}-targets.cmake)
   endif()
 
+  # OVERRIDE_MODULE_PATH is not compatible with a custom template config file
+  if(NOT _generate_file AND DEFINED _IBPF_OVERRIDE_MODULE_PATH)
+    message(FATAL_ERROR "OVERRIDE_MODULE_PATH option is not compatible with a custom CMake config template.")
+  endif()
 
   # If the template config file does not exist, write a basic one
   if(_generate_file)
@@ -503,7 +607,7 @@ function(INSTALL_BASIC_PACKAGE_FILES _Name)
 
 \@PACKAGE_INIT\@
 
-\@PACKAGE_DEPENDENCIES\@
+${PACKAGE_DEPENDENCIES}
 
 if(NOT TARGET ${_IBPF_NAMESPACE}${_first_target})
   include(\"\${CMAKE_CURRENT_LIST_DIR}/${_targets_filename}\")
@@ -560,109 +664,6 @@ ${_compatibility_vars}
           DESTINATION ${_IBPF_INSTALL_DESTINATION}
           COMPONENT ${_IBPF_COMPONENT})
 
-
-  # Prepare PACKAGE_DEPENDENCIES variable
-  set(_need_private_deps 0)
-  if(NOT BUILD_SHARED_LIBS)
-    set(_need_private_deps 1)
-  else()
-    foreach(_target ${_targets})
-      get_property(_type TARGET ${_target} PROPERTY TYPE)
-      if("${_type}" STREQUAL "STATIC_LIBRARY")
-        set(_need_private_deps 1)
-        break()
-      endif()
-    endforeach()
-  endif()
-
-  unset(PACKAGE_DEPENDENCIES)
-  set(_overridden_module_path_list "")
-  if(DEFINED _IBPF_DEPENDENCIES)
-    set(PACKAGE_DEPENDENCIES "#### Expanded from @PACKAGE_DEPENDENCIES@ by install_basic_package_files() ####\n\ninclude(CMakeFindDependencyMacro)\n")
-
-    if (DEFINED _IBPF_OVERRIDE_MODULE_PATH)
-      foreach(_path ${_IBPF_OVERRIDE_MODULE_PATH})
-
-          if (IS_ABSOLUTE ${_path})
-              set(_absolute_module_path ${_path})
-          else()
-              set(_absolute_module_path "${CMAKE_CURRENT_SOURCE_DIR}/${_path}")
-          endif()
-
-          file(RELATIVE_PATH _relative_path ${CMAKE_INSTALL_PREFIX} ${_absolute_module_path})
-          string(APPEND _overridden_module_path_list ";\${PACKAGE_PREFIX_DIR}/${_relative_path}")
-      endforeach()
-      string(APPEND PACKAGE_DEPENDENCIES "foreach(overridden_module_path ${_overridden_module_path_list})\n")
-      string(APPEND PACKAGE_DEPENDENCIES "    list(PREPEND CMAKE_MODULE_PATH \${overridden_module_path})\n")
-      string(APPEND PACKAGE_DEPENDENCIES "endforeach()\n")
-
-      # If OVERRIDE_MODULE_PATH is used, then if a dependency is not found find_dependency will
-      # halt the execution of the <package>config.cmake script, never restoring the original
-      # value of CMAKE_MODULE_PATH. For this reason, in this case we just use find_package
-      set(_IBPF_FIND_DEPENDENCY_COMMAND "find_package")
-    else()
-      set(_IBPF_FIND_DEPENDENCY_COMMAND "find_dependency")
-    endif()
-
-    # FIXME When CMake 3.9 or greater is required, remove this madness and just
-    #       use find_dependency
-    if (CMAKE_VERSION VERSION_LESS 3.9)
-      string(APPEND PACKAGE_DEPENDENCIES "
-set(_${_Name}_FIND_PARTS_REQUIRED)
-if (${_Name}_FIND_REQUIRED)
-  set(_${_Name}_FIND_PARTS_REQUIRED REQUIRED)
-endif()
-set(_${_Name}_FIND_PARTS_QUIET)
-if (${_Name}_FIND_QUIETLY)
-  set(_${_Name}_FIND_PARTS_QUIET QUIET)
-endif()
-")
-
-      foreach(_dep ${_IBPF_DEPENDENCIES})
-        if("${_dep}" MATCHES ".+ .+")
-            string(REPLACE " " ";" _dep_list "${_dep}")
-            list(INSERT _dep_list 1 \${_${_Name}_FIND_PARTS_QUIET} \${_${_Name}_FIND_PARTS_REQUIRED})
-            string(REPLACE ";" " " _depx "${_dep_list}")
-            string(APPEND PACKAGE_DEPENDENCIES "find_package(${_depx})\n")
-        else()
-          string(APPEND PACKAGE_DEPENDENCIES "${_IBPF_FIND_DEPENDENCY_COMMAND}(${_dep})\n")
-        endif()
-      endforeach()
-      if(_need_private_deps)
-        foreach(_dep ${_IBPF_PRIVATE_DEPENDENCIES})
-          if("${_dep}" MATCHES ".+ .+")
-            string(REPLACE " " ";" _dep_list "${_dep}")
-            list(INSERT _dep_list 1 \${_${_Name}_FIND_PARTS_QUIET} \${_${_Name}_FIND_PARTS_REQUIRED})
-            string(REPLACE ";" "\n       " _depx "${_dep_list}")
-            string(APPEND PACKAGE_DEPENDENCIES "find_package(${_depx})\n")
-          else()
-            string(APPEND PACKAGE_DEPENDENCIES "$_IBPF_FIND_DEPENDENCY_COMMAND}(${_dep})\n")
-          endif()
-          endforeach()
-      endif()
-
-    else()
-
-      foreach(_dep ${_IBPF_DEPENDENCIES})
-        string(APPEND PACKAGE_DEPENDENCIES "${_IBPF_FIND_DEPENDENCY_COMMAND}(${_dep})\n")
-      endforeach()
-      if(_need_private_deps)
-        foreach(_dep ${_IBPF_PRIVATE_DEPENDENCIES})
-          string(APPEND PACKAGE_DEPENDENCIES "$_IBPF_FIND_DEPENDENCY_COMMAND}(${_dep})\n")
-        endforeach()
-      endif()
-
-    endif()
-
-    if(DEFINED _IBPF_OVERRIDE_MODULE_PATH)
-      string(APPEND PACKAGE_DEPENDENCIES "foreach(overridden_module_path ${_overridden_module_path_list})\n")
-      string(APPEND PACKAGE_DEPENDENCIES "    list(REMOVE_ITEM CMAKE_MODULE_PATH \${overridden_module_path})\n")
-      string(APPEND PACKAGE_DEPENDENCIES "endforeach()\n")
-    endif()
-
-    set(PACKAGE_DEPENDENCIES "${PACKAGE_DEPENDENCIES}\n###############################################################################\n")
-  endif()
-
   # Prepare PACKAGE_VERSION variable
   set(PACKAGE_VERSION ${_IBPF_VERSION})
 
@@ -689,6 +690,7 @@ endif()
       set(${_IBPF_VARS_PREFIX}_${p} "${INSTALL_${_IBPF_VARS_PREFIX}_${p}}")
     endif()
   endforeach()
+  list(APPEND _install_path_vars CMAKE_INSTALL_PREFIX)
   configure_package_config_file("${_config_cmake_in}"
                                 "${CMAKE_CURRENT_BINARY_DIR}/${_config_filename}.install"
                                 INSTALL_DESTINATION ${_IBPF_INSTALL_DESTINATION}


### PR DESCRIPTION
`OVERRIDE_MODULE_PATH` used the `PACKAGE_PREFIX_DIR` variable, that however was an internal undocumented detail of configure_package_config_file and that was changed in CMake 3.29.1 by https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9390 .

See https://github.com/ami-iit/matio-cpp/issues/78#issuecomment-2044457554 for more context.

To fix the problem, we switch to add directly the `OVERRIDE_MODULE_PATH` logic in the generated cmake config template, so that there we can use the `@PACKAGE_CMAKE_INSTALL_PREFIX@` variable, and rely on the `configure_package_config_file` to appropriately substitute `@PACKAGE_CMAKE_INSTALL_PREFIX@` with the actual relocated install prefix. To do so, we also pass `CMAKE_INSTALL_PREFIX` to the `PATH_VARS` option of `configure_package_config_file`.

See also https://github.com/ami-iit/matio-cpp/pull/79 . I also added a test to prevent regression related to this in CI, in the form of `cmake-package-check BipedalLocomotionFramework --targets BipedalLocomotion::Framework` thanks to https://github.com/ami-iit/cmake-package-check/pull/8 .