### PR TITLE
Add the possibility to set the number of threads used by onnxruntime in MANN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - Add support for testing if a portion of code allocates memory via `MemoryAllocationMonitor`` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/768)
 - Implement `Math::ZeroOrderSpline` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/834)
 - Add the possibility to get only position or position/velocity from the spline (https://github.com/ami-iit/bipedal-locomotion-framework/pull/834)
+- Add the possibility to set the number of threads used by onnxruntime in `MANN` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/836)
 
 ### Changed
 - 🤖 [ergoCubSN001] Add logging of the wrist and fix the name of the waist imu (https://github.com/ami-iit/bipedal-locomotion-framework/pull/810)

--- a/src/ML/include/BipedalLocomotion/ML/MANN.h
+++ b/src/ML/include/BipedalLocomotion/ML/MANN.h
@@ -129,11 +129,12 @@ public:
      * Initialize the network.
      * @param paramHandler pointer to the parameters handler.
      * @note the following parameters are required by the class
-     * |        Parameter Name       |       Type       |                                       Description                                              | Mandatory |
-     * |:---------------------------:|:----------------:|:----------------------------------------------------------------------------------------------:|:---------:|
-     * |       `onnx_model_path`     |      `string`    |          Path to the `onnx` model that will be loaded to perform inference                     |    Yes    |
-     * |     `number_of_joints`      |       `int`      |               Number of robot joints considered in the model                                   |    Yes    |
-     * | `projected_base_datapoints` |       `int`      |    Number of samples of the base horizon considered in the model (it must be an even number)   |    Yes    |
+     * |        Parameter Name       |       Type       |                                       Description                                               | Mandatory |
+     * |:---------------------------:|:----------------:|:-----------------------------------------------------------------------------------------------:|:---------:|
+     * |       `onnx_model_path`     |      `string`    |          Path to the `onnx` model that will be loaded to perform inference                      |    Yes    |
+     * |     `number_of_joints`      |       `int`      |               Number of robot joints considered in the model                                    |    Yes    |
+     * | `projected_base_datapoints` |       `int`      |    Number of samples of the base horizon considered in the model (it must be an even number)    |    Yes    |
+     * |     `number_of_threads`     |       `int`      | Number of threads used to perform the inference. Default value is the number of available cores |    No     |
      * @return True in case of success, false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler) override;


### PR DESCRIPTION
With @LoreMoretti and @traversaro, we observed that during inference, onnxruntime spawns n threads, where n is the number of cores, as explained in https://onnxruntime.ai/docs/performance/tune-performance/threading.html. This results in a slowdown for other threads and processes. This PR allows the user to set the number of threads used for the inference