### PR TITLE
Implement the python bindings for the Butterworth low pass filter

### DIFF
--- a/bindings/python/ContinuousDynamicalSystem/CMakeLists.txt
+++ b/bindings/python/ContinuousDynamicalSystem/CMakeLists.txt
@@ -6,9 +6,9 @@ if(TARGET BipedalLocomotion::ContinuousDynamicalSystem)
 
   add_bipedal_locomotion_python_module(
     NAME ContinuousDynamicalSystemBindings
-    SOURCES src/MultiStateWeightProvider.cpp src/LinearTimeInvariantSystem.cpp src/FloatingBaseSystemKinematics.cpp src/CentroidalDynamics.cpp src/Module.cpp
+    SOURCES src/MultiStateWeightProvider.cpp src/LinearTimeInvariantSystem.cpp src/FloatingBaseSystemKinematics.cpp src/CentroidalDynamics.cpp src/ButterworthLowPassFilter.cpp src/Module.cpp
     HEADERS ${H_PREFIX}/DynamicalSystem.h ${H_PREFIX}/LinearTimeInvariantSystem.h ${H_PREFIX}/FloatingBaseSystemKinematics.h ${H_PREFIX}/Integrator.h
-            ${H_PREFIX}/MultiStateWeightProvider.h ${H_PREFIX}/CentroidalDynamics.h
+            ${H_PREFIX}/MultiStateWeightProvider.h ${H_PREFIX}/CentroidalDynamics.h ${H_PREFIX}/ButterworthLowPassFilter.h
             ${H_PREFIX}/Module.h
     LINK_LIBRARIES BipedalLocomotion::ContinuousDynamicalSystem
     TESTS tests/test_linear_system.py tests/test_floating_base_system_kinematics.py tests/test_centroidal_dynamics.py

--- a/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/ButterworthLowPassFilter.h
+++ b/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/ButterworthLowPassFilter.h
@@ -1,0 +1,26 @@
+/**
+ * @file ButterworthLowPass.h
+ * @authors Giulio Romualdi
+ * @copyright 2024 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_CONTINUOUS_DYNAMICAL_SYSTEM_BUTTERWORTH_LOW_PASS_FILTER_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_CONTINUOUS_DYNAMICAL_SYSTEM_BUTTERWORTH_LOW_PASS_FILTER_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ContinuousDynamicalSystem
+{
+
+void CreateButterworthLowPassFilter(pybind11::module& module);
+
+} // namespace ContinuousDynamicalSystem
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_CONTINUOUS_DYNAMICAL_SYSTEM_BUTTERWORTH_LOW_PASS_FILTER_H

--- a/bindings/python/ContinuousDynamicalSystem/src/ButterworthLowPassFilter.cpp
+++ b/bindings/python/ContinuousDynamicalSystem/src/ButterworthLowPassFilter.cpp
@@ -1,0 +1,42 @@
+/**
+ * @file ButterworthLowPass.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2024 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/ContinuousDynamicalSystem/ButterworthLowPassFilter.h>
+#include <BipedalLocomotion/System/Advanceable.h>
+
+#include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/ButterworthLowPassFilter.h>
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
+
+#include <pybind11/eigen.h>
+#include <pybind11/stl.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ContinuousDynamicalSystem
+{
+
+void CreateButterworthLowPassFilter(pybind11::module& module)
+{
+    using namespace BipedalLocomotion::ContinuousDynamicalSystem;
+    namespace py = ::pybind11;
+
+    BipedalLocomotion::bindings::System::CreateAdvanceable<Eigen::VectorXd, //
+                                                           Eigen::VectorXd>(module,
+                                                                            "ButterworthLowPassFilter");
+
+    py::class_<ButterworthLowPassFilter, //
+               ::BipedalLocomotion::System::Advanceable<Eigen::VectorXd, //
+                                                        Eigen::VectorXd>>(module,
+                                                                          "ButterworthLowPassFilter")
+        .def(py::init());
+}
+
+} // namespace ContinuousDynamicalSystem
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/ContinuousDynamicalSystem/src/Module.cpp
+++ b/bindings/python/ContinuousDynamicalSystem/src/Module.cpp
@@ -12,6 +12,7 @@
 #include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h>
 #include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/Module.h>
 #include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/MultiStateWeightProvider.h>
+#include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/ButterworthLowPassFilter.h>
 
 namespace BipedalLocomotion
 {
@@ -28,6 +29,7 @@ void CreateModule(pybind11::module& module)
     CreateFloatingBaseSystemKinematics(module);
     CreateMultiStateWeightProvider(module);
     CreateCentroidalDynamics(module);
+    CreateButterworthLowPassFilter(module);
 }
 } // namespace ContinuousDynamicalSystem
 } // namespace bindings

--- a/bindings/python/System/src/Advanceable.cpp
+++ b/bindings/python/System/src/Advanceable.cpp
@@ -6,9 +6,9 @@
  */
 
 #include <pybind11/cast.h>
+#include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/eigen.h>
 
 #include <BipedalLocomotion/bindings/System/Advanceable.h>
 
@@ -36,20 +36,19 @@ namespace bindings
 namespace System
 {
 
-
-void CreateSharedSource(pybind11::module& module)
-{
-    CreateSource<Eigen::VectorXd>(module, "VectorXd");
-}
-
-void CreateSharedInputPort(pybind11::module& module)
+void CreateCommonDataStructure(pybind11::module& module)
 {
     CreateInputPort<::BipedalLocomotion::System::EmptySignal>(module, "Empty");
-}
-
-void CreateSharedOutputPort(pybind11::module& module)
-{
+    CreateInputPort<::Eigen::VectorXd>(module, "VectorXd");
     CreateOutputPort<::BipedalLocomotion::System::EmptySignal>(module, "Empty");
+    CreateOutputPort<::Eigen::VectorXd>(module, "VectorXd");
+
+    CreateAdvanceableImpl<::BipedalLocomotion::System::EmptySignal, ::Eigen::VectorXd>(module, "EmptyVectorXd");
+    CreateAdvanceableImpl<::Eigen::VectorXd, ::BipedalLocomotion::System::EmptySignal>(module, "VectorXdEmpty");
+    CreateSourceImpl<::Eigen::VectorXd>(module, "VectorXd");
+    CreateSinkImpl<::Eigen::VectorXd>(module, "VectorXd");
+
+    CreateAdvanceableImpl<::Eigen::VectorXd, ::Eigen::VectorXd>(module, "VectorXd");
 }
 
 } // namespace System

--- a/bindings/python/System/src/Module.cpp
+++ b/bindings/python/System/src/Module.cpp
@@ -26,9 +26,7 @@ void CreateModule(pybind11::module& module)
 {
     module.doc() = "System module";
 
-    CreateSharedInputPort(module);
-    CreateSharedOutputPort(module);
-    CreateSharedSource(module);
+    CreateCommonDataStructure(module);
 
     CreateVariablesHandler(module);
     CreateLinearTask(module);


### PR DESCRIPTION
Moreover, I had to modify how the sink, source, and advanceable bindings are created for the `Eigen::VectorXd`. This is required otherwise if we try to register a type that has been already registered we get 
```
generc_type xxxx is already registered
```
See: https://github.com/pybind/pybind11/issues/439