### PR TITLE
Fix `VectorsCollectionClient.read_data(False)` to provide `collection` as output and avoid segmentation fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project are documented in this file.
 - InstallBasicPackageFiles: Fix bug of OVERRIDE_MODULE_PATH that corrupt `CMAKE_MODULE_PATH` values set by blf transitive dependencies (https://github.com/ami-iit/bipedal-locomotion-framework/pull/827)
 - InstallBasicPackageFiles: Fix compatibility with CMake 3.29.1 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/835)
 - Fix `YARPRobotLoggerDevice` excessively long time horizon for signals logged with `YARP_CLOCK` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/839)
+- Fix `VectorsCollectionClient.read_data(False)` to provide `collection` as output and avoid segmentation fault (https://github.com/ami-iit/bipedal-locomotion-framework/pull/850)
 
 ### Removed
 

--- a/bindings/python/YarpUtilities/src/VectorsCollection.cpp
+++ b/bindings/python/YarpUtilities/src/VectorsCollection.cpp
@@ -69,7 +69,10 @@ void CreateVectorsCollectionClient(pybind11::module& module)
              [](VectorsCollectionClient& impl)
                  -> BipedalLocomotion::YarpUtilities::VectorsCollectionMetadata {
                  BipedalLocomotion::YarpUtilities::VectorsCollectionMetadata metadata;
-                 impl.getMetadata(metadata);
+                 if (impl.getMetadata(metadata) == false)
+                 {
+                     throw ::pybind11::value_error("Impossible to retrieve the metadata.");
+                 }
                  return metadata;
              })
         .def("read_data",

--- a/bindings/python/YarpUtilities/src/VectorsCollection.cpp
+++ b/bindings/python/YarpUtilities/src/VectorsCollection.cpp
@@ -5,12 +5,13 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
+#include <optional>
+#include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/eigen.h>
 
-#include <BipedalLocomotion/YarpUtilities/VectorsCollectionServer.h>
 #include <BipedalLocomotion/YarpUtilities/VectorsCollectionClient.h>
+#include <BipedalLocomotion/YarpUtilities/VectorsCollectionServer.h>
 
 #include <BipedalLocomotion/bindings/YarpUtilities/BufferedPort.h>
 #include <BipedalLocomotion/bindings/YarpUtilities/VectorsCollection.h>
@@ -65,17 +66,23 @@ void CreateVectorsCollectionClient(pybind11::module& module)
         .def("connect", &VectorsCollectionClient::connect)
         .def("disconnect", &VectorsCollectionClient::disconnect)
         .def("get_metadata",
-        [](VectorsCollectionClient& impl) -> BipedalLocomotion::YarpUtilities::VectorsCollectionMetadata
-        {
-            BipedalLocomotion::YarpUtilities::VectorsCollectionMetadata metadata;
-            impl.getMetadata(metadata);
-            return metadata;
-        })
+             [](VectorsCollectionClient& impl)
+                 -> BipedalLocomotion::YarpUtilities::VectorsCollectionMetadata {
+                 BipedalLocomotion::YarpUtilities::VectorsCollectionMetadata metadata;
+                 impl.getMetadata(metadata);
+                 return metadata;
+             })
         .def("read_data",
-             [](VectorsCollectionClient& impl, bool shouldWait) -> std::map<std::string, std::vector<double>>
-             {
-                BipedalLocomotion::YarpUtilities::VectorsCollection* collection = impl.readData(shouldWait);
-                return collection->vectors;
+             [](VectorsCollectionClient& impl,
+                bool shouldWait) -> std::optional<std::map<std::string, std::vector<double>>> {
+                 BipedalLocomotion::YarpUtilities::VectorsCollection* collection
+                     = impl.readData(shouldWait);
+                 if (collection == nullptr)
+                 {
+                     // Return an empty optional if the collection is not available
+                     return std::nullopt;
+                 }
+                 return collection->vectors;
              });
 }
 

--- a/bindings/python/YarpUtilities/src/VectorsCollection.cpp
+++ b/bindings/python/YarpUtilities/src/VectorsCollection.cpp
@@ -5,7 +5,6 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
-#include <optional>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/bindings/python/YarpUtilities/src/VectorsCollection.cpp
+++ b/bindings/python/YarpUtilities/src/VectorsCollection.cpp
@@ -77,15 +77,10 @@ void CreateVectorsCollectionClient(pybind11::module& module)
              })
         .def("read_data",
              [](VectorsCollectionClient& impl,
-                bool shouldWait) -> std::optional<std::map<std::string, std::vector<double>>> {
+                bool shouldWait) -> BipedalLocomotion::YarpUtilities::VectorsCollection* {
                  BipedalLocomotion::YarpUtilities::VectorsCollection* collection
                      = impl.readData(shouldWait);
-                 if (collection == nullptr)
-                 {
-                     // Return an empty optional if the collection is not available
-                     return std::nullopt;
-                 }
-                 return collection->vectors;
+                 return collection;
              });
 }
 


### PR DESCRIPTION
I was using `VectorsCollectionClient.read_data(False)` in Python, and when the `VectorsCollectionClient` was unable to retrieve data, it caused a segmentation fault. With this modification, the method returns `None` instead, preventing the segmentation fault.