### PR TITLE
Add vector size check for joint values in setReferences in YarpRobotControl.cpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project are documented in this file.
 - InstallBasicPackageFiles: Fix bug of OVERRIDE_MODULE_PATH that corrupt `CMAKE_MODULE_PATH` values set by blf transitive dependencies (https://github.com/ami-iit/bipedal-locomotion-framework/pull/827)
 - InstallBasicPackageFiles: Fix compatibility with CMake 3.29.1 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/835)
 - Fix `YARPRobotLoggerDevice` excessively long time horizon for signals logged with `YARP_CLOCK` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/839)
+- Fix crash in `robot_control.set_references()` if the passed vector is not the correct size (https://github.com/ami-iit/bipedal-locomotion-framework/pull/852)
 
 ### Removed
 

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -476,8 +476,28 @@ struct YarpRobotControl::Impl
             || !this->desiredJointValuesAndMode.index[IRobotControl::ControlMode::PositionDirect]
                     .empty())
         {
+
+            if (jointValues.size() != this->actuatedDOFs)
+            {
+                log()->error("{} The size of the joint values is different from the number of "
+                             "actuated DoFs. Expected size: {}. Received size: {}.",
+                             errorPrefix,
+                             this->actuatedDOFs,
+                             jointValues.size());
+                return false;
+            }
+
             if (currentJointValues.has_value())
             {
+                if (currentJointValues->size() != this->actuatedDOFs)
+                {
+                    log()->error("{} The size of the current joint values is different from the "
+                                 "number of actuated DoFs. Expected size: {}. Received size: {}.",
+                                 errorPrefix,
+                                 this->actuatedDOFs,
+                                 currentJointValues->size());
+                    return false;
+                }
                 this->positionFeedback = currentJointValues.value();
             } else
             {


### PR DESCRIPTION
Fixes #851.

Now gives a clear error message if the vector size is incorrect:

```
[ERROR] [2024-06-13 15:35:43.808] [thread: 236092] [blf] [YarpRobotControl::Impl::setReferences] The size of the joint values is different from the number of actuated DoFs. Expected size: 7. Received size: 3.
```