### PR TITLE
Create python bindings of `VectorsCollection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 - Add the possibility to set the number of threads used by onnxruntime in `MANN` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/836)
 - Implement `ButterworthLowPassFilter` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/838)
 - Implement `Conversions::toiDynTreeRot` function (https://github.com/ami-iit/bipedal-locomotion-framework/pull/842)
+- Create python bindings of `VectorsCollection` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/854)
 
 ### Changed
 - 🤖 [ergoCubSN001] Add logging of the wrist and fix the name of the waist imu (https://github.com/ami-iit/bipedal-locomotion-framework/pull/810)

--- a/bindings/python/YarpUtilities/include/BipedalLocomotion/bindings/YarpUtilities/VectorsCollection.h
+++ b/bindings/python/YarpUtilities/include/BipedalLocomotion/bindings/YarpUtilities/VectorsCollection.h
@@ -20,6 +20,7 @@ namespace YarpUtilities
 void CreateVectorsCollectionServer(pybind11::module& module);
 void CreateVectorsCollectionClient(pybind11::module& module);
 void CreateVectorsCollectionMetadata(pybind11::module& module);
+void CreateVectorsCollection(pybind11::module& module);
 
 } // namespace YarpUtilities
 } // namespace bindings

--- a/bindings/python/YarpUtilities/src/Module.cpp
+++ b/bindings/python/YarpUtilities/src/Module.cpp
@@ -22,7 +22,8 @@ void CreateModule(pybind11::module& module)
     CreateVectorsCollectionServer(module);
     CreateVectorsCollectionClient(module);
     CreateVectorsCollectionMetadata(module);
+    CreateVectorsCollection(module);
 }
-} // namespace IK
+} // namespace YarpUtilities
 } // namespace bindings
 } // namespace BipedalLocomotion

--- a/bindings/python/YarpUtilities/src/VectorsCollection.cpp
+++ b/bindings/python/YarpUtilities/src/VectorsCollection.cpp
@@ -5,7 +5,6 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
-#include <optional>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -76,13 +75,14 @@ void CreateVectorsCollectionClient(pybind11::module& module)
                  return metadata;
              })
         .def("read_data",
-             [](VectorsCollectionClient& impl, bool shouldWait)
-                 -> std::optional<BipedalLocomotion::YarpUtilities::VectorsCollection> {
+             [](VectorsCollectionClient& impl,
+                bool shouldWait) -> BipedalLocomotion::YarpUtilities::VectorsCollection {
                  VectorsCollection* collectionPtr = impl.readData(shouldWait);
                  if (collectionPtr == nullptr)
                  {
-                     // Return an empty optional if the collection is not available
-                     return std::nullopt;
+                     // Return an empty collection
+                     VectorsCollection collection;
+                     return collection;
                  }
                  VectorsCollection collection = *collectionPtr;
                  return collection;


### PR DESCRIPTION
My previous PR #850 was not working as expected because I forgot to create the bindings for `VectorsCollection`. In particular, when you call `read_data` you get the following error:
```python
TypeError: Unable to convert function return value to a Python type! The signature was
        (self: bipedal_locomotion_framework.bindings.yarp_utilities.VectorsCollectionClient, arg0: bool) -> BipedalLocomotion::YarpUtilities::VectorsCollection
```
This PR creates Python bindings for `VectorsCollection` and modifies the behavior of `read_data` to provide an empty collection as output when it is unable to retrieve data.