### PR TITLE
Switch from mamba to conda

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         channels: conda-forge,robostack-staging
         channel-priority: true
@@ -36,7 +36,7 @@ jobs:
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
         # Dependencies
-        mamba install cmake compilers make ninja pkg-config \
+        conda install cmake compilers make ninja pkg-config \
                       "idyntree>=8.0.0" "yarp>=3.5.0" libmatio libmatio-cpp librobometry \
                       liblie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog \
                       nlohmann_json manif manifpy pybind11 numpy pytest scipy opencv pcl \
@@ -47,7 +47,7 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
-        mamba install manifpy expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 \
+        conda install manifpy expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 \
                       libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 \
                       libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64 \
                       mesa-libgl-devel-cos6-x86_64
@@ -56,7 +56,7 @@ jobs:
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
-        mamba install vs2019_win-64
+        conda install vs2019_win-64
 
     - name: Windows-workarounds [Windows]
       if: contains(matrix.os, 'windows')
@@ -66,13 +66,13 @@ jobs:
         :: pcl is removed as a workaround for https://github.com/ami-iit/bipedal-locomotion-framework/pull/695#issuecomment-1632208836
         :: pcl can be re-added once we have a ros humble build compatible with PCL 1.13.0
         :: pybind11 constrained as workaround for https://github.com/conda-forge/pybind11-feedstock/issues/95
-        mamba install "pybind11<2.12.0"
-        mamba remove icub-models pcl
+        conda install "pybind11<2.12.0"
+        conda remove icub-models pcl
 
     - name: Print used environment
       shell: bash -l {0}
       run: |
-        mamba list
+        conda list
         env
 
     - name: Configure [Linux&macOS]

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
           channels: conda-forge
           channel-priority: true
@@ -33,7 +33,7 @@ jobs:
           conda config --remove channels defaults
 
           # Dependencies
-          mamba install doxygen=1.9.1 toml pygments docutils jinja2
+          conda install doxygen=1.9.1 toml pygments docutils jinja2
 
       - name: Fetch m.css
         shell: bash -l {0}

--- a/examples/InverseKinematics/README.md
+++ b/examples/InverseKinematics/README.md
@@ -16,9 +16,9 @@ pip install robot_descriptions
 
 In case you do want to run this tutorial without compiling `bipedal-locomotion-framework` we suggest installing the dependencies with `conda` as follows
 ```console
-mamba create -n blf-ik-tutorial
-mamba activate blf-ik-tutorial
-mamba install -c conda-forge bipedal-locomotion-framework meshcat-python notebook robot_descriptions
+conda create -n blf-ik-tutorial
+conda activate blf-ik-tutorial
+conda install -c conda-forge bipedal-locomotion-framework meshcat-python notebook robot_descriptions
 ```
 
 Then you can run the notebook by typing the following command in a terminal

--- a/examples/MANN/README.md
+++ b/examples/MANN/README.md
@@ -13,9 +13,9 @@ If you installed `bipedal-locomotion-framework` with the [`robotology-superbuild
 
 In case you do want to run this tutorial without compiling `bipedal-locomotion-framework` we suggest installing the dependencies with `conda` as follows
 ```console
-mamba create -n blf-mann-tutorial
-mamba activate blf-mann-tutorial
-mamba install -c conda-forge -c robotology bipedal-locomotion-framework meshcat-python notebook resolve_robotics_uri_py ergocub-software
+conda create -n blf-mann-tutorial
+conda activate blf-mann-tutorial
+conda install -c conda-forge -c robotology bipedal-locomotion-framework meshcat-python notebook resolve_robotics_uri_py ergocub-software
 ```
 
 Then you can run the notebooks by typing the following command in a terminal:


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/pull/1653 for the rationale. In general nowadays `conda` should be more and less as fast as `mamba`, and is more actively maintained.