### PR TITLE
add setControlModeAsync member function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project are documented in this file.
 - Implement `Conversions::toiDynTreeRot` function (https://github.com/ami-iit/bipedal-locomotion-framework/pull/842)
 - Create python bindings of `VectorsCollection` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/854)
 - Added a simple motor control example (https://github.com/ami-iit/bipedal-locomotion-framework/pull/855)
+- Add `setControlModeAsync` function to set motor control mode in an asynchronous process (https://github.com/ami-iit/bipedal-locomotion-framework/pull/860)
 
 ### Changed
 - 🤖 [ergoCubSN001] Add logging of the wrist and fix the name of the waist imu (https://github.com/ami-iit/bipedal-locomotion-framework/pull/810)

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
@@ -9,6 +9,7 @@
 #define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_ROBOT_CONTROL_H
 
 // std
+#include <future>
 #include <memory>
 #include <optional>
 
@@ -36,12 +37,12 @@ class YarpRobotControl : public IRobotControl
     std::unique_ptr<Impl> m_pimpl;
 
 public:
-
     /**
      * Constructor
      */
     YarpRobotControl();
 
+    // clang-format off
     /**
      * Initialize the Interface
      * @param handler pointer to a parameter handler interface
@@ -54,6 +55,7 @@ public:
      * |         `positioning_tolerance`        | `double` |                    Max Admissible error for position control joint [rad]                     |    Yes    |
      * | `position_direct_max_admissible_error` | `double` |                 Max admissible error for position direct control joint [rad]                 |    Yes    |
      * @return True/False in case of success/failure.
+     // clang-format on
      */
     bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler) final;
 
@@ -94,6 +96,15 @@ public:
     bool setControlMode(const IRobotControl::ControlMode& mode) final;
 
     /**
+     * Set the desired control mode in an asynchronous thread.
+     * @param controlMode a control mode for all the joints.
+     * @return An std::future object to a boolean True/False in case of success/failure.
+     * @warning Call this function if you want to control all the joint with the same control mode.
+     * Since this function spawns a new thread, the invoking thread is not blocked.
+     */
+    std::future<bool> setControlModeAsync(const IRobotControl::ControlMode& mode) final;
+
+    /**
      * Set the desired reference.
      * @param desiredJointValues desired joint values.
      * @param controlModes vector containing the control mode for each joint.
@@ -104,9 +115,10 @@ public:
      * between -100 and 100.
      * @warning At the current stage only revolute joints are supported.
      */
-    bool setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
-                       const std::vector<IRobotControl::ControlMode>& controlModes,
-                       std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {}) final;
+    bool
+    setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                  const std::vector<IRobotControl::ControlMode>& controlModes,
+                  std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {}) final;
 
     /**
      * Set the desired reference.
@@ -121,9 +133,10 @@ public:
      * Otherwise call setReferences(Eigen::Ref<const Eigen::VectorXd>, const
      * std::vector<IRobotControl::ControlMode>&).
      */
-    bool setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
-                       const IRobotControl::ControlMode& mode,
-                       std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {}) final;
+    bool
+    setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                  const IRobotControl::ControlMode& mode,
+                  std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {}) final;
 
     /**
      * Get the list of the controlled joints
@@ -143,8 +156,7 @@ public:
      */
     ~YarpRobotControl();
 };
-} // namespace ParametersHandler
+} // namespace RobotInterface
 } // namespace BipedalLocomotion
-
 
 #endif // BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_ROBOT_CONTROL_H

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
@@ -101,6 +101,7 @@ public:
      * @return An std::future object to a boolean True/False in case of success/failure.
      * @warning Call this function if you want to control all the joint with the same control mode.
      * Since this function spawns a new thread, the invoking thread is not blocked.
+     * Warning: the function is not thread safe. Pay attention when calling it in combination with setReferences.
      */
     std::future<bool> setControlModeAsync(const IRobotControl::ControlMode& mode) final;
 

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
@@ -96,12 +96,25 @@ public:
     bool setControlMode(const IRobotControl::ControlMode& mode) final;
 
     /**
+     * Set the control mode in an asynchronous thread.
+     * @param controlModes vector containing the control mode for each joint.
+     * @return An std::future object to a boolean True/False in case of success/failure.
+     * @warning At the current stage only revolute joints are supported.
+     * Since this function spawns a new thread, the invoking thread is not blocked.
+     * Note that this function is not thread safe. You should check the future object status before
+     * calling other functions like setReferences().
+     */
+    std::future<bool>
+    setControlModeAsync(const std::vector<IRobotControl::ControlMode>& controlModes) final;
+
+    /**
      * Set the desired control mode in an asynchronous thread.
      * @param controlMode a control mode for all the joints.
      * @return An std::future object to a boolean True/False in case of success/failure.
      * @warning Call this function if you want to control all the joint with the same control mode.
      * Since this function spawns a new thread, the invoking thread is not blocked.
-     * Warning: the function is not thread safe. Pay attention when calling it in combination with setReferences.
+     * Note that this function is not thread safe. You should check the future object status before
+     * calling other functions like setReferences().
      */
     std::future<bool> setControlModeAsync(const IRobotControl::ControlMode& mode) final;
 

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -709,9 +709,18 @@ bool YarpRobotControl::setControlMode(const IRobotControl::ControlMode& mode)
     return this->setControlMode(controlModes);
 }
 
+std::future<bool>
+YarpRobotControl::setControlModeAsync(const std::vector<IRobotControl::ControlMode>& controlModes)
+{
+    // lambda function to set the control mode
+    auto setControlMode
+        = [this, controlModes]() -> bool { return this->setControlMode(controlModes); };
+
+    return std::async(std::launch::async, setControlMode);
+}
+
 std::future<bool> YarpRobotControl::setControlModeAsync(const IRobotControl::ControlMode& mode)
 {
-
     // lambda function to set the control mode
     auto setControlMode = [this, mode]() -> bool { return this->setControlMode(mode); };
 

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cmath>
+#include <future>
 #include <thread>
 #include <unordered_map>
 
@@ -706,6 +707,19 @@ bool YarpRobotControl::setControlMode(const IRobotControl::ControlMode& mode)
     // create a vector containing the same control mode for all the joints
     const std::vector<IRobotControl::ControlMode> controlModes(m_pimpl->actuatedDOFs, mode);
     return this->setControlMode(controlModes);
+}
+
+std::future<bool> YarpRobotControl::setControlModeAsync(const IRobotControl::ControlMode& mode)
+{
+
+    // lambda function to set the control mode
+    auto setControlMode = [this, mode]() -> bool {
+        // create a vector containing the same control mode for all the joints
+        const std::vector<IRobotControl::ControlMode> controlModes(m_pimpl->actuatedDOFs, mode);
+        return this->setControlMode(controlModes);
+    };
+
+    return std::async(std::launch::async, setControlMode);
 }
 
 bool YarpRobotControl::setReferences(

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -713,11 +713,7 @@ std::future<bool> YarpRobotControl::setControlModeAsync(const IRobotControl::Con
 {
 
     // lambda function to set the control mode
-    auto setControlMode = [this, mode]() -> bool {
-        // create a vector containing the same control mode for all the joints
-        const std::vector<IRobotControl::ControlMode> controlModes(m_pimpl->actuatedDOFs, mode);
-        return this->setControlMode(controlModes);
-    };
+    auto setControlMode = [this, mode]() -> bool { return this->setControlMode(mode); };
 
     return std::async(std::launch::async, setControlMode);
 }

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
@@ -8,6 +8,7 @@
 #ifndef BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_IROBOT_CONTROL_H
 #define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_IROBOT_CONTROL_H
 
+#include <future>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -79,9 +80,10 @@ public:
      * control in rad/s. If the robot is controlled in torques, the desired joint values are
      * expressed in Nm.
      */
-    virtual bool setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
-                               const std::vector<IRobotControl::ControlMode>& controlModes,
-                               std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {})
+    virtual bool
+    setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                  const std::vector<IRobotControl::ControlMode>& controlModes,
+                  std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {})
         = 0;
 
     /**
@@ -97,9 +99,10 @@ public:
      * Otherwise call setReferences(Eigen::Ref<const Eigen::VectorXd>, const
      * std::vector<IRobotControl::ControlMode>&).
      */
-    virtual bool setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
-                               const IRobotControl::ControlMode& controlMode,
-                               std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {})
+    virtual bool
+    setReferences(Eigen::Ref<const Eigen::VectorXd> desiredJointValues,
+                  const IRobotControl::ControlMode& controlMode,
+                  std::optional<Eigen::Ref<const Eigen::VectorXd>> currentJointValues = {})
         = 0;
 
     /**
@@ -117,6 +120,15 @@ public:
      * @warning Call this function if you want to control all the joint with the same control mode.
      */
     virtual bool setControlMode(const IRobotControl::ControlMode& mode) = 0;
+
+    /**
+     * Set the desired control mode in an asynchronous thread.
+     * @param controlMode a control mode for all the joints.
+     * @return True/False in case of success/failure.
+     * @warning Call this function if you want to control all the joint with the same control mode.
+     * Since this function spawns a new thread, the invoking thread is not blocked.
+     */
+    virtual std::future<bool> setControlModeAsync(const IRobotControl::ControlMode& mode) = 0;
 
     /**
      * Get the list of the controlled joints

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
@@ -122,9 +122,19 @@ public:
     virtual bool setControlMode(const IRobotControl::ControlMode& mode) = 0;
 
     /**
+     * Set the control mode in an asynchronous thread.
+     * @param controlModes vector containing the control mode for each joint.
+     * @return An std::future object to a boolean True/False in case of success/failure.
+     * @warning At the current stage only revolute joints are supported.
+     * Since this function spawns a new thread, the invoking thread is not blocked.
+     */
+    virtual std::future<bool>
+    setControlModeAsync(const std::vector<IRobotControl::ControlMode>& controlModes) = 0;
+
+    /**
      * Set the desired control mode in an asynchronous thread.
      * @param controlMode a control mode for all the joints.
-     * @return True/False in case of success/failure.
+     * @return An std::future object to a boolean True/False in case of success/failure.
      * @warning Call this function if you want to control all the joint with the same control mode.
      * Since this function spawns a new thread, the invoking thread is not blocked.
      */


### PR DESCRIPTION
The goal of this PR is to add a member function to set the motor control mode in an asynchronous process, so that the invoking thread does not get blocked.

This feature might be handy when the switch of control mode is done within `Advanceable Runners` which have real time constraints and deadline misses checks. 