### PR TITLE
conda-forge-ci: Do not install unneded cdt packages

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -47,10 +47,7 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
-        conda install manifpy expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 \
-                      libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 \
-                      libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64 \
-                      mesa-libgl-devel-cos6-x86_64
+        conda install manifpy mesa-libgl-devel-cos7-x86_64
 
     - name: Windows-only Dependencies [Windows]
       if: contains(matrix.os, 'windows')


### PR DESCRIPTION
A lot of cdt packages (https://conda-forge.org/docs/maintainer/knowledge_base/#core-dependency-tree-packages-cdts) have been converted to regular packages over the years, so I guess the only one actually still needed is `mesa-libgl-devel-cos7-x86_64`, and hopefully at some point we can get rid of that as well: https://github.com/conda-forge/staged-recipes/pull/25919 .