### PR TITLE
Fix link to deprecated CMake target YARP::YARP_OS

### DIFF
--- a/cmake/AddBipedalLocomotionYARPThrift.cmake
+++ b/cmake/AddBipedalLocomotionYARPThrift.cmake
@@ -33,7 +33,7 @@ function(add_bipedal_locomotion_yarp_thrift)
 
   add_library(${name} ${AUTOGENERATE_SRC} ${AUTOGENERATE_HDR})
 
-  target_link_libraries(${name} PUBLIC YARP::YARP_OS)
+  target_link_libraries(${name} PUBLIC YARP::YARP_os)
 
   add_library(BipedalLocomotion::${name} ALIAS ${name})
 


### PR DESCRIPTION
Avoid annoying warning:

~~~
D:/miniforge3/envs/blfdev/Library/include\yarp/os/api.h(53): warning : "The YARP::YARP_OS target is deprecated. Use YARP::YARP_os instead" [D:\src\bipedal-locomotion-framework\build\devices\RobotDynamicsEstim
atorDevice\RobotDynamicsEstimatorDevice.vcxproj]
  yarp_plugin_RobotDynamicsEstimatorDevice.cpp
D:/miniforge3/envs/blfdev/Library/include\yarp/os/api.h(53): warning : "The YARP::YARP_OS target is deprecated. Use YARP::YARP_os instead" [D:\src\bipedal-locomotion-framework\build\devices\RobotDynamicsEstim
atorDevice\RobotDynamicsEstimatorDevice.vcxproj]
~~~