### PR TITLE
Update yarp-robot-logger.xml for ergocubSN002

### DIFF
--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
@@ -66,7 +66,7 @@ BSD-3-Clause license. -->
   </group>
 
   <group name="RobotCameraBridge">
-      <param name="stream_cameras">false</param>
+      <param name="stream_cameras">true</param>
       <group name="Cameras">
         <param name="rgb_cameras_list">("jabra")</param>
         <param name="rgbd_cameras_list">()</param>


### PR DESCRIPTION
By default it would be convenient that the `jabra` camera is streamed, which means setting `stream_cameras` parameter to `true` by default for `ergocubSN002` (as it is done for `ergocubSN001`).