### PR TITLE
Bump manif in CI to 0.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   YARP_TAG: v3.8.0
   iDynTree_TAG: 42f2874b729348575aeee723c1775c3425735ef9
   CasADi_TAG: 3.5.5.2
-  manif_TAG: 0.0.4.102
+  manif_TAG: 0.0.5
   matioCpp_TAG: v0.2.0
   LieGroupControllers_TAG: v0.2.0
   osqp_TAG: v0.6.2
@@ -225,7 +225,7 @@ jobs:
 
         # manif
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/robotology-dependencies/manif.git
+        git clone https://github.com/artivis/manif.git
         cd manif
         git checkout ${manif_TAG}
         mkdir build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
 
         # manif
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/robotology-dependencies/manif.git
+        git clone https://github.com/artivis/manif.git
         cd manif
         git checkout ${manif_TAG}
         mkdir build


### PR DESCRIPTION
manif 0.0.5 was tagged today: https://github.com/artivis/manif/releases/tag/0.0.5 .

If the blf test pass fine with the new manif, we can release it in conda-forge and the superbuild.