### PR TITLE
Use conda-forge's catch2 in CI to avoid build failures, set OMP_NUM_THREADS=1 and updated catch2's used by FetchContent to 3.7.1

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -10,6 +10,11 @@ on:
   # Execute a "nightly" build at 2 AM UTC
   - cron:  '0 2 * * *'
 
+# Workaround for https://github.com/conda-forge/mumps-feedstock/issues/125
+# and https://github.com/conda-forge/mumps-feedstock/pull/126#issuecomment-2355357834
+env:
+  OMP_NUM_THREADS: 1
+
 jobs:
   build:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}@conda]'

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -10,6 +10,10 @@ on:
   # Execute a "nightly" build at 2 AM UTC
   - cron:  '0 2 * * *'
 
+# Workaround for https://github.com/conda-forge/mumps-feedstock/issues/125
+env:
+  OMP_NUM_THREADS: 1
+
 jobs:
   build:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}@conda]'

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -10,10 +10,6 @@ on:
   # Execute a "nightly" build at 2 AM UTC
   - cron:  '0 2 * * *'
 
-# Workaround for https://github.com/conda-forge/mumps-feedstock/issues/125
-env:
-  OMP_NUM_THREADS: 1
-
 jobs:
   build:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}@conda]'

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -45,7 +45,7 @@ jobs:
                       liblie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog \
                       nlohmann_json manif manifpy pybind11 numpy pytest scipy opencv pcl \
                       tomlplusplus libunicycle-footstep-planner "icub-models>=1.23.4" \
-                      ros-humble-rclcpp onnxruntime-cpp libbayes-filters-lib cmake-package-check
+                      ros-humble-rclcpp onnxruntime-cpp libbayes-filters-lib cmake-package-check catch2
 
     - name: Linux-only Dependencies [Linux]
       if: contains(matrix.os, 'ubuntu')
@@ -83,7 +83,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_IK:BOOL=OFF -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-              -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+              -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DUSE_SYSTEM_Catch2:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
     - name: Build [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
@@ -105,7 +105,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DUSE_SYSTEM_Catch2:BOOL=ON -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
     - name: Build [Windows]
       if: contains(matrix.os, 'windows')

--- a/cmake/AddBipedalLocomotionUnitTest.cmake
+++ b/cmake/AddBipedalLocomotionUnitTest.cmake
@@ -16,7 +16,7 @@ if (BUILD_TESTING)
     include(FetchContent)
     FetchContent_Declare(Catch2
       GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-      GIT_TAG        v3.0.1)
+      GIT_TAG        v3.7.1)
 
     FetchContent_GetProperties(Catch2)
     if(NOT Catch2_POPULATED)


### PR DESCRIPTION
Fix the build error:

~~~
[82/462] Building CXX object _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o
FAILED: _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o 
/usr/share/miniconda3/envs/test/bin/x86_64-conda-linux-gnu-c++ -Dcasadi_VERSION=3.6.6 -I/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/.. -I/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/generated-includes -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /usr/share/miniconda3/envs/test/include -O3 -DNDEBUG -std=c++17 -fPIC -ffile-prefix-map=/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src=. -MD -MT _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o -MF _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o.d -o _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o -c /home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/internal/catch_clara.cpp
In file included from /home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/internal/catch_clara.cpp:12:
/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:47:14: error: 'uint64_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
   47 |         std::uint64_t m_count;
      |              ^~~~~~~~
      |              wint_t
/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:51:42: error: expected ')' before 'count'
   51 |         constexpr pluralise(std::uint64_t count, StringRef label):
      |                            ~             ^~~~~~
      |                                          )
[83/462] Building CXX object _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_source_line_info.cpp.o
[84/462] Building CXX object _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o
FAILED: _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o 
/usr/share/miniconda3/envs/test/bin/x86_64-conda-linux-gnu-c++ -Dcasadi_VERSION=3.6.6 -I/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/.. -I/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/generated-includes -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /usr/share/miniconda3/envs/test/include -O3 -DNDEBUG -std=c++17 -fPIC -ffile-prefix-map=/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src=. -MD -MT _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o -MF _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o.d -o _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o -c /home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/internal/catch_case_insensitive_comparisons.cpp
In file included from /home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/internal/catch_case_insensitive_comparisons.cpp:10:
/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:47:14: error: 'uint64_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
   47 |         std::uint64_t m_count;
      |              ^~~~~~~~
      |              wint_t
/home/runner/work/bipedal-locomotion-framework/bipedal-locomotion-framework/build/_deps/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:51:42: error: expected ')' before 'count'
   51 |         constexpr pluralise(std::uint64_t count, StringRef label):
      |                            ~             ^~~~~~
      |                                          )
[85/462] Building CXX object _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/catch_config.cpp.o
[86/462] Building CXX object src/RobotInterface/YarpImplementation/CMakeFiles/RobotInterfaceYarpImplementation.dir/src/YarpSensorBridge.cpp.o
[87/462] Building CXX object _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_commandline.cpp.o
ninja: build stopped: subcommand failed.
~~~

