### PR TITLE
Fix bug related to prepare_data() method calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 - Bug fix of `JointTorqueControlDevice` device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/890)
+- Bug fix of `prepare_data` method calling in `joints-grid-position-tracking` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/895)
 
 ## [0.19.0] - 2024-09-06
 ### Added

--- a/utilities/joints-grid-position-tracking/blf-joints-grid-position-tracking.py
+++ b/utilities/joints-grid-position-tracking/blf-joints-grid-position-tracking.py
@@ -203,8 +203,7 @@ def main():
         ):
             raise RuntimeError("Unable to set the references")
 
-        if not vectors_collection_server.prepare_data():
-            raise RuntimeError("Unable to prepare the data")
+        vectors_collection_server.prepare_data()
 
         vectors_collection_server.clear_data()
 


### PR DESCRIPTION
This PR fixes the bug found in https://github.com/ami-iit/element_pi-ft-modeling/issues/96#issuecomment-2383535504. Basically, the output type of the method `prepare_data()` should be `void`, while in https://github.com/ami-iit/bipedal-locomotion-framework/commit/d63fa9fbf67e10527a05431faa4951b4d8294580#diff-41b66f0e3904e0ce5ecc91e8dff26a004e80b7b6f1c27b81874d5b6554ce3154 the output is considered as `bool`. With this PR, the method is called in the proper way.

cc @GiulioRomualdi 