### PR TITLE
Add software position limits to motor current tracking application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Implement low-pass filter for estimated friction torques in `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/892)
 - Add `blf-motor-current-tracking.py` application (https://github.com/ami-iit/bipedal-locomotion-framework/pull/894)
 - Add the possibility to initialize the base position and the feet pose in the `unicycleTrajectoryGenerator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/887)
+- Add software joint position limits  to the `blf-motor-current-tracking.py` application (https://github.com/ami-iit/bipedal-locomotion-framework/pull/901)
 
 ### Changed
 

--- a/utilities/motor-current-tracking/README.md
+++ b/utilities/motor-current-tracking/README.md
@@ -43,9 +43,11 @@ In this file, the following parameters are defined:
 3. the `use_safety_threshold_for_starting_position` boolean, which determines wheter to use (or not) the `safety_threshold` when computing the starting positions.
 4. the number of starting positions `number_of_starting_points` from which the same reference trajectory is repeated.
 5. the `bypass_motor_current_measure` boolean vector (one element per motor), which determines wether to use the measured motor current when generating the trajectory as detailed later.
-6. the `SINUSOID` parameters group, which defines the sinusoid trajectory as detailed later.
-7. the `RAMP` parameters group, which defines the ramp trajectory as detailed later.
-8. the `MOTOR` parameters group, which defines the list of available joints `joints_list`, the respective `k_tau` coefficient (in [A/Nm]) and the respective `max_safety_current` (in [A]).
+6. the `software_joint_lower_limits` optional float vector, which overrides (only if reducing the range of motion) the hardware `joint_lower_limits`.
+7. the `software_joint_upper_limits` optional float vector, which overrides (only if reducing the range of motion) the hardware `joint_upper_limits`.
+8. the `SINUSOID` parameters group, which defines the sinusoid trajectory as detailed later.
+9. the `RAMP` parameters group, which defines the ramp trajectory as detailed later.
+10. the `MOTOR` parameters group, which defines the list of available joints `joints_list`, the respective `k_tau` coefficient (in [A/Nm]) and the respective `max_safety_current` (in [A]).
 
 Instead, the configuration file [`robot_control.ini`](./config/robots/ergoCubSN001/blf_motor_current_tracking/robot_control.ini) defines the list of motors to command.
 

--- a/utilities/motor-current-tracking/blf-motor-current-tracking.py
+++ b/utilities/motor-current-tracking/blf-motor-current-tracking.py
@@ -491,6 +491,30 @@ def main():
     lower_limits = np.deg2rad(lower_limits)
     upper_limits = np.deg2rad(upper_limits)
 
+    # Check whether softwares joint limits are available
+    # If available, use them to reduce the range of motion
+    try:
+        software_lower_limits = param_handler.get_parameter_vector_float(
+            "software_joint_lower_limits"
+        )
+        software_upper_limits = param_handler.get_parameter_vector_float(
+            "software_joint_upper_limits"
+        )
+    except ValueError:
+        software_lower_limits = None
+        software_upper_limits = None
+    
+    if software_lower_limits is not None and software_upper_limits is not None:
+        if len(software_lower_limits) != len(joints_to_control) or len(software_upper_limits) != len(joints_to_control):
+            raise ValueError(
+                "{} The number of joints must be equal to the size of the software joint limits".format(
+                    logPrefix
+                )
+            )
+        lower_limits = np.maximum(lower_limits, np.deg2rad(software_lower_limits))
+        upper_limits = np.minimum(upper_limits, np.deg2rad(software_upper_limits))
+
+
     # Modify joint limits to reduce range of motion
     for idx, joint in enumerate(joints_to_control):
         if joint == "l_hip_roll" or joint == "r_hip_roll":

--- a/utilities/motor-current-tracking/blf-motor-current-tracking.py
+++ b/utilities/motor-current-tracking/blf-motor-current-tracking.py
@@ -503,7 +503,7 @@ def main():
     except ValueError:
         software_lower_limits = None
         software_upper_limits = None
-    
+
     if software_lower_limits is not None and software_upper_limits is not None:
         if len(software_lower_limits) != len(joints_to_control) or len(software_upper_limits) != len(joints_to_control):
             raise ValueError(

--- a/utilities/motor-current-tracking/blf-motor-current-tracking.py
+++ b/utilities/motor-current-tracking/blf-motor-current-tracking.py
@@ -514,12 +514,6 @@ def main():
         lower_limits = np.maximum(lower_limits, np.deg2rad(software_lower_limits))
         upper_limits = np.minimum(upper_limits, np.deg2rad(software_upper_limits))
 
-
-    # Modify joint limits to reduce range of motion
-    for idx, joint in enumerate(joints_to_control):
-        if joint == "l_hip_roll" or joint == "r_hip_roll":
-            upper_limits[idx] = np.deg2rad(80)
-
     # Create the sensor bridge
     sensor_bridge = blf.robot_interface.YarpSensorBridge()
     sensor_bridge_handler = param_handler.get_group("SENSOR_BRIDGE")


### PR DESCRIPTION
This PR adds software position limits, which can be specified in the config file, to the `blf-motor-current-tracking.py` application.

The software position limits can only restrict the range of motion of the joint with respect to the hardware limits.