### PR TITLE
Fix loading of Python bindings on Windows when installed in arbitrary directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 - Bug fix of `JointTorqueControlDevice` device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/890)
 - Bug fix of `prepare_data` method calling in `joints-grid-position-tracking` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/895)
 - Fix the normal force limit constraint in the `CentroidalMPC` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/898)
+- Fix loading of Python bindings on Windows when installed in arbitrary directory (https://github.com/ami-iit/bipedal-locomotion-framework/pull/905)
 
 ## [0.19.0] - 2024-09-06
 ### Added

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -69,7 +69,7 @@ if(FRAMEWORK_COMPILE_PYTHON_BINDINGS)
         file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "    if(os.path.exists(library_dll_path)):${NEW_LINE}")
         file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "        os.add_dll_directory(library_dll_path)${NEW_LINE}")
     endif()
-    
+
     file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "from .bindings import *${NEW_LINE}from . import utils${NEW_LINE}")
 
     # Install the __init__.py file

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -50,9 +50,27 @@ if(FRAMEWORK_COMPILE_PYTHON_BINDINGS)
     add_subdirectory(python)
 
     # Create the __init__.py file
-    file(GENERATE
-         OUTPUT "${BLF_PYTHON_PACKAGE}/__init__.py"
-         CONTENT "from .bindings import *${NEW_LINE}from . import utils${NEW_LINE}")
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/__init__.py "")
+
+    # If we are on Windows and BUILD_SHARED_LIBS is ON, handle the fact that
+    # the Python interpreter does not look into PATH to find dll (see https://docs.python.org/3.8/library/os.html#os.add_dll_directory)
+    if(WIN32 AND BUILD_SHARED_LIBS)
+        if(IS_ABSOLUTE PYTHON_INSTDIR)
+            set(PYTHON_FULL_INSTDIR "${PYTHON_INSTDIR}")
+        else()
+            set(PYTHON_FULL_INSTDIR "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTDIR}")
+        endif()
+        file(RELATIVE_PATH RELATIVE_PATH_BETWEEN_INIT_PY_AND_DLL_DIRECTORY ${PYTHON_FULL_INSTDIR} ${CMAKE_INSTALL_FULL_BINDIR})
+        file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "import os${NEW_LINE}")
+        file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "library_dll_path = os.path.join(os.path.dirname(__file__),'${RELATIVE_PATH_BETWEEN_INIT_PY_AND_DLL_DIRECTORY}')${NEW_LINE}")
+        file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "# Avoid to call add_dll_directory if not necessary,${NEW_LINE}")
+        file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "# for example if the library to find are already found in the proper location in a conda environment${NEW_LINE}")
+        file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "if(library_dll_path != os.path.join(os.environ.get('CONDA_PREFIX', ''),'Library','bin') and library_dll_path != os.path.join(os.environ.get('CONDA_PREFIX', ''),'bin')):${NEW_LINE}")
+        file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "    if(os.path.exists(library_dll_path)):${NEW_LINE}")
+        file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "        os.add_dll_directory(library_dll_path)${NEW_LINE}")
+    endif()
+    
+    file(APPEND "${BLF_PYTHON_PACKAGE}/__init__.py" "from .bindings import *${NEW_LINE}from . import utils${NEW_LINE}")
 
     # Install the __init__.py file
     install(FILES "${BLF_PYTHON_PACKAGE}/__init__.py"


### PR DESCRIPTION
Since Python 3.8, Python ignores the `PATH` env variable when trying to load the DLL of compiled Python extensions. 

We kind ignored the problem until now as if you install in `%CONDA_PREFIX%\Library\bin` in conda environment everything works out of the box, but the problem is present when bipedal-locomotion-framework is installed in an arbitrary install prefix and the Python bindings are found via `PYTHONPATH` env variable, see https://github.com/robotology/robotology-superbuild/issues/1268 .

This PR fixes the problem by adding some automatically generated code in the `__init__.py` file that automatically calls `os.add_dll_directory` as necessary.

As the Python code is generated by CMake it may be a bit cryptic, the actual rendered code is:

~~~py
import os
library_dll_path = os.path.join(os.path.dirname(__file__),'../../../bin')
# Avoid to call add_dll_directory if not necessary,
# for example if the library to find are already found in the proper location in a conda environment
if(library_dll_path != os.path.join(os.environ.get('CONDA_PREFIX', ''),'Library','bin') and library_dll_path != os.path.join(os.environ.get('CONDA_PREFIX', ''),'bin')):
    if(os.path.exists(library_dll_path)):
        os.add_dll_directory(library_dll_path)
~~~

Similar to:
* https://github.com/robotology/idyntree/pull/1209
* https://github.com/robotology/human-dynamics-estimation/pull/398