### PR TITLE
Add option FRAMEWORK_COMPILE_Ros1Publisher and deprecate  BipedalLocomotion::YarpUtilities::RosPublisher class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ All notable changes to this project are documented in this file.
 - Add software joint position limits  to the `blf-motor-current-tracking.py` application (https://github.com/ami-iit/bipedal-locomotion-framework/pull/901)
 - Implement `velMANN` class to perform inference on MANN model with velocity-based features in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/889)
 - Implement `velMANNAutoregressive`, `velMANNAutoregressiveInputBuilder`, and `velMANNTrajectoryGenerator` to generate trajectories using MANN model with velocity-based features in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/889)
+- Added option `FRAMEWORK_COMPILE_Ros1Publisher` to enable or disable the compilation of the `BipedalLocomotion::YarpUtilities::RosPublisher` class
 
 ### Changed
 - Change device jtcvc to use motor velocity and joint velocity in input to PINN models (https://github.com/ami-iit/bipedal-locomotion-framework/pull/903)
 - Set the system timer resolution to the minimum value for higher precision on `Windows` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/907)
 - Update the `mas-remapper` configuration file for `ergoCubSN000` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/913)
+- Deprecate the `BipedalLocomotion::YarpUtilities::RosPublisher` class
 
 ### Fixed
 - Bug fix of `JointTorqueControlDevice` device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/890)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ All notable changes to this project are documented in this file.
 - Add software joint position limits  to the `blf-motor-current-tracking.py` application (https://github.com/ami-iit/bipedal-locomotion-framework/pull/901)
 - Implement `velMANN` class to perform inference on MANN model with velocity-based features in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/889)
 - Implement `velMANNAutoregressive`, `velMANNAutoregressiveInputBuilder`, and `velMANNTrajectoryGenerator` to generate trajectories using MANN model with velocity-based features in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/889)
-- Added option `FRAMEWORK_COMPILE_Ros1Publisher` to enable or disable the compilation of the `BipedalLocomotion::YarpUtilities::RosPublisher` class
+- Added option `FRAMEWORK_COMPILE_Ros1Publisher` to enable or disable the compilation of the `BipedalLocomotion::YarpUtilities::RosPublisher` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/914)
 
 ### Changed
 - Change device jtcvc to use motor velocity and joint velocity in input to PINN models (https://github.com/ami-iit/bipedal-locomotion-framework/pull/903)
 - Set the system timer resolution to the minimum value for higher precision on `Windows` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/907)
 - Update the `mas-remapper` configuration file for `ergoCubSN000` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/913)
-- Deprecate the `BipedalLocomotion::YarpUtilities::RosPublisher` class
+- Deprecate the `BipedalLocomotion::YarpUtilities::RosPublisher` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/914)
 
 ### Fixed
 - Bug fix of `JointTorqueControlDevice` device (https://github.com/ami-iit/bipedal-locomotion-framework/pull/890)

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -141,6 +141,10 @@ framework_dependent_option(FRAMEWORK_COMPILE_YarpUtilities
   "Compile YarpHelper library?" ON
   "FRAMEWORK_USE_YARP" OFF)
 
+framework_dependent_option(FRAMEWORK_COMPILE_Ros1Publisher
+  "Compile YarpUtilities::RosPublisher class?" ON
+  "FRAMEWORK_USE_YARP" OFF)
+
 framework_dependent_option(FRAMEWORK_COMPILE_RosImplementation
   "Compile All the ROS implementations?" ON
   "FRAMEWORK_USE_rclcpp" OFF)

--- a/devices/examples/ROSPublisherTestDevice/CMakeLists.txt
+++ b/devices/examples/ROSPublisherTestDevice/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-if(FRAMEWORK_COMPILE_YarpImplementation AND FRAMEWORK_COMPILE_YarpUtilities)
+if(FRAMEWORK_COMPILE_YarpImplementation AND FRAMEWORK_COMPILE_YarpUtilities AND FRAMEWORK_COMPILE_Ros1Publisher)
 # Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
 add_bipedal_yarp_device(
   NAME ROSPublisherTestDevice

--- a/src/YarpUtilities/CMakeLists.txt
+++ b/src/YarpUtilities/CMakeLists.txt
@@ -5,10 +5,17 @@
 # set target name
 if(FRAMEWORK_COMPILE_YarpUtilities)
 
+  set(YarpUtilities_Ros1Publisher_PUBLIC_HEADERS "")
+  set(YarpUtilities_Ros1Publisher_SOURCES "")
+  if(FRAMEWORK_COMPILE_Ros1Publisher)
+    list(APPEND YarpUtilities_Ros1Publisher_PUBLIC_HEADERS "include/BipedalLocomotion/YarpUtilities/RosPublisher.h")
+    list(APPEND YarpUtilities_Ros1Publisher_SOURCES "src/RosPublisher.cpp")
+  endif()
+
   add_bipedal_locomotion_library(
     NAME                   YarpUtilities
-    SOURCES                src/Helper.cpp src/RosPublisher.cpp
-    PUBLIC_HEADERS         include/BipedalLocomotion/YarpUtilities/Helper.h include/BipedalLocomotion/YarpUtilities/Helper.tpp include/BipedalLocomotion/YarpUtilities/RosPublisher.h
+    SOURCES                src/Helper.cpp
+    PUBLIC_HEADERS         include/BipedalLocomotion/YarpUtilities/Helper.h include/BipedalLocomotion/YarpUtilities/Helper.tpp ${YarpUtilities_Ros1Publisher_PUBLIC_HEADERS}
     PUBLIC_LINK_LIBRARIES  ${YARP_LIBRARIES} ${iDynTree_LIBRARIES} BipedalLocomotion::GenericContainer BipedalLocomotion::ParametersHandler BipedalLocomotion::TextLogging
     SUBDIRECTORIES         tests)
 

--- a/src/YarpUtilities/CMakeLists.txt
+++ b/src/YarpUtilities/CMakeLists.txt
@@ -14,7 +14,7 @@ if(FRAMEWORK_COMPILE_YarpUtilities)
 
   add_bipedal_locomotion_library(
     NAME                   YarpUtilities
-    SOURCES                src/Helper.cpp
+    SOURCES                src/Helper.cpp ${YarpUtilities_Ros1Publisher_SOURCES}
     PUBLIC_HEADERS         include/BipedalLocomotion/YarpUtilities/Helper.h include/BipedalLocomotion/YarpUtilities/Helper.tpp ${YarpUtilities_Ros1Publisher_PUBLIC_HEADERS}
     PUBLIC_LINK_LIBRARIES  ${YARP_LIBRARIES} ${iDynTree_LIBRARIES} BipedalLocomotion::GenericContainer BipedalLocomotion::ParametersHandler BipedalLocomotion::TextLogging
     SUBDIRECTORIES         tests)

--- a/src/YarpUtilities/include/BipedalLocomotion/YarpUtilities/RosPublisher.h
+++ b/src/YarpUtilities/include/BipedalLocomotion/YarpUtilities/RosPublisher.h
@@ -30,7 +30,7 @@ namespace YarpUtilities
  *  - Transform broadcaster
  * Although the class might be ROS independent, in order to run the code, ROS is required and usual YARP-ROS connections need to be made.
  */
-class RosPublisher
+class [[deprecated("The ROS 1-based BipedalLocomotion::YarpUtilities::RosPublisher is deprecated, use ROS 2 instead.")]] RosPublisher
 {
 public:
     /**


### PR DESCRIPTION
Since YARP 3.10, the `rosmsg` functionality is provided in the separate repository https://github.com/robotology/yarp-ros . The robotology-superbuild integrates this repository, but this package is not available in conda-forge, so this PR adds an option `FRAMEWORK_COMPILE_Ros1Publisher` to disable the compilation of the `BipedalLocomotion::YarpUtilities::RosPublisher` class that depends on `rosmsg`, and also deprecates the class so that it can be removed in the future.