### PR TITLE
Add rpc commands to YarpLoggerDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Implement `velMANN` class to perform inference on MANN model with velocity-based features in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/889)
 - Implement `velMANNAutoregressive`, `velMANNAutoregressiveInputBuilder`, and `velMANNTrajectoryGenerator` to generate trajectories using MANN model with velocity-based features in `ML` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/889)
 - Added option `FRAMEWORK_COMPILE_Ros1Publisher` to enable or disable the compilation of the `BipedalLocomotion::YarpUtilities::RosPublisher` class (https://github.com/ami-iit/bipedal-locomotion-framework/pull/914)
+- Added rpc commands to `YarpLoggerDevice` to trigger the saving of data to a local file (https://github.com/ami-iit/bipedal-locomotion-framework/pull/915)
 
 ### Changed
 - Change device jtcvc to use motor velocity and joint velocity in input to PINN models (https://github.com/ami-iit/bipedal-locomotion-framework/pull/903)

--- a/devices/YarpRobotLoggerDevice/CMakeLists.txt
+++ b/devices/YarpRobotLoggerDevice/CMakeLists.txt
@@ -34,6 +34,11 @@ if(FRAMEWORK_COMPILE_YarpRobotLoggerDevice)
     endif()
   endif()
 
+  add_bipedal_locomotion_yarp_thrift(
+      NAME YarpRobotLoggerDeviceCommands
+      THRIFT thrifts/YarpRobotLoggerDeviceCommands.thrift
+      INSTALLATION_FOLDER YarpRobotLoggerDevice)
+
   # Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
   add_bipedal_yarp_device(
     NAME YarpRobotLoggerDevice
@@ -55,6 +60,7 @@ if(FRAMEWORK_COMPILE_YarpRobotLoggerDevice)
       BipedalLocomotion::PerceptionInterfaceYarpImplementation
       BipedalLocomotion::TextLoggingYarpImplementation
       BipedalLocomotion::SystemYarpImplementation
+      BipedalLocomotion::YarpRobotLoggerDeviceCommands
       tiny-process-library::tiny-process-library
     CONFIGURE_PACKAGE_NAME yarp_robot_logger_device)
 

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -180,7 +180,7 @@ private:
     std::mutex m_bufferManagerMutex;
     robometry::BufferManager m_bufferManager;
 
-    const std::string m_rpcPortName{"/YarpRobotLoggerDevice/commands/rpc:i"}; /**< name of Remote
+    const std::string m_rpcPortName{"/commands/rpc:i"}; /**< name of Remote
                                                                             Procedure Call port. */
     yarp::os::Port m_rpcPort; /**< Remote Procedure Call port. */
 

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -32,12 +32,15 @@
 #include <BipedalLocomotion/YarpUtilities/VectorsCollectionClient.h>
 #include <BipedalLocomotion/YarpUtilities/VectorsCollectionServer.h>
 
+#include <YarpRobotLoggerDeviceCommands.h>
+
 namespace BipedalLocomotion
 {
 
 class YarpRobotLoggerDevice : public yarp::dev::DeviceDriver,
                               public yarp::dev::IMultipleWrapper,
-                              public yarp::os::PeriodicThread
+                              public yarp::os::PeriodicThread,
+                              public YarpRobotLoggerDeviceCommands
 {
 public:
     YarpRobotLoggerDevice(double period,
@@ -177,6 +180,10 @@ private:
     std::mutex m_bufferManagerMutex;
     robometry::BufferManager m_bufferManager;
 
+    const std::string m_rpcPortName{"/YarpLoggerDevice/commands/rpc:i"}; /**< name of Remote
+                                                                            Procedure Call port. */
+    yarp::os::Port m_rpcPort; /**< Remote Procedure Call port. */
+
     void lookForNewLogs();
     void lookForExogenousSignals();
 
@@ -254,6 +261,10 @@ private:
     const std::string robotDescriptionList = "description_list";
 
     const std::string timestampsName = "timestamps";
+
+    virtual bool lastCallSave();
+
+    virtual bool periodicSave();
 };
 
 } // namespace BipedalLocomotion

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -180,7 +180,7 @@ private:
     std::mutex m_bufferManagerMutex;
     robometry::BufferManager m_bufferManager;
 
-    const std::string m_rpcPortName{"/YarpLoggerDevice/commands/rpc:i"}; /**< name of Remote
+    const std::string m_rpcPortName{"/YarpRobotLoggerDevice/commands/rpc:i"}; /**< name of Remote
                                                                             Procedure Call port. */
     yarp::os::Port m_rpcPort; /**< Remote Procedure Call port. */
 

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -262,9 +262,7 @@ private:
 
     const std::string timestampsName = "timestamps";
 
-    virtual bool lastCallSave();
-
-    virtual bool periodicSave();
+    virtual bool saveData();
 };
 
 } // namespace BipedalLocomotion

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -2006,14 +2006,7 @@ bool YarpRobotLoggerDevice::close()
     return true;
 }
 
-bool YarpRobotLoggerDevice::lastCallSave()
-{
-    std::string fileName;
-    m_bufferManager.saveToFile(fileName);
-    return this->saveCallback(fileName, robometry::SaveCallbackSaveMethod::last_call);
-}
-
-bool YarpRobotLoggerDevice::periodicSave()
+bool YarpRobotLoggerDevice::saveData()
 {
     std::string fileName;
     m_bufferManager.saveToFile(fileName);

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -395,7 +395,7 @@ bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
     }
 
     // open rpc port for YarpRobotLoggerDevice commands
-    std::string portPrefix{};
+    std::string portPrefix{"/yarp-robot-logger"};
 
     if (!params->getParameter("port_prefix", portPrefix))
     {

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -394,8 +394,19 @@ bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
         return false;
     }
 
+    // open rpc port for YarpRobotLoggerDevice commands
+    std::string portPrefix{};
+
+    if (!params->getParameter("port_prefix", portPrefix))
+    {
+
+        log()->info("{} The 'port_prefix' is not provided. It willnot be used.", logPrefix);
+    }
+
+    std::string rpcPortFullName = portPrefix + m_rpcPortName;
+
     this->yarp().attachAsServer(this->m_rpcPort);
-    if (!m_rpcPort.open(m_rpcPortName))
+    if (!m_rpcPort.open(rpcPortFullName))
     {
         log()->error("{} Could not open", logPrefix);
         return false;

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -400,7 +400,9 @@ bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
     if (!params->getParameter("port_prefix", portPrefix))
     {
 
-        log()->info("{} The 'port_prefix' is not provided. It willnot be used.", logPrefix);
+        log()->info("{} The 'port_prefix' is not provided. The default prefix {} will be used.",
+                    logPrefix,
+                    portPrefix);
     }
 
     std::string rpcPortFullName = portPrefix + m_rpcPortName;

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -394,6 +394,13 @@ bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
         return false;
     }
 
+    this->yarp().attachAsServer(this->m_rpcPort);
+    if (!m_rpcPort.open(m_rpcPortName))
+    {
+        log()->error("{} Could not open", logPrefix);
+        return false;
+    }
+
     return true;
 }
 
@@ -1997,4 +2004,18 @@ bool YarpRobotLoggerDevice::close()
     }
 
     return true;
+}
+
+bool YarpRobotLoggerDevice::lastCallSave()
+{
+    std::string fileName;
+    m_bufferManager.saveToFile(fileName);
+    return this->saveCallback(fileName, robometry::SaveCallbackSaveMethod::last_call);
+}
+
+bool YarpRobotLoggerDevice::periodicSave()
+{
+    std::string fileName;
+    m_bufferManager.saveToFile(fileName);
+    return this->saveCallback(fileName, robometry::SaveCallbackSaveMethod::periodic);
 }

--- a/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
+++ b/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
@@ -8,7 +8,5 @@
 
 service YarpRobotLoggerDeviceCommands
 {
-    bool lastCallSave();
-
-    bool periodicSave();
+    bool saveData();
 }

--- a/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
+++ b/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
@@ -1,0 +1,14 @@
+/**
+ * @file YarpRobotLoggerDeviceCommands.thrift
+ * @authors Lorenzo Moretti <lorenzo.moretti@iit.it>
+ * @copyright 2024 iCub Facility - Istituto Italiano di Tecnologia
+ *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ * @date 2024
+ */
+
+service YarpRobotLoggerDeviceCommands
+{
+    bool lastCallSave();
+
+    bool periodicSave();
+}

--- a/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
+++ b/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
@@ -1,7 +1,7 @@
 /**
  * @file YarpRobotLoggerDeviceCommands.thrift
  * @authors Lorenzo Moretti <lorenzo.moretti@iit.it>
- * @copyright 2024 iCub Facility - Istituto Italiano di Tecnologia
+ * @copyright 2024 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
  *            Released under the terms of the BSD-3-Clause license.
  * @date 2024
  */

--- a/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
+++ b/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
@@ -1,7 +1,7 @@
 /**
  * @file YarpRobotLoggerDeviceCommands.thrift
  * @authors Lorenzo Moretti <lorenzo.moretti@iit.it>
- * @copyright 2024 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
+ * @copyright 2024 Fondazione Istituto Italiano di Tecnologia
  *            Released under the terms of the BSD-3-Clause license.
  * @date 2024
  */

--- a/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
+++ b/devices/YarpRobotLoggerDevice/thrifts/YarpRobotLoggerDeviceCommands.thrift
@@ -2,7 +2,7 @@
  * @file YarpRobotLoggerDeviceCommands.thrift
  * @authors Lorenzo Moretti <lorenzo.moretti@iit.it>
  * @copyright 2024 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *            Released under the terms of the BSD-3-Clause license.
  * @date 2024
  */
 


### PR DESCRIPTION
This PR aims to add a rpc command to the `YarpLoggerDevice`.

This command should be used to trigger YarpLoggerDevice to save data to local file (which currently is only possible by closing the device itself with ctrl+c).

I have added a command which saves according to the method `robometry::SaveCallbackSaveMethod::periodic`.