### PR TITLE
Enable the setting of the measured feet transform for the Unicycle Trajectory Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 - Add `ZMPgenerator` to `UnicycleTrajectoryGenerator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/916)
 - Add `VariableFeasibleRegionTaskVariableFeasibleRegionTask` in the TSID controller (https://github.com/ami-iit/bipedal-locomotion-framework/pull/922)
+- Add `setMeasuredTransform` in the `UnicycleTrajectoryGenerator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/927)
 
 ### Changed
 - Some improvements on the YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/910)

--- a/src/Planners/include/BipedalLocomotion/Planners/UnicycleTrajectoryGenerator.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/UnicycleTrajectoryGenerator.h
@@ -175,9 +175,9 @@ public:
     std::chrono::nanoseconds getSamplingTime() const;
 
     /**
-     * @brief Set the measured transform to use when regenerating the trajectory.
+     * @brief Set the feet transforms to use when regenerating the trajectory.
      */
-    void setMeasuredTransform(const manif::SE3d& measuredTransform);
+    void setFeetTransform(const manif::SE3d& leftFootTransform, const manif::SE3d& rightFootTransform);
 
 private:
     class Impl;

--- a/src/Planners/include/BipedalLocomotion/Planners/UnicycleTrajectoryGenerator.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/UnicycleTrajectoryGenerator.h
@@ -174,6 +174,11 @@ public:
      */
     std::chrono::nanoseconds getSamplingTime() const;
 
+    /**
+     * @brief Set the measured transform to use when regenerating the trajectory.
+     */
+    void setMeasuredTransform(const manif::SE3d& measuredTransform);
+
 private:
     class Impl;
     std::unique_ptr<Impl> m_pImpl;

--- a/src/Planners/src/UnicycleTrajectoryGenerator.cpp
+++ b/src/Planners/src/UnicycleTrajectoryGenerator.cpp
@@ -99,8 +99,9 @@ public:
 
     BipedalLocomotion::Planners::UnicycleTrajectoryPlanner unicycleTrajectoryPlanner;
 
-    manif::SE3d measuredTransform;
-    bool useMeasuredTransform;
+    manif::SE3d measuredLeftFootTransform;
+    manif::SE3d measuredRightFootTransform;
+    bool useMeasuredFeetTransforms;
 
     /**
      * ask for a new trajectory to the unicycle trajectory planner
@@ -563,11 +564,13 @@ bool Planners::UnicycleTrajectoryGenerator::advance()
                 = m_pImpl->time + m_pImpl->newTrajectoryMergeCounter * m_pImpl->parameters.dt;
             manif::SE3d measuredTransform;
 
-            if (m_pImpl->useMeasuredTransform)
+            if (m_pImpl->useMeasuredFeetTransforms)
             {
-                measuredTransform = m_pImpl->measuredTransform;
-                m_pImpl->useMeasuredTransform = false; // once used, it is no more usable. User
-                                                       // should reset it again.
+                measuredTransform = m_pImpl->trajectory.isLeftFootLastSwinging.front()
+                                        ? m_pImpl->measuredRightFootTransform
+                                        : m_pImpl->measuredLeftFootTransform;
+                m_pImpl->useMeasuredFeetTransforms = false; // once used, it is no more usable. User
+                                                            // should reset it again.
             } else
             {
 
@@ -972,9 +975,10 @@ BipedalLocomotion::Planners::UnicycleTrajectoryGenerator::getSamplingTime() cons
     return m_pImpl->parameters.dt;
 };
 
-void BipedalLocomotion::Planners::UnicycleTrajectoryGenerator::setMeasuredTransform(
-    const manif::SE3d& measuredTransform)
+void BipedalLocomotion::Planners::UnicycleTrajectoryGenerator::setFeetTransform(
+    const manif::SE3d& leftFootTransform, const manif::SE3d& rightFootTransform)
 {
-    m_pImpl->measuredTransform = measuredTransform;
-    m_pImpl->useMeasuredTransform = true;
+    m_pImpl->measuredLeftFootTransform = leftFootTransform;
+    m_pImpl->measuredRightFootTransform = rightFootTransform;
+    m_pImpl->useMeasuredFeetTransforms = true;
 };

--- a/src/Planners/src/UnicycleTrajectoryGenerator.cpp
+++ b/src/Planners/src/UnicycleTrajectoryGenerator.cpp
@@ -99,6 +99,9 @@ public:
 
     BipedalLocomotion::Planners::UnicycleTrajectoryPlanner unicycleTrajectoryPlanner;
 
+    manif::SE3d measuredTransform;
+    bool useMeasuredTransform;
+
     /**
      * ask for a new trajectory to the unicycle trajectory planner
      */
@@ -558,12 +561,22 @@ bool Planners::UnicycleTrajectoryGenerator::advance()
 
             std::chrono::nanoseconds initTimeTrajectory
                 = m_pImpl->time + m_pImpl->newTrajectoryMergeCounter * m_pImpl->parameters.dt;
+            manif::SE3d measuredTransform;
 
-            manif::SE3d measuredTransform = m_pImpl->trajectory.isLeftFootLastSwinging.front()
-                                                ? m_pImpl->trajectory.rightFootTransform.at(
-                                                    m_pImpl->newTrajectoryMergeCounter)
-                                                : m_pImpl->trajectory.leftFootTransform.at(
-                                                    m_pImpl->newTrajectoryMergeCounter);
+            if (m_pImpl->useMeasuredTransform)
+            {
+                measuredTransform = m_pImpl->measuredTransform;
+                m_pImpl->useMeasuredTransform = false; // once used, it is no more usable. User
+                                                       // should reset it again.
+            } else
+            {
+
+                measuredTransform = m_pImpl->trajectory.isLeftFootLastSwinging.front()
+                                        ? m_pImpl->trajectory.rightFootTransform.at(
+                                              m_pImpl->newTrajectoryMergeCounter)
+                                        : m_pImpl->trajectory.leftFootTransform.at(
+                                              m_pImpl->newTrajectoryMergeCounter);
+            }
 
             // ask for a new trajectory (and spawn an asynchronous thread to compute it)
             {
@@ -957,4 +970,11 @@ std::chrono::nanoseconds
 BipedalLocomotion::Planners::UnicycleTrajectoryGenerator::getSamplingTime() const
 {
     return m_pImpl->parameters.dt;
+};
+
+void BipedalLocomotion::Planners::UnicycleTrajectoryGenerator::setMeasuredTransform(
+    const manif::SE3d& measuredTransform)
+{
+    m_pImpl->measuredTransform = measuredTransform;
+    m_pImpl->useMeasuredTransform = true;
 };


### PR DESCRIPTION
This PR adds a member function to set the feet measured transform in the Unicycle Trajectory Generator

The feet measured transforms are used by the unicycle planner when regenerating the trajectory.