### PR TITLE
Enable Programmatic Creation of  VariableRegularizationTask  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Add `setFeetTransform` in the `UnicycleTrajectoryGenerator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/927)
 - Add `getCurrentTime` to the `FixedFootDetector` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/928)
 - Add the possibility to easily disable/enable the rt logging in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/932)
+- Enable Programmatic Creation of `VariableRegularizationTask` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/934)
 
 ### Changed
 - Some improvements on the YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/910)

--- a/src/TSID/include/BipedalLocomotion/TSID/VariableRegularizationTask.h
+++ b/src/TSID/include/BipedalLocomotion/TSID/VariableRegularizationTask.h
@@ -82,6 +82,8 @@ public:
     bool isValid() const override;
 };
 
+BLF_REGISTER_TSID_TASK(VariableRegularizationTask);
+
 } // namespace TSID
 } // namespace BipedalLocomotion
 


### PR DESCRIPTION
Thanks to  #828, one can build a TSID object programmatically.

This PR adds the `VariableRegularizationTask` to the list of tasks that can be built programmatically.