### PR TITLE
Fixed some prints of the logger device

### DIFF
--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -694,8 +694,11 @@ bool YarpRobotLoggerDevice::addChannel(const std::string& nameKey,
     if (metadataNames.empty() || vectorSize != metadataNames.size())
     {
         log()->warn("The metadata names for channel {} are empty or the size of the metadata names "
-                    "is different from the vector size. The default metadata will be used.",
-                    nameKey);
+                    "is different from the vector size. The default metadata will be used."
+                    "Vector size: {}. Metadata names size: {}",
+                    nameKey,
+                    vectorSize,
+                    metadataNames.size());
         if (!m_bufferManager.addChannel({nameKey, {vectorSize, 1}}))
         {
             log()->error("Failed to add the channel in buffer manager named: {}", nameKey);
@@ -1887,6 +1890,7 @@ bool YarpRobotLoggerDevice::saveCallback(const std::string& fileName,
         }
 
         log()->info("{} Saved video {}_{}_{} in {}.",
+                    logPrefix,
                     fileName,
                     camera,
                     "rgb",
@@ -1935,6 +1939,7 @@ bool YarpRobotLoggerDevice::saveCallback(const std::string& fileName,
         }
 
         log()->info("{} Saved video {}_{}_{} in {}.",
+                    logPrefix,
                     fileName,
                     camera,
                     "rgb",
@@ -1951,6 +1956,7 @@ bool YarpRobotLoggerDevice::saveCallback(const std::string& fileName,
         }
 
         log()->info("{} Saved video {}_{}_{} in {}.",
+                    logPrefix,
                     fileName,
                     camera,
                     "depth",


### PR DESCRIPTION
The prints introduced in https://github.com/ami-iit/bipedal-locomotion-framework/pull/910 were not working properly