### PR TITLE
Fix iDynTree warnings

### DIFF
--- a/bindings/python/ML/src/VelMANNAutoregressive.cpp
+++ b/bindings/python/ML/src/VelMANNAutoregressive.cpp
@@ -5,7 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
-#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/bindings/python/ML/src/VelMANNTrajectoryGenerator.cpp
+++ b/bindings/python/ML/src/VelMANNTrajectoryGenerator.cpp
@@ -5,7 +5,7 @@
  * distributed under the terms of the BSD-3-Clause license.
  */
 
-#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model.h>
 #include <pybind11/chrono.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>

--- a/devices/FloatingBaseEstimatorDevice/include/BipedalLocomotion/FloatingBaseEstimatorDevice.h
+++ b/devices/FloatingBaseEstimatorDevice/include/BipedalLocomotion/FloatingBaseEstimatorDevice.h
@@ -12,7 +12,7 @@
 #include <BipedalLocomotion/RobotInterface/YarpSensorBridge.h>
 #include <BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h>
 
-#include <iDynTree/Estimation/ContactStateMachine.h>
+#include <iDynTree/ContactStateMachine.h>
 #include <iDynTree/ModelLoader.h>
 
 #include <yarp/os/PeriodicThread.h>

--- a/devices/RobotDynamicsEstimatorDevice/include/BipedalLocomotion/RobotDynamicsEstimatorDevice.h
+++ b/devices/RobotDynamicsEstimatorDevice/include/BipedalLocomotion/RobotDynamicsEstimatorDevice.h
@@ -16,8 +16,8 @@
 #include <BipedalLocomotion/RobotInterface/YarpSensorBridge.h>
 #include <BipedalLocomotion/YarpUtilities/VectorsCollection.h>
 
-#include <iDynTree/Estimation/ContactStateMachine.h>
-#include <iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h>
+#include <iDynTree/ContactStateMachine.h>
+#include <iDynTree/ExtWrenchesAndJointTorquesEstimator.h>
 #include <iDynTree/ModelLoader.h>
 
 #include <yarp/dev/DeviceDriver.h>

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -19,7 +19,7 @@ if(FRAMEWORK_COMPILE_FloatingBaseEstimators)
     SOURCES                src/FloatingBaseEstimator.cpp src/InvariantEKFBaseEstimator.cpp src/LeggedOdometry.cpp src/BaseEstimatorFromFootIMU.cpp
     SUBDIRECTORIES         tests/FloatingBaseEstimators
     PUBLIC_HEADERS         ${H_PREFIX}/FloatingBaseEstimatorParams.h ${H_PREFIX}/FloatingBaseEstimatorIO.h ${H_PREFIX}/FloatingBaseEstimator.h ${H_PREFIX}/InvariantEKFBaseEstimator.h ${H_PREFIX}/LeggedOdometry.h ${H_PREFIX}/BaseEstimatorFromFootIMU.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen BipedalLocomotion::Contacts iDynTree::idyntree-modelio-urdf BipedalLocomotion::TextLogging
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen BipedalLocomotion::Contacts iDynTree::idyntree-modelio BipedalLocomotion::TextLogging
                            MANIF::manif)
 endif()
 

--- a/src/Estimators/tests/FloatingBaseEstimators/CMakeLists.txt
+++ b/src/Estimators/tests/FloatingBaseEstimators/CMakeLists.txt
@@ -24,7 +24,7 @@ if(FRAMEWORK_USE_icub-models)
     SOURCES BaseEstimatorFromFootIMUTest.cpp
     LINKS BipedalLocomotion::FloatingBaseEstimators BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions
           Eigen3::Eigen
-          iDynTree::idyntree-modelio-urdf
+          iDynTree::idyntree-modelio
           icub-models::icub-models)
 
 endif()

--- a/src/ML/src/VelMANNAutoregressive.cpp
+++ b/src/ML/src/VelMANNAutoregressive.cpp
@@ -17,7 +17,7 @@
 #include <BipedalLocomotion/Math/Constants.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
 
-#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model.h>
 #include <manif/SE3.h>
 
 using namespace BipedalLocomotion::ML;

--- a/src/ML/src/VelMANNTrajectoryGenerator.cpp
+++ b/src/ML/src/VelMANNTrajectoryGenerator.cpp
@@ -13,10 +13,10 @@
 #include <BipedalLocomotion/ML/VelMANNTrajectoryGenerator.h>
 #include <BipedalLocomotion/TextLogging/Logger.h>
 
-#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model.h>
 #include <manif/SE3.h>
 
-#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/EigenHelpers.h>
 
 using namespace BipedalLocomotion::ML;
 using namespace BipedalLocomotion;

--- a/src/ML/tests/VelMANNTrajectoryGeneratorTest.cpp
+++ b/src/ML/tests/VelMANNTrajectoryGeneratorTest.cpp
@@ -7,8 +7,8 @@
 
 #include <memory>
 
-#include <iDynTree/Model/Model.h>
-#include <iDynTree/ModelIO/ModelLoader.h>
+#include <iDynTree/Model.h>
+#include <iDynTree/ModelLoader.h>
 
 // Catch2
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
Fix CMake warnings:

~~~
2025-02-19T07:19:21.4248687Z CMake Warning (dev) at /usr/share/miniconda3/envs/test/lib/cmake/BipedalLocomotionFramework/BipedalLocomotionFrameworkTargets.cmake:222 (set_target_properties):
2025-02-19T07:19:21.4250227Z   The library that is being linked to, iDynTree::idyntree-modelio-urdf, is
2025-02-19T07:19:21.4251015Z   marked as being deprecated by the owner.  The message provided by the
2025-02-19T07:19:21.4251627Z   developer is:
2025-02-19T07:19:21.4251824Z 
2025-02-19T07:19:21.4252113Z   Do not use deprecated target iDynTree::idyntree-modelio-urdf, use
2025-02-19T07:19:21.4252725Z   iDynTree::idyntree-modelio instead.
2025-02-19T07:19:21.4253030Z 
~~~

and compilation warnings:

~~~
2025-02-19T07:14:16.1240459Z /usr/share/miniconda3/envs/test/include/iDynTree/Core/EigenHelpers.h:8:4: warning: #warning <iDynTree/Core/EigenHelpers.h> is deprecated. Please use <iDynTree/EigenHelpers.h>. To disable this warning use -Wno-deprecated. [-Wcpp]
2025-02-19T07:14:16.1242591Z     8 |   #warning <iDynTree/Core/EigenHelpers.h> is deprecated. Please use <iDynTree/EigenHelpers.h>. To disable this warning use -Wno-deprecated.
2025-02-19T07:14:16.1243561Z       |    ^~~~~~~
~~~

The minimum required version of iDynTree is already >= 12, so we do not bump it in any way.