### PR TITLE
Add option FRAMEWORK_COMPILE_MotorCurrentTrackingApplication in cmake file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 - Add missing `ContinuousDynamicalSystem` row to `Exported components` in the README (https://github.com/ami-iit/bipedal-locomotion-framework/pull/919)
 - Avoid using ``iCubGazeboV3`` model in ``BaseEstimatorFromFootIMU`` test (https://github.com/ami-iit/bipedal-locomotion-framework/pull/910)
 - Fix typos in tsid balancing torque control config files (https://github.com/ami-iit/bipedal-locomotion-framework/pull/926)
+- Add option `FRAMEWORK_COMPILE_MotorCurrentTrackingApplication` in cmake file to install correctly the application motor-current-tracking (https://github.com/ami-iit/bipedal-locomotion-framework/pull/937)
 
 ## [0.20.0] - 2024-12-16
 ### Added

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -292,3 +292,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_ReducedModelControllers
 framework_dependent_option(FRAMEWORK_COMPILE_JointsGridPositionTrackingApplication
   "Compile joints-grid-position-tracking application?" ON
   "FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_PYTHON_BINDINGS;FRAMEWORK_COMPILE_RobotInterface;FRAMEWORK_COMPILE_Math" OFF)
+
+framework_dependent_option(FRAMEWORK_COMPILE_MotorCurrentTrackingApplication
+  "Compile motor-current-tracking application?" ON
+  "FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_COMPILE_PYTHON_BINDINGS;FRAMEWORK_COMPILE_RobotInterface" OFF)


### PR DESCRIPTION
Adding this line allows us to install correctly the application [motor-current-tracking
](https://github.com/ami-iit/bipedal-locomotion-framework/tree/master/utilities/motor-current-tracking)

cc @GiulioRomualdi 