### PR TITLE
Do not run cmake-package-check on Windows under bash

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -104,6 +104,7 @@ jobs:
         ctest --output-on-failure -C ${{ matrix.build_type }}
 
     - name: Install and test installed package [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         cd build
@@ -133,6 +134,7 @@ jobs:
         ctest --output-on-failure -C ${{ matrix.build_type }}
 
     - name: Install and test installed package [Windows]
+      if: contains(matrix.os, 'windows')
       shell: cmd /C call {0}
       run: |
         cd build

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -103,6 +103,13 @@ jobs:
         cd build
         ctest --output-on-failure -C ${{ matrix.build_type }}
 
+    - name: Install and test installed package [Linux&macOS]
+      shell: bash -l {0}
+      run: |
+        cd build
+        cmake --install . --config ${{ matrix.build_type }}
+        cmake-package-check BipedalLocomotionFramework --targets BipedalLocomotion::Framework
+
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')
       shell: cmd /C call {0}
@@ -125,8 +132,8 @@ jobs:
         cd build
         ctest --output-on-failure -C ${{ matrix.build_type }}
 
-    - name: Install and test installed package
-      shell: bash -l {0}
+    - name: Install and test installed package [Windows]
+      shell: cmd /C call {0}
       run: |
         cd build
         cmake --install . --config ${{ matrix.build_type }}


### PR DESCRIPTION
`cmake-package-check` on Windows uses `Ninja`, that needs to be run under `cmd.exe` as the activation scripts of Visual Studio do not run on bash. I have no idea how it worked before. I am not a big fan of all the duplication between Windows and Linux/macOS, but that is already how the CI job is implemented.

Fix https://github.com/ami-iit/bipedal-locomotion-framework/issues/940 .