### PR TITLE
Add motor temperature sensor support to SensorBridge and YarpSensorBridge and logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented in this file.
 - Add the possibility to easily disable/enable the rt logging in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/932)
 - Enable Programmatic Creation of `VariableRegularizationTask` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/934)
 - Check if the setpoint has been set at least once in TSID and IK (https://github.com/ami-iit/bipedal-locomotion-framework/pull/939)
-- Add motor temperature sensor support to SensorBridge and `YarpSensorBridge` and `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/946)
+- Add motor temperature sensor support to `SensorBridge`, `YarpSensorBridge` and `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/946)
 
 ### Changed
 - Some improvements on the YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/910)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 - Add the possibility to easily disable/enable the rt logging in `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/932)
 - Enable Programmatic Creation of `VariableRegularizationTask` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/934)
 - Check if the setpoint has been set at least once in TSID and IK (https://github.com/ami-iit/bipedal-locomotion-framework/pull/939)
+- Add motor temperature sensor support to SensorBridge and `YarpSensorBridge` and `YarpRobotLoggerDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/946)
 
 ### Changed
 - Some improvements on the YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/910)

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
@@ -71,6 +71,8 @@ BSD-3-Clause license. -->
     <param name="stream_pids">false</param>
     <param name="stream_motor_PWM">false</param>
     <param name="stream_temperatures">false</param>
+    <param name="stream_joint_accelerations">true</param>
+    <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
       <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
@@ -58,6 +58,8 @@ BSD-3-Clause license. -->
     <param name="stream_pids">false</param>
     <param name="stream_motor_PWM">false</param>
     <param name="stream_temperatures">true</param>
+    <param name="stream_joint_accelerations">true</param>
+    <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
       <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
@@ -60,6 +60,8 @@ BSD-3-Clause license. -->
     <param name="stream_pids">false</param>
     <param name="stream_motor_PWM">true</param>
     <param name="stream_temperatures">true</param>
+    <param name="stream_joint_accelerations">true</param>
+    <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
       <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw", "l_thumb_add", "l_thumb_oc", "l_index_oc", "l_middle_oc", "l_ring_pinky_oc", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "r_thumb_add", "r_thumb_oc", "r_index_oc", "r_middle_oc", "r_ring_pinky_oc", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
@@ -95,6 +95,8 @@ BSD-3-Clause license. -->
     <param name="stream_pids">false</param>
     <param name="stream_motor_PWM">true</param>
     <param name="stream_temperatures">true</param>
+    <param name="stream_joint_accelerations">true</param>
+    <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
       <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_pitch", "l_wrist_roll", "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_pitch", "r_wrist_roll", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
@@ -88,6 +88,8 @@ BSD-3-Clause license. -->
     <param name="stream_pids">false</param>
     <param name="stream_motor_PWM">true</param>
     <param name="stream_temperatures">true</param>
+    <param name="stream_joint_accelerations">true</param>
+    <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
       <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_pitch", "l_wrist_roll", "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_pitch", "r_wrist_roll", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
@@ -43,6 +43,8 @@ BSD-3-Clause license. -->
     <param name="stream_inertials">false</param>
     <param name="stream_cartesian_wrenches">true</param>
     <param name="stream_forcetorque_sensors">true</param>
+    <param name="stream_joint_accelerations">true</param>
+    <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
       <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -54,6 +54,8 @@ BSD-3-Clause license. -->
     <param name="stream_pids">false</param>
     <param name="stream_motor_PWM">true</param>
     <param name="stream_temperatures">true</param>
+    <param name="stream_joint_accelerations">true</param>
+    <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
       <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_prosup", "l_wrist_pitch",  "l_wrist_yaw", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_prosup", "r_wrist_pitch", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -168,6 +168,7 @@ private:
     bool m_streamMotorStates{false};
     bool m_streamJointStates{false};
     bool m_streamJointAccelerations{true};
+    bool m_streamMotorTemperature{false};
     bool m_streamMotorPWM{false};
     bool m_streamPIDs{false};
     bool m_streamInertials{false};
@@ -226,6 +227,7 @@ private:
     const std::string motorStateVelocitiesName = "motors_state::velocities";
     const std::string motorStateAccelerationsName = "motors_state::accelerations";
     const std::string motorStateCurrentsName = "motors_state::currents";
+    const std::string motorStateTemperaturesName = "motors_state::temperatures";
     const std::string motorStatePwmName = "motors_state::PWM";
 
     const std::string motorStatePidsName = "PIDs";

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -611,6 +611,17 @@ bool YarpRobotLoggerDevice::setupRobotSensorBridge(
         log()->info("{} The joint accelerations is not logged", logPrefix);
     }
 
+    if (!ptr->getParameter("stream_motor_temperature", m_streamMotorTemperature))
+    {
+        log()->info("{} The 'stream_motor_temperature' parameter is not found. The motor "
+                    "temperature is not logged",
+                    logPrefix);
+    }
+    if (!m_streamMotorTemperature)
+    {
+        log()->info("{} The motor temperature is not logged", logPrefix);
+    }
+
     if (!ptr->getParameter("stream_motor_states", m_streamMotorStates))
     {
         log()->info("{} The 'stream_motor_states' parameter is not found. The motor states is not "
@@ -822,6 +833,10 @@ bool YarpRobotLoggerDevice::attachAll(const yarp::dev::PolyDriverList& poly)
         ok = ok && addChannel(motorStateVelocitiesName, joints.size(), joints);
         ok = ok && addChannel(motorStateAccelerationsName, joints.size(), joints);
         ok = ok && addChannel(motorStateCurrentsName, joints.size(), joints);
+        if (m_streamMotorTemperature)
+        {
+            ok = ok && addChannel(motorStateTemperaturesName, joints.size(), joints);
+        }
     }
 
     if (m_streamMotorPWM)
@@ -1579,6 +1594,14 @@ void YarpRobotLoggerDevice::run()
         if (m_robotSensorBridge->getMotorCurrents(m_jointSensorBuffer))
         {
             logData(motorStateCurrentsName, m_jointSensorBuffer, time);
+        }
+
+        if (m_streamMotorTemperature)
+        {
+            if (m_robotSensorBridge->getMotorTemperatures(m_jointSensorBuffer))
+            {
+                logData(motorStateTemperaturesName, m_jointSensorBuffer, time);
+            }
         }
     }
 

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -60,6 +60,8 @@ namespace RobotInterface
  * |                            |stream_motor_states              | boolean           |Flag to activate the attachment to remapped control boards for motor states reading      |
  * |                            |stream_motor_PWM                 | boolean           |Flag to activate the attachment to remapped control boards for PWM reading      |
  * |                            |stream_temperatures              | boolean           |Flag to activate the attachment to MAS temperature sensors      |
+ * |                            |stream_joint_accelerations       | boolean           |Flag to activate the attachment to joint accelerations from encoders      |
+ * |                            |stream_motor_temperature         | boolean           |Flag to activate the attachment to motor temperature sensors      |
  * |RemoteControlBoardRemapper  |                                 |                   |Expects only one remapped remotecontrolboard device attached to it, if there multiple remote control boards, then  use a remapper to create a single remotecontrolboard |
  * |                            |joints_list                      | vector of strings |This parameter is **optional**. The joints list used to open the remote control board remapper. If the list is not passed, the order of the joint stored in the PolyDriver is used       |
  * |InertialSensors             |                                 |                   |Expects IMU to be opened as genericSensorClient devices communicating through the inertial server and other inertials as a part multiple analog sensors remapper ("multipleanalogsensorsremapper") |
@@ -417,6 +419,32 @@ public:
      */
     bool getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrents,
                           OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+
+    /**
+     * Get motor temperature in degrees celsius
+      * @param[out] motorTemperature motor temperature in degrees celsius
+      * @param[out] receiveTimeInSeconds time at which the measurement was received
+      * @warning the size is decided at the configuration and remains fixed,
+      * and internal checks must be done at the implementation level by the Derived class.
+      * This means that the user must pass a resized argument "motorTemperatures" to this method
+      * @return true/false in case of success/failure
+      */
+    bool getMotorTemperatures(Eigen::Ref<Eigen::VectorXd> motorTemperatures,
+                              OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+
+    /**
+     * Get motor temperature in degrees celsius
+     * @param[in] jointName name of the joint
+     * @param[out] motorTemperature motor temperature in degrees celsius
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     * @return true/false in case of success/failure
+     */
+    bool getMotorTemperature(const std::string& jointName,
+                             double& motorTemperature,
+                             OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get motor PWM

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
@@ -25,8 +25,8 @@
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/ICurrentControl.h>
 #include <yarp/dev/IGenericSensor.h>
-#include <yarp/dev/IMotorEncoders.h>
 #include <yarp/dev/IMotor.h>
+#include <yarp/dev/IMotorEncoders.h>
 #include <yarp/dev/IPidControl.h>
 #include <yarp/dev/ITorqueControl.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
@@ -66,7 +66,7 @@ struct YarpSensorBridge::Impl
         yarp::dev::ICurrentControl* currsensors{nullptr};
         yarp::dev::ITorqueControl* torques{nullptr};
         yarp::dev::IMotorEncoders* motorEncoders{nullptr};
-        yarp::dev::IMotor* motor{nullptr};        
+        yarp::dev::IMotor* motor{nullptr};
         yarp::dev::IPidControl* pids{nullptr};
         yarp::dev::IAmplifierControl* amp{nullptr};
     };

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
@@ -26,6 +26,7 @@
 #include <yarp/dev/ICurrentControl.h>
 #include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/IMotorEncoders.h>
+#include <yarp/dev/IMotor.h>
 #include <yarp/dev/IPidControl.h>
 #include <yarp/dev/ITorqueControl.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
@@ -65,6 +66,7 @@ struct YarpSensorBridge::Impl
         yarp::dev::ICurrentControl* currsensors{nullptr};
         yarp::dev::ITorqueControl* torques{nullptr};
         yarp::dev::IMotorEncoders* motorEncoders{nullptr};
+        yarp::dev::IMotor* motor{nullptr};        
         yarp::dev::IPidControl* pids{nullptr};
         yarp::dev::IAmplifierControl* amp{nullptr};
     };
@@ -124,6 +126,7 @@ struct YarpSensorBridge::Impl
         Eigen::VectorXd pidPositions;
         Eigen::VectorXd pidPositionErrors;
         Eigen::VectorXd motorPWMs;
+        Eigen::VectorXd motorTemperatures;
 
         Eigen::VectorXd jointPositionsUnordered;
         Eigen::VectorXd jointVelocitiesUnordered;
@@ -133,6 +136,7 @@ struct YarpSensorBridge::Impl
         Eigen::VectorXd motorPositionsUnordered;
         Eigen::VectorXd motorVelocitiesUnordered;
         Eigen::VectorXd motorAccelerationsUnordered;
+        Eigen::VectorXd motorTemperaturesUnordered;
         Eigen::VectorXd pidPositionsUnordered;
         Eigen::VectorXd pidPositionErrorsUnordered;
         Eigen::VectorXd motorPWMsUnordered;
@@ -981,6 +985,7 @@ struct YarpSensorBridge::Impl
         bool okPWM = !metaData.bridgeOptions.isPWMControlEnabled;
         bool okMotorsSensor = !metaData.bridgeOptions.isMotorSensorsEnabled;
         bool okPID = !metaData.bridgeOptions.isPIDsEnabled;
+        bool okMotorTemperature = !metaData.bridgeOptions.isMotorTemperatureSensorEnabled;
 
         for (int devIdx = 0; devIdx < devList.size(); devIdx++)
         {
@@ -1011,7 +1016,13 @@ struct YarpSensorBridge::Impl
                 okPID = devList[devIdx]->poly->view(controlBoardRemapperInterfaces.pids);
             }
 
-            if (okPID && okJointsSensor && okMotorsSensor && okPWM)
+            if (!okMotorTemperature && metaData.bridgeOptions.isMotorTemperatureSensorEnabled)
+            {
+                okMotorTemperature
+                    = devList[devIdx]->poly->view(controlBoardRemapperInterfaces.motor);
+            }
+
+            if (okPID && okJointsSensor && okMotorsSensor && okPWM && okMotorTemperature)
             {
                 if (!compareControlBoardJointsList())
                 {
@@ -1092,6 +1103,18 @@ struct YarpSensorBridge::Impl
 
             // zero buffers
             controlBoardRemapperMeasures.motorPWMs.setZero();
+        }
+
+        if (metaData.bridgeOptions.isMotorTemperatureSensorEnabled)
+        {
+            // firstly resize all the controlboard data buffers
+            controlBoardRemapperMeasures.motorTemperatures.resize(metaData.bridgeOptions.nrJoints);
+
+            controlBoardRemapperMeasures.motorTemperaturesUnordered.resize(
+                metaData.bridgeOptions.nrJoints);
+
+            // zero buffers
+            controlBoardRemapperMeasures.motorTemperatures.setZero();
         }
 
         if (metaData.bridgeOptions.isMotorSensorsEnabled)
@@ -1724,6 +1747,34 @@ struct YarpSensorBridge::Impl
             } else
             {
                 log()->error("{} Unable to read from ICurrentControl interface, use previous "
+                             "measurement.",
+                             logPrefix);
+            }
+        }
+
+        if (controlBoardRemapperInterfaces.motor)
+        {
+            ok = controlBoardRemapperInterfaces.motor->getTemperatures(
+                controlBoardRemapperMeasures.motorTemperaturesUnordered.data());
+
+            if (ok)
+            {
+                if (checkForNan)
+                {
+                    if (nanExistsInVec(controlBoardRemapperMeasures.motorTemperaturesUnordered,
+                                       logPrefix,
+                                       "MotorTemperatures"))
+                    {
+                        return false;
+                    }
+                }
+
+                controlBoardRemapperMeasures.motorTemperatures.noalias()
+                    = controlBoardRemapperMeasures.remappedJointPermutationMatrix
+                      * controlBoardRemapperMeasures.motorTemperaturesUnordered;
+            } else
+            {
+                log()->error("{} Unable to read from IMotorTemperature interface, use previous "
                              "measurement.",
                              logPrefix);
             }

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -48,6 +48,15 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
         log()->info("{} Joint accelerations will not be streamed.", logPrefix);
     }
 
+    if (!ptr->getParameter("stream_motor_temperature", m_pimpl->metaData.bridgeOptions.isMotorTemperatureSensorEnabled))
+    {
+        log()->info("{} Unable to get stream_motor_temperature. Set to false by default", logPrefix);
+    }
+    if (!m_pimpl->metaData.bridgeOptions.isMotorTemperatureSensorEnabled)
+    {
+        log()->info("{} Motor temperature sensors will not be streamed.", logPrefix);
+    }
+
     bool ret{true};
     ret = m_pimpl->subConfigLoader("stream_joint_states",
                                    "RemoteControlBoardRemapper",
@@ -437,6 +446,14 @@ bool YarpSensorBridge::getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVeloc
     {
         return false;
     }
+
+    if (jointVelocties.size() != m_pimpl->controlBoardRemapperMeasures.jointVelocities.size())
+    {
+        log()->error("[YarpSensorBridge::getJointVelocities] Joint velocities and positions have "
+                     "different sizes.");
+        return false;
+    }
+
     jointVelocties = m_pimpl->controlBoardRemapperMeasures.jointVelocities;
 
     if (receiveTimeInSeconds)
@@ -498,6 +515,14 @@ bool YarpSensorBridge::getJointAccelerations(Eigen::Ref<Eigen::VectorXd> jointAc
     {
         return false;
     }
+
+    if (jointAccelerations.size()
+        != m_pimpl->controlBoardRemapperMeasures.jointAccelerations.size())
+    {
+        log()->error("{} Joint accelerations and positions have different sizes.", logPrefix);
+        return false;
+    }
+
     jointAccelerations = m_pimpl->controlBoardRemapperMeasures.jointAccelerations;
     if (receiveTimeInSeconds)
     {
@@ -716,6 +741,13 @@ bool YarpSensorBridge::getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrent
         return false;
     }
 
+    if (motorCurrents.size() != m_pimpl->controlBoardRemapperMeasures.motorCurrents.size())
+    {
+        log()->error("[YarpSensorBridge::getMotorCurrents] The size of the input vector does not "
+                     "match the number of motor currents.");
+        return false;
+    }
+
     motorCurrents = m_pimpl->controlBoardRemapperMeasures.motorCurrents;
 
     if (receiveTimeInSeconds)
@@ -763,6 +795,13 @@ bool YarpSensorBridge::getMotorPWMs(Eigen::Ref<Eigen::VectorXd> motorPWMs,
                                           m_pimpl->metaData.bridgeOptions.isPWMControlEnabled,
                                           m_pimpl->controlBoardRemapperMeasures.motorPWMs))
     {
+        return false;
+    }
+
+    if (motorPWMs.size() != m_pimpl->controlBoardRemapperMeasures.motorPWMs.size())
+    {
+        log()->error("[YarpSensorBridge::getMotorPWMs] The size of the input vector does not match "
+                     "the number of motor PWMs.");
         return false;
     }
 
@@ -816,6 +855,13 @@ bool YarpSensorBridge::getJointTorques(Eigen::Ref<Eigen::VectorXd> jointTorques,
         return false;
     }
 
+    if (jointTorques.size() != m_pimpl->controlBoardRemapperMeasures.jointTorques.size())
+    {
+        log()->error("[YarpSensorBridge::getJointTorques] The size of the input vector does not "
+                     "match the number of joint torques.");
+        return false;
+    }
+
     jointTorques = m_pimpl->controlBoardRemapperMeasures.jointTorques;
 
     if (receiveTimeInSeconds)
@@ -863,6 +909,13 @@ bool YarpSensorBridge::getPidPositions(Eigen::Ref<Eigen::VectorXd> pidPositions,
                                           m_pimpl->metaData.bridgeOptions.isPIDsEnabled,
                                           m_pimpl->controlBoardRemapperMeasures.pidPositions))
     {
+        return false;
+    }
+
+    if (pidPositions.size() != m_pimpl->controlBoardRemapperMeasures.pidPositions.size())
+    {
+        log()->error("[YarpSensorBridge::getPidPositions] The size of the input vector does not "
+                     "match the number of pid positions.");
         return false;
     }
 
@@ -917,6 +970,13 @@ bool YarpSensorBridge::getPidPositionErrors(Eigen::Ref<Eigen::VectorXd> pidPosit
         return false;
     }
 
+    if (pidPositionErrors.size() != m_pimpl->controlBoardRemapperMeasures.pidPositionErrors.size())
+    {
+        log()->error("[YarpSensorBridge::getPidPositionErrors] The size of the input vector does "
+                     "not match the number of pid position errors.");
+        return false;
+    }
+
     pidPositionErrors = m_pimpl->controlBoardRemapperMeasures.pidPositionErrors;
 
     if (receiveTimeInSeconds)
@@ -964,6 +1024,13 @@ bool YarpSensorBridge::getMotorPositions(Eigen::Ref<Eigen::VectorXd> motorPositi
                                           m_pimpl->metaData.bridgeOptions.isMotorSensorsEnabled,
                                           m_pimpl->controlBoardRemapperMeasures.motorPositions))
     {
+        return false;
+    }
+
+    if (motorPositions.size() != m_pimpl->controlBoardRemapperMeasures.motorPositions.size())
+    {
+        log()->error("[YarpSensorBridge::getMotorPositions] The size of the input vector does not "
+                     "match the number of motor positions.");
         return false;
     }
 
@@ -1017,6 +1084,13 @@ bool YarpSensorBridge::getMotorVelocities(Eigen::Ref<Eigen::VectorXd> motorVeloc
         return false;
     }
 
+    if (motorVelocties.size() != m_pimpl->controlBoardRemapperMeasures.motorVelocities.size())
+    {
+        log()->error("[YarpSensorBridge::getMotorVelocities] The size of the input vector does not "
+                     "match the number of motor velocities.");
+        return false;
+    }
+
     motorVelocties = m_pimpl->controlBoardRemapperMeasures.motorVelocities;
 
     if (receiveTimeInSeconds)
@@ -1067,8 +1141,71 @@ bool YarpSensorBridge::getMotorAccelerations(Eigen::Ref<Eigen::VectorXd> motorAc
         return false;
     }
 
+    if (motorAccelerations.size()
+        != m_pimpl->controlBoardRemapperMeasures.motorAccelerations.size())
+    {
+        log()->error("[YarpSensorBridge::getMotorAccelerations] The size of the input vector does "
+                     "not match the number of motor accelerations.");
+        return false;
+    }
+
     motorAccelerations = m_pimpl->controlBoardRemapperMeasures.motorAccelerations;
 
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
+    return true;
+}
+
+bool YarpSensorBridge::getMotorTemperature(const std::string& jointName,
+                                           double& motorTorque,
+                                           OptionalDoubleRef receiveTimeInSeconds)
+{
+    if (!m_pimpl->checkControlBoardSensor("[YarpSensorBridge::getMotorTorque]",
+                                          m_pimpl->controlBoardRemapperInterfaces.motor,
+                                          m_pimpl->metaData.bridgeOptions.isMotorSensorsEnabled,
+                                          m_pimpl->controlBoardRemapperMeasures.motorTemperatures))
+    {
+        return false;
+    }
+
+    int idx;
+    if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList, jointName, idx))
+    {
+        log()->error("[YarpSensorBridge::getMotorTorque] {} could not be found in the configured "
+                     "list of motors.",
+                     jointName);
+        return false;
+    }
+
+    motorTorque = m_pimpl->controlBoardRemapperMeasures.motorTemperatures[idx];
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
+    return true;
+}
+
+bool YarpSensorBridge::getMotorTemperatures(Eigen::Ref<Eigen::VectorXd> motorTemperatures,
+                                            OptionalDoubleRef receiveTimeInSeconds)
+{
+    if (!m_pimpl->checkControlBoardSensor("[YarpSensorBridge::getMotorTemperatures]",
+                                          m_pimpl->controlBoardRemapperInterfaces.motor,
+                                          m_pimpl->metaData.bridgeOptions.isMotorSensorsEnabled,
+                                          m_pimpl->controlBoardRemapperMeasures.motorTemperatures))
+    {
+        return false;
+    }
+
+    if (motorTemperatures.size() != m_pimpl->controlBoardRemapperMeasures.motorTemperatures.size())
+    {
+        log()->error("[YarpSensorBridge::getMotorTemperatures] The size of the input vector does "
+                     "not match the number of motor temperatures.");
+        return false;
+    }
+
+    motorTemperatures = m_pimpl->controlBoardRemapperMeasures.motorTemperatures;
     if (receiveTimeInSeconds)
         receiveTimeInSeconds.value().get()
             = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -48,9 +48,11 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
         log()->info("{} Joint accelerations will not be streamed.", logPrefix);
     }
 
-    if (!ptr->getParameter("stream_motor_temperature", m_pimpl->metaData.bridgeOptions.isMotorTemperatureSensorEnabled))
+    if (!ptr->getParameter("stream_motor_temperature",
+                           m_pimpl->metaData.bridgeOptions.isMotorTemperatureSensorEnabled))
     {
-        log()->info("{} Unable to get stream_motor_temperature. Set to false by default", logPrefix);
+        log()->info("{} Unable to get stream_motor_temperature. Set to false by default",
+                    logPrefix);
     }
     if (!m_pimpl->metaData.bridgeOptions.isMotorTemperatureSensorEnabled)
     {
@@ -449,8 +451,8 @@ bool YarpSensorBridge::getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVeloc
 
     if (jointVelocties.size() != m_pimpl->controlBoardRemapperMeasures.jointVelocities.size())
     {
-        log()->error("[YarpSensorBridge::getJointVelocities] Joint velocities and positions have "
-                     "different sizes.");
+        log()->error("[YarpSensorBridge::getJointVelocities] The size of the input vector does not "
+                     "match the number of joints.");
         return false;
     }
 
@@ -519,7 +521,8 @@ bool YarpSensorBridge::getJointAccelerations(Eigen::Ref<Eigen::VectorXd> jointAc
     if (jointAccelerations.size()
         != m_pimpl->controlBoardRemapperMeasures.jointAccelerations.size())
     {
-        log()->error("{} Joint accelerations and positions have different sizes.", logPrefix);
+        log()->error("{} The size of the input vector does not match the number of joints.",
+                     logPrefix);
         return false;
     }
 

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -45,6 +45,7 @@ struct SensorBridgeOptions
     bool isPIDsEnabled{false}; /** flag to connect pid position measurement sources */
     bool isMotorSensorsEnabled{false}; /** flag to connect motor measurement sources */
     bool isPWMControlEnabled{false}; /** flag to connect PWM measurement sources */
+    bool isMotorTemperatureSensorEnabled{false}; /** flag to connect motor temperature measurement sources */
 
     bool isTemperatureSensorEnabled{false}; /** flag to connect temperature measurement sources */
 
@@ -712,6 +713,35 @@ public:
      */
     virtual bool getMotorAccelerations(Eigen::Ref<Eigen::VectorXd> motorAccelerations,
                                        OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get motor temperature in degrees celsius
+     * @param[out] motorTemperature motor temperature in degrees celsius
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "motorTemperatures" to this method
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorTemperatures(Eigen::Ref<Eigen::VectorXd> motorTemperatures,
+                                       OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get motor temperature in degrees celsius
+     * @param[in] jointName name of the joint
+     * @param[out] motorTemperature motor temperature in degrees celsius
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorTemperature(const std::string& jointName,
+                                     double& motorTemperature,
+                                     OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };


### PR DESCRIPTION
This PR mitigates https://github.com/ami-iit/bipedal-locomotion-framework/issues/819 in the case of motor temperature. Thanks to https://github.com/robotology/yarp/pull/3188, the motor temperature will now be streamed in `stateExt`, eliminating the need for RPC calls between `controlboard_nws` and `RemoteControlBoard`.