### PR TITLE
Improve JointTorqueControl device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 - Some improvements on the YarpRobotLoggerDevice (https://github.com/ami-iit/bipedal-locomotion-framework/pull/910)
 - Removed ROS1 device publisher and the corresponding example (https://github.com/ami-iit/bipedal-locomotion-framework/pull/910)
 - Remove the possibility of setting the desired gravity direction and desired forward velocity separately in the `IK::GravityTrask` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/939)
+- Improve `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/948)
 
 ### Fixed
 - Fix outputs of `UnicycleTrajectoryGenerator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/916)

--- a/devices/JointTorqueControlDevice/include/BipedalLocomotion/JointTorqueControlDevice.h
+++ b/devices/JointTorqueControlDevice/include/BipedalLocomotion/JointTorqueControlDevice.h
@@ -71,6 +71,7 @@ struct MotorTorqueCurrentParameters
     double maxCurr; /**< maximum current */
     std::string frictionModel; ///< friction model
     double maxOutputFriction; /**< maximum output of the friction model */
+    double jointVelThreshold{0.0}; /**< joint velocity saturation */
 
     /**
      * Reset the parameters

--- a/devices/JointTorqueControlDevice/include/BipedalLocomotion/JointTorqueControlDevice.h
+++ b/devices/JointTorqueControlDevice/include/BipedalLocomotion/JointTorqueControlDevice.h
@@ -181,6 +181,7 @@ private:
     yarp::sig::Vector estimatedFrictionTorques;
     yarp::sig::Vector torqueIntegralErrors;
     std::string m_portPrefix{"/hijackingTrqCrl"}; /**< Default port prefix. */
+    BipedalLocomotion::YarpUtilities::VectorsCollectionServer m_vectorsCollectionServer; /**< Logger server. */
     std::vector<int> m_gearRatios;
     std::vector<std::string> m_axisNames;
     LowPassFilterParameters m_lowPassFilterParameters;
@@ -206,6 +207,7 @@ private:
         std::vector<double> m_frictionLogging;
         std::vector<double> m_currentLogging;
     } m_status;
+    bool m_publishEstimationVectorsCollection{false}; /**< True if the estimation is published. */
 
     bool openCalledCorrectly{false};
 
@@ -235,6 +237,12 @@ private:
     void readStatus();
     // bool loadGains(yarp::os::Searchable& config);
     bool loadFrictionParams(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler);
+
+    /**
+     * Published the status.
+     * This is a separate thread.
+     */
+    void publishStatus();
 
     /**
      * Load the coupling matrices from the group whose name

--- a/devices/JointTorqueControlDevice/include/BipedalLocomotion/JointTorqueControlDevice.h
+++ b/devices/JointTorqueControlDevice/include/BipedalLocomotion/JointTorqueControlDevice.h
@@ -181,7 +181,6 @@ private:
     yarp::sig::Vector estimatedFrictionTorques;
     yarp::sig::Vector torqueIntegralErrors;
     std::string m_portPrefix{"/hijackingTrqCrl"}; /**< Default port prefix. */
-    BipedalLocomotion::YarpUtilities::VectorsCollectionServer m_vectorsCollectionServer; /**< Logger server. */
     std::vector<int> m_gearRatios;
     std::vector<std::string> m_axisNames;
     LowPassFilterParameters m_lowPassFilterParameters;
@@ -238,12 +237,6 @@ private:
     bool loadFrictionParams(std::weak_ptr<const ParametersHandler::IParametersHandler> paramHandler);
 
     /**
-     * Published the status.
-     * This is a separate thread.
-     */
-    void publishStatus();
-
-    /**
      * Load the coupling matrices from the group whose name
      *      is specified in group_name
      *
@@ -256,7 +249,6 @@ private:
     std::mutex globalMutex; ///< mutex protecting control variables & proxy interface methods
 
     // Method that actually executes one control loop
-    std::chrono::nanoseconds timeOfLastControlLoop{std::chrono::nanoseconds::zero()};
     void controlLoop();
 
 

--- a/devices/JointTorqueControlDevice/src/JointTorqueControlDevice.cpp
+++ b/devices/JointTorqueControlDevice/src/JointTorqueControlDevice.cpp
@@ -1180,6 +1180,12 @@ bool JointTorqueControlDevice::open(yarp::os::Searchable& config)
     // run the thread
     if (m_publishEstimationVectorsCollection)
     {
+        if (!m_vectorsCollectionServer.initialize(params))
+        {
+            log()->error("{} Unable to configure the server.", logPrefix);
+            return false;
+        }
+
         m_vectorsCollectionServer.populateMetadata("motor_currents::desired", joint_list);
         m_vectorsCollectionServer.populateMetadata("friction_torques::estimated", joint_list);
         m_vectorsCollectionServer.finalizeMetadata();


### PR DESCRIPTION
This PR introduces some minor changes.
- Removed unused functions to clean up the code.
- Added saturation of friction torque when joint velocity exceeds a threshold.
- Removed the controlLoop time check since it is already handled by the YARP thread.
