### PR TITLE
Update version of tiny-process-lib and cvnp to fix usage with CMake 4 and numpy 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project are documented in this file.
 - Fix typos in tsid balancing torque control config files (https://github.com/ami-iit/bipedal-locomotion-framework/pull/926)
 - Add option `FRAMEWORK_COMPILE_MotorCurrentTrackingApplication` in cmake file to install correctly the application motor-current-tracking (https://github.com/ami-iit/bipedal-locomotion-framework/pull/937)
 - Fix resize vector in `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/951)
+- Fix build with CMake 4 and NumPy 2 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/955)
 
 ### Deprecated
 - Deprecate `FloatingBaseSystemKinematics` in favour of `FloatingBaseSystemVelocityKinematics` class in `ContinuousDynamicalSystem` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/950)

--- a/bindings/python/RobotInterface/CMakeLists.txt
+++ b/bindings/python/RobotInterface/CMakeLists.txt
@@ -30,8 +30,9 @@ if(TARGET BipedalLocomotion::RobotInterface
     include(FetchContent)
     FetchContent_Declare(
       cvnp
-      GIT_REPOSITORY https://github.com/pthom/cvnp
-      GIT_TAG        6aeac770ccff122abf82573da1ae03e18e7a4707
+      # Temporary use a fork until https://github.com/pthom/cvnp/pull/20 is merged
+      GIT_REPOSITORY https://github.com/traversaro/cvnp
+      GIT_TAG        08af05fe536daa692c75c15a437be900d3b3bc0f
       )
     FetchContent_MakeAvailable(cvnp)
     set(cvnp_target_link cvnp)

--- a/devices/YarpRobotLoggerDevice/CMakeLists.txt
+++ b/devices/YarpRobotLoggerDevice/CMakeLists.txt
@@ -11,7 +11,7 @@ if(FRAMEWORK_COMPILE_YarpRobotLoggerDevice)
     include(FetchContent)
     FetchContent_Declare(tiny_process_library
       GIT_REPOSITORY https://gitlab.com/eidheim/tiny-process-library.git
-      GIT_TAG v2.0.4)
+      GIT_TAG 8bbb5a211c5c9df8ee69301da9d22fb977b27dc1)
 
     if(NOT tiny_process_library_POPULATED)
       FetchContent_Populate(tiny_process_library)


### PR DESCRIPTION
I started updating `tiny-process-lib` and `cvnp` to fix the CMake 4.0.0 configuration failures, but while I doing so I reviewed cvnp history, and I noticed that there was some numpy 2.0 fixes (see https://github.com/pthom/cvnp/issues/17 and https://github.com/pthom/cvnp/commit/d2b808a0b6faeb025647973cb966e728e816d6d2) that were not included in blf. 

As the ICameraBridge Python bindings do not have test coverage, it is possible that there were already broken with numpy 2 and we did not realized as numpy 1 was still used in the environment where the ICameraBridge Python bindings is used, so updating cvnp to the latest version is probably beneficial also for numpy 2 support.

I had to use a checkout and not a tag for `tiny-process-lib` as there was no tag with the required fixes for CMake 4.0.0, but I opened an issue upstream at https://gitlab.com/eidheim/tiny-process-library/-/issues/60 to track this. For cvnp instead no tag is available, and I had to switch to use a fork temporary to include the required change (https://github.com/pthom/cvnp/pull/20), once that PR is merged we can switch back to use the upstream repo.



