### PR TITLE
Support compilation with casadi >= 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project are documented in this file.
 - Remove the possibility of setting the desired gravity direction and desired forward velocity separately in the `IK::GravityTrask` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/939)
 - Improve `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/948)
 - Add wrapping of IJointFault device in `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/954)
-- Increase minimum version of CMake supported to 3.22.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/956)
+- Increase minimum version of CMake supported to 3.18.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/956)
 
 ### Fixed
 - Fix outputs of `UnicycleTrajectoryGenerator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/916)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project are documented in this file.
 - Remove the possibility of setting the desired gravity direction and desired forward velocity separately in the `IK::GravityTrask` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/939)
 - Improve `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/948)
 - Add wrapping of IJointFault device in `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/954)
+- Increase minimum version of CMake supported to 3.22.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/956)
 
 ### Fixed
 - Fix outputs of `UnicycleTrajectoryGenerator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/916)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project are documented in this file.
 - Add option `FRAMEWORK_COMPILE_MotorCurrentTrackingApplication` in cmake file to install correctly the application motor-current-tracking (https://github.com/ami-iit/bipedal-locomotion-framework/pull/937)
 - Fix resize vector in `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/951)
 - Fix build with CMake 4 and NumPy 2 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/955)
+- Fix build with casadi >= 3.7.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/956)
 
 ### Deprecated
 - Deprecate `FloatingBaseSystemKinematics` in favour of `FloatingBaseSystemVelocityKinematics` class in `ContinuousDynamicalSystem` component (https://github.com/ami-iit/bipedal-locomotion-framework/pull/950)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-cmake_minimum_required(VERSION 3.22.0)
+cmake_minimum_required(VERSION 3.18.0)
 
 ## MAIN project
 project(BipedalLocomotionFramework

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license.
 
-cmake_minimum_required(VERSION 3.16.0)
+cmake_minimum_required(VERSION 3.22.0)
 
 ## MAIN project
 project(BipedalLocomotionFramework

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -45,7 +45,14 @@ blf_optional_find_package(casadi QUIET)
 checkandset_dependency(casadi)
 dependency_classifier(casadi IS_USED ${FRAMEWORK_USE_casadi} PUBLIC)
 add_compile_definitions(casadi_VERSION=${casadi_VERSION})
-
+# Support for both casadi < and >= 3.7.0
+if(casadi_FOUND AND TARGET casadi AND NOT casadi::casadi)
+  # This is equivalent to add_library(casadi::casadi ALIAS casadi), but compatible with 3.16
+  # Once the cmake_minimum_required is at least 3.18 (see https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4837),
+  # this can be changed to add_library(casadi::casadi ALIAS casadi)
+  add_library(casadi::casadi INTERFACE IMPORTED)
+  set_target_properties(casadi::casadi PROPERTIES INTERFACE_LINK_LIBRARIES casadi)
+endif()
 
 blf_optional_find_package(cppad QUIET)
 checkandset_dependency(cppad)

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -47,11 +47,8 @@ dependency_classifier(casadi IS_USED ${FRAMEWORK_USE_casadi} PUBLIC)
 add_compile_definitions(casadi_VERSION=${casadi_VERSION})
 # Support for both casadi < and >= 3.7.0
 if(casadi_FOUND AND TARGET casadi AND NOT casadi::casadi)
-  # This is equivalent to add_library(casadi::casadi ALIAS casadi), but compatible with 3.16
-  # Once the cmake_minimum_required is at least 3.18 (see https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4837),
-  # this can be changed to add_library(casadi::casadi ALIAS casadi)
-  add_library(casadi::casadi INTERFACE IMPORTED)
-  set_target_properties(casadi::casadi PROPERTIES INTERFACE_LINK_LIBRARIES casadi)
+  # This requires at least CMake 3.18 as minimum supported CMake version https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4837
+  add_library(casadi::casadi ALIAS casadi)
 endif()
 
 blf_optional_find_package(cppad QUIET)

--- a/src/Conversions/CMakeLists.txt
+++ b/src/Conversions/CMakeLists.txt
@@ -36,7 +36,7 @@ if (FRAMEWORK_COMPILE_CasadiConversions)
         NAME                   CasadiConversions
         IS_INTERFACE
         PUBLIC_HEADERS         include/BipedalLocomotion/Conversions/CasadiConversions.h
-        PUBLIC_LINK_LIBRARIES  Eigen3::Eigen BipedalLocomotion::CommonConversions casadi
+        PUBLIC_LINK_LIBRARIES  Eigen3::Eigen BipedalLocomotion::CommonConversions casadi::casadi
         INSTALLATION_FOLDER    Conversions
         )
 endif()

--- a/src/Planners/CMakeLists.txt
+++ b/src/Planners/CMakeLists.txt
@@ -13,7 +13,7 @@ if (FRAMEWORK_COMPILE_Planners)
                    ${H_PREFIX}/Spline.h ${H_PREFIX}/CubicSpline.h ${H_PREFIX}/QuinticSpline.h
     SOURCES src/ConvexHullHelper.cpp src/DCMPlanner.cpp  src/TimeVaryingDCMPlanner.cpp src/SwingFootPlanner.cpp
     PUBLIC_LINK_LIBRARIES Eigen3::Eigen BipedalLocomotion::ParametersHandler BipedalLocomotion::System BipedalLocomotion::Contacts BipedalLocomotion::Math
-    PRIVATE_LINK_LIBRARIES Qhull::qhull_r casadi iDynTree::idyntree-core BipedalLocomotion::Math BipedalLocomotion::TextLogging
+    PRIVATE_LINK_LIBRARIES Qhull::qhull_r casadi::casadi iDynTree::idyntree-core BipedalLocomotion::Math BipedalLocomotion::TextLogging
     INSTALLATION_FOLDER Planners)
 
   add_subdirectory(tests)

--- a/src/ReducedModelControllers/CMakeLists.txt
+++ b/src/ReducedModelControllers/CMakeLists.txt
@@ -11,7 +11,7 @@ if(FRAMEWORK_COMPILE_ReducedModelControllers)
     PUBLIC_HEADERS         ${H_PREFIX}/CentroidalMPC.h
     SOURCES                src/CentroidalMPC.cpp
     PUBLIC_LINK_LIBRARIES  Eigen3::Eigen BipedalLocomotion::ParametersHandler BipedalLocomotion::System BipedalLocomotion::Contacts
-    PRIVATE_LINK_LIBRARIES casadi BipedalLocomotion::Math BipedalLocomotion::TextLogging BipedalLocomotion::CasadiConversions
+    PRIVATE_LINK_LIBRARIES casadi::casadi BipedalLocomotion::Math BipedalLocomotion::TextLogging BipedalLocomotion::CasadiConversions
     SUBDIRECTORIES         tests)
 
 endif()


### PR DESCRIPTION
casadi 3.7.0 was recently released, with a breaking change from the CMake point of view, quoting from https://github.com/casadi/casadi/releases/tag/3.7.0 : 

> breaking The casadi cmake target now has a namespace. The preferred way of configuring your cmake is:
> ```cmake
> find_package(casadi CONFIG REQUIRED)
> 
> add_executable(casadi_demo casadi_demo.cpp)
> target_link_libraries(casadi_demo casadi::casadi)
> ```

This PR changes the CMake code to always link the `casadi::casadi` imported target. Support for casadi < 3.7.0 is mantained by appropriately defining an alias target named `casadi::casadi` for the `casadi` imported target.

As defining ALIAS for non-global imported targets requires at least CMake 3.18.0 (see  https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4837), and anyhow we dropped support for building with apt dependencies on Ubuntu 20.04 (that has CMake 3.16 by default) in the robotology-superbuild in https://github.com/robotology/robotology-superbuild/pull/1802 (and anyhow Ubuntu 20.04 is EOL in two months, see https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare), I raised the minimum version of CMake required to 3.22.0 (that is the CMake version available by default in apt on Ubuntu 22.04). 