### PR TITLE
Modify JointTorqueControlDevice to use motor temperature as additional input for PINN (friction estimation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented in this file.
 - Add wrapping of IJointFault device in `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/954)
 - Increase minimum version of CMake supported to 3.18.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/956)
 - Use resource finder to load friction models in `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/961)
+- Modify `JointTorqueControlDevice` to use motor temperature as additional input for PINN (friction estimation) (https://github.com/ami-iit/bipedal-locomotion-framework/pull/960)
 
 ### Fixed
 - Fix outputs of `UnicycleTrajectoryGenerator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/916)

--- a/devices/JointTorqueControlDevice/include/BipedalLocomotion/JointTorqueControlDevice.h
+++ b/devices/JointTorqueControlDevice/include/BipedalLocomotion/JointTorqueControlDevice.h
@@ -176,6 +176,7 @@ private:
     yarp::sig::Vector desiredMotorCurrents;
     yarp::sig::Vector measuredJointVelocities;
     yarp::sig::Vector measuredMotorVelocities;
+    yarp::sig::Vector measuredMotorTemperatures;
     yarp::sig::Vector measuredJointTorques;
     yarp::sig::Vector measuredJointPositions;
     yarp::sig::Vector measuredMotorPositions;

--- a/devices/JointTorqueControlDevice/include/BipedalLocomotion/PINNFrictionEstimator.h
+++ b/devices/JointTorqueControlDevice/include/BipedalLocomotion/PINNFrictionEstimator.h
@@ -49,11 +49,13 @@ public:
      * Estimate the joint friction starting from raw data
      * @param[in] inputMotorVelocity a double representing the motor velocity (rad/sec)
      * @param[in] inputJointVelocity a double representing the joint velocity (rad/sec)
+     * @param[in] inputMotorTemperature a double representing the motor temperature (Celsius)
      * @param[out] output a double representing the joint friction torque
      * @return true if the estimation is successful, false otherwise
      */
     bool estimate(double inputMotorVelocity,
                   double inputJointVelocity,
+                  double inputMotorTemperature,
                   double& output);
 
 

--- a/devices/JointTorqueControlDevice/include/BipedalLocomotion/PassThroughControlBoard.h
+++ b/devices/JointTorqueControlDevice/include/BipedalLocomotion/PassThroughControlBoard.h
@@ -27,6 +27,7 @@
 #include <yarp/dev/IVelocityControl.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IJointFault.h>
+#include <yarp/dev/IMotor.h>
 
 #include <BipedalLocomotion/TextLogging/Logger.h>
 
@@ -58,7 +59,8 @@ class BipedalLocomotion::PassThroughControlBoard : public yarp::dev::DeviceDrive
                                                    public yarp::dev::IAmplifierControl,
                                                    public yarp::dev::IControlCalibration,
                                                    public yarp::dev::IControlLimits,
-                                                   public yarp::dev::IJointFault
+                                                   public yarp::dev::IJointFault,
+                                                   public yarp::dev::IMotor
 {
 protected:
     yarp::dev::IEncodersTimed* proxyIEncodersTimed;
@@ -133,6 +135,10 @@ public:
     virtual bool getMotorEncoderSpeeds(double* spds);
     virtual bool getMotorEncoderAcceleration(int m, double* acc);
     virtual bool getMotorEncoderAccelerations(double* accs);
+    virtual bool getTemperatures(double *vals);
+    virtual bool getTemperature(int m, double* val);
+    virtual bool getTemperatureLimit(int m, double* temp);
+    virtual bool setTemperatureLimit(int m, const double temp);
 
     // POSITION CONTROL
     virtual bool positionMove(int j, double ref);

--- a/devices/JointTorqueControlDevice/src/PINNFrictionEstimator.cpp
+++ b/devices/JointTorqueControlDevice/src/PINNFrictionEstimator.cpp
@@ -30,6 +30,8 @@ struct PINNFrictionEstimator::Impl
 
     std::deque<float> jointVelocityBuffer;
     std::deque<float> motorVelocityBuffer;
+    double inputMotorTemperature;
+    bool alsoMotorTemperature = false;
 
     size_t historyLength;
 
@@ -89,11 +91,26 @@ bool PINNFrictionEstimator::initialize(const std::string& networkModelPath,
     // Get model input size
     std::vector<int64_t> inputShape = m_pimpl->session->GetInputTypeInfo(0).GetTensorTypeAndShapeInfo().GetShape();
 
+    // We need to understand if the model takes as input also the motor temperature
+    // To do this, since the model eventually takes only one sample of motor temperature
+    // we can check if the size of the input is divisible by 2:
+    // if it is divisible by 2, the model does not takes as input the motor temperature
+    // instead, if it is not divisible by 2, the model takes as input the motor temperature
+    // and we need to remove the last element of the input to compute the historyLength correctly
     const std::size_t inputCount = inputShape[1];
 
     int numberOfInputs = 2;
 
-    m_pimpl->historyLength = inputCount / numberOfInputs;
+    if (inputCount % numberOfInputs == 0)
+    {
+        // No need to remove any element, so historyLength is just inputCount / 2
+        m_pimpl->historyLength = inputCount / numberOfInputs;
+    }else
+    {
+        // If not divisible by 2, remove one element (assumed to be motor temperature) and calculate historyLength
+        m_pimpl->alsoMotorTemperature = true;
+        m_pimpl->historyLength = (inputCount - 1) / numberOfInputs;
+    }
 
     // format the input
     m_pimpl->structuredInput.rawData.resize(inputCount);
@@ -134,10 +151,12 @@ void PINNFrictionEstimator::resetEstimator()
 {
     m_pimpl->motorVelocityBuffer.clear();
     m_pimpl->jointVelocityBuffer.clear();
+    m_pimpl->inputMotorTemperature = 0.0;
 }
 
 bool PINNFrictionEstimator::estimate(double inputMotorVelocity,
                                      double inputJointVelocity,
+                                     double inputMotorTemperature,
                                      double& output)
 {
     if (m_pimpl->motorVelocityBuffer.size() == m_pimpl->historyLength)
@@ -162,12 +181,21 @@ bool PINNFrictionEstimator::estimate(double inputMotorVelocity,
     // Copy the joint positions and then the motor positions in the
     // structured input without emptying the buffer
     // Use iterators to copy the data to the vector
+    std::size_t index = 0;
     std::copy(m_pimpl->motorVelocityBuffer.cbegin(),
               m_pimpl->motorVelocityBuffer.cend(),
-              m_pimpl->structuredInput.rawData.begin());
-        std::copy(m_pimpl->jointVelocityBuffer.cbegin(),
+              m_pimpl->structuredInput.rawData.begin() + index);
+    index += m_pimpl->historyLength;
+    std::copy(m_pimpl->jointVelocityBuffer.cbegin(),
               m_pimpl->jointVelocityBuffer.cend(),
-              m_pimpl->structuredInput.rawData.begin() + m_pimpl->historyLength);
+              m_pimpl->structuredInput.rawData.begin() + index);
+    index += m_pimpl->historyLength;
+    if (m_pimpl->alsoMotorTemperature)
+    {
+        m_pimpl->structuredInput.rawData[index] = static_cast<float>(m_pimpl->inputMotorTemperature);
+        index += 1;
+
+    }
 
     // perform the inference
     const char* inputNames[] = {"input"};

--- a/devices/JointTorqueControlDevice/src/PINNFrictionEstimator.cpp
+++ b/devices/JointTorqueControlDevice/src/PINNFrictionEstimator.cpp
@@ -31,7 +31,7 @@ struct PINNFrictionEstimator::Impl
     std::deque<float> jointVelocityBuffer;
     std::deque<float> motorVelocityBuffer;
     double inputMotorTemperature;
-    bool alsoMotorTemperature = false;
+    bool includeMotorTemperatureAsInput = false;
 
     size_t historyLength;
 
@@ -108,7 +108,7 @@ bool PINNFrictionEstimator::initialize(const std::string& networkModelPath,
     }else
     {
         // If not divisible by 2, remove one element (assumed to be motor temperature) and calculate historyLength
-        m_pimpl->alsoMotorTemperature = true;
+        m_pimpl->includeMotorTemperatureAsInput = true;
         m_pimpl->historyLength = (inputCount - 1) / numberOfInputs;
     }
 
@@ -190,7 +190,7 @@ bool PINNFrictionEstimator::estimate(double inputMotorVelocity,
               m_pimpl->jointVelocityBuffer.cend(),
               m_pimpl->structuredInput.rawData.begin() + index);
     index += m_pimpl->historyLength;
-    if (m_pimpl->alsoMotorTemperature)
+    if (m_pimpl->includeMotorTemperatureAsInput)
     {
         m_pimpl->structuredInput.rawData[index] = static_cast<float>(m_pimpl->inputMotorTemperature);
         index += 1;

--- a/devices/JointTorqueControlDevice/src/PassThroughControlBoard.cpp
+++ b/devices/JointTorqueControlDevice/src/PassThroughControlBoard.cpp
@@ -358,6 +358,41 @@ bool PassThroughControlBoard::getMotorEncoderSpeeds(double* spds)
     return proxyIMotorEncoders->getMotorEncoderSpeeds(spds);
 }
 
+bool PassThroughControlBoard::getTemperatures(double *vals)
+{
+    if (!proxyIMotor)
+    {
+        return false;
+    }
+    return proxyIMotor->getTemperatures(vals);
+}
+
+bool PassThroughControlBoard::getTemperature(int m, double* val)
+{
+    if (!proxyIMotor)
+    {
+        return false;
+    }
+    return proxyIMotor->getTemperature(m, val);
+}
+
+bool PassThroughControlBoard::getTemperatureLimit(int m, double* temp)
+{
+    if (!proxyIMotor)
+    {
+        return false;
+    }
+    return proxyIMotor->getTemperatureLimit(m, temp);
+}
+
+bool PassThroughControlBoard::setTemperatureLimit(int m, const double temp)
+{
+    if (!proxyIMotor)
+    {
+        return false;
+    }
+    return proxyIMotor->setTemperatureLimit(m, temp);
+}
 bool PassThroughControlBoard::getMotorEncoderAcceleration(int m, double* acc)
 {
     if (!proxyIMotorEncoders)


### PR DESCRIPTION
Since we started using motor temperature as additional input for friction estimation via PINN (see for example https://github.com/ami-iit/element_sensorless-torque-control/issues/219 and https://github.com/ami-iit/element_sensorless-torque-control/issues/204), we need to modify the `JointTorqueControlDevice` accordingly. 

cc @isorrentino @GiulioRomualdi 