### PR TITLE
Only link pcl_common to PerceptionInterface instead of the full PCL_LIBRARIES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented in this file.
 - Add wrapping of IJointFault device in `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/954)
 - Increase minimum version of CMake supported to 3.18.0 (https://github.com/ami-iit/bipedal-locomotion-framework/pull/956)
 - Use resource finder to load friction models in `JointTorqueControlDevice` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/961)
+- Only link pcl_common to PerceptionInterface instead of the full PCL_LIBRARIES (https://github.com/ami-iit/bipedal-locomotion-framework/pull/962)
 
 ### Fixed
 - Fix outputs of `UnicycleTrajectoryGenerator` (https://github.com/ami-iit/bipedal-locomotion-framework/pull/916)

--- a/src/RobotInterface/CMakeLists.txt
+++ b/src/RobotInterface/CMakeLists.txt
@@ -21,6 +21,6 @@ add_bipedal_locomotion_library(
     NAME                   PerceptionInterface
     IS_INTERFACE
     PUBLIC_HEADERS         ${H_PREFIX}/ICameraBridge.h ${H_PREFIX}/IPointCloudBridge.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::System ${OpenCV_LIBS} ${PCL_LIBRARIES}
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::System ${OpenCV_LIBS} pcl_common
     INSTALLATION_FOLDER    RobotInterface)
 endif()

--- a/utilities/realsense-test/CMakeLists.txt
+++ b/utilities/realsense-test/CMakeLists.txt
@@ -7,7 +7,7 @@ if(FRAMEWORK_COMPILE_RealSenseTestApplication)
     NAME realsense-test
     SOURCES src/Main.cpp src/Module.cpp
     HEADERS include/BipedalLocomotion/RealSenseTest//Module.h
-    LINK_LIBRARIES   YARP::YARP_os BipedalLocomotion::PerceptionCapture BipedalLocomotion::ParametersHandlerYarpImplementation BipedalLocomotion::YarpUtilities)
+    LINK_LIBRARIES   YARP::YARP_os BipedalLocomotion::PerceptionCapture BipedalLocomotion::ParametersHandlerYarpImplementation BipedalLocomotion::YarpUtilities ${PCL_LIBRARIES})
 
   install_ini_files(${CMAKE_CURRENT_SOURCE_DIR}/config)
 endif()


### PR DESCRIPTION
Instead, we link the `realsense-test` (that uses the PCL visualizer) to the whole `${PCL_LIBRARIES}`.

See https://github.com/robotology/robotology-superbuild/pull/1842#issuecomment-2790076032 for the context of this PR.