### PR TITLE
Remove use of deprecated FrameGrabberInterfaces.h YARP header

### DIFF
--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
@@ -32,7 +32,6 @@
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 
 // YARP Camera Interfaces
-#include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/IRGBDSensor.h>
 
 // YARP Control Board Interfaces

--- a/src/RobotInterface/YarpImplementation/src/YarpCameraBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpCameraBridge.cpp
@@ -12,7 +12,7 @@
 
 // YARP Camera Interfaces
 #include <yarp/cv/Cv.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IRGBDSensor.h>
 
 // std


### PR DESCRIPTION
The header was deprecated since before YARP 3.9 (see https://github.com/robotology/gazebo-yarp-plugins/pull/698), and it was removed in YARP 3.12, so removing its use fix the compilation against YARP 3.12 .