### PR TITLE
Do not use FRAMEWORK_COMPILE_Math before it is defined

### DIFF
--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -165,14 +165,6 @@ framework_dependent_option(FRAMEWORK_COMPILE_Contact
   "Compile Contact libraries?" ON
   "FRAMEWORK_USE_manif;FRAMEWORK_USE_nlohmann_json" OFF)
 
-framework_dependent_option(FRAMEWORK_COMPILE_Planners
-  "Compile Planners libraries?" ON
-  "FRAMEWORK_USE_Qhull;FRAMEWORK_USE_casadi;FRAMEWORK_USE_manif;FRAMEWORK_COMPILE_Math;FRAMEWORK_COMPILE_Contact" OFF)
-
-framework_dependent_option(FRAMEWORK_COMPILE_ContactModels
-  "Compile ContactModels library?" ON
-  "" OFF)
-
 framework_dependent_option(FRAMEWORK_COMPILE_System
   "Compile System library?" ON
   "" OFF)
@@ -180,6 +172,14 @@ framework_dependent_option(FRAMEWORK_COMPILE_System
 framework_dependent_option(FRAMEWORK_COMPILE_Math
   "Compile Math library?" ON
   "FRAMEWORK_USE_manif;FRAMEWORK_COMPILE_System" OFF)
+
+framework_dependent_option(FRAMEWORK_COMPILE_Planners
+  "Compile Planners libraries?" ON
+  "FRAMEWORK_USE_Qhull;FRAMEWORK_USE_casadi;FRAMEWORK_USE_manif;FRAMEWORK_COMPILE_Math;FRAMEWORK_COMPILE_Contact" OFF)
+
+framework_dependent_option(FRAMEWORK_COMPILE_ContactModels
+  "Compile ContactModels library?" ON
+  "" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_Unicycle
     "Compile the Unicycle Planner library?" ON


### PR DESCRIPTION
Fix https://github.com/ami-iit/bipedal-locomotion-framework/issues/969 . 

The change https://github.com/ami-iit/bipedal-locomotion-framework/pull/910/commits/dda586d0edbb8002af994f545da32000a9db952a (part of https://github.com/ami-iit/bipedal-locomotion-framework/pull/910) moved the definition of `FRAMEWORK_COMPILE_Math` **after** the definition of `FRAMEWORK_COMPILE_Planners`, that uses `FRAMEWORK_COMPILE_Math`, resulting in a strange race condition of how this variables were set. This PR fixes this reordering the `framework_dependent_option` calls to ensure that the variables are always defined before their use.