### PR TITLE
Define FRAMEWORK_COMPILE_ManifConversions before FRAMEWORK_COMPILE_RobotDynamicsEstimator

### DIFF
--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -201,13 +201,13 @@ framework_dependent_option(FRAMEWORK_COMPILE_FloatingBaseEstimators
   "Compile FloatingBaseEstimators libraries?" ON
   "FRAMEWORK_USE_manif;FRAMEWORK_COMPILE_Contact" OFF)
 
-framework_dependent_option(FRAMEWORK_COMPILE_RobotDynamicsEstimator
-  "Compile RobotDynamicsEstimator libraries?" ON
-  "FRAMEWORK_COMPILE_System;FRAMEWORK_COMPILE_ManifConversions;FRAMEWORK_USE_manif;FRAMEWORK_USE_BayesFilters" OFF)
-
 framework_dependent_option(FRAMEWORK_COMPILE_ManifConversions
   "Compile manif Conversions libraries?" ON
   "FRAMEWORK_USE_manif" OFF)
+
+framework_dependent_option(FRAMEWORK_COMPILE_RobotDynamicsEstimator
+  "Compile RobotDynamicsEstimator libraries?" ON
+  "FRAMEWORK_COMPILE_System;FRAMEWORK_COMPILE_ManifConversions;FRAMEWORK_USE_manif;FRAMEWORK_USE_BayesFilters" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_matioCppConversions
   "Compile matioCpp Conversions libraries?" ON


### PR DESCRIPTION
Similar to https://github.com/ami-iit/bipedal-locomotion-framework/pull/973, `FRAMEWORK_COMPILE_ManifConversions` was used before being defined in the definition of `FRAMEWORK_COMPILE_RobotDynamicsEstimator`.