### PR TITLE
Bump version to 0.21.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.18.0)
 
 ## MAIN project
 project(BipedalLocomotionFramework
-  VERSION 0.21.100)
+  VERSION 0.21.1)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
This needs to be merged after:
* https://github.com/ami-iit/bipedal-locomotion-framework/pull/980
* https://github.com/ami-iit/bipedal-locomotion-framework/pull/979

As the public API is the same between 0.21.1, I did not added a new docs page, also to avoid the double commit required to switch `main.dox` to refer to the tag and revert it to refer to master, as in:
* https://github.com/ami-iit/bipedal-locomotion-framework/commit/9142af070bfab885caad4d7e58d8332c75b655db
* https://github.com/ami-iit/bipedal-locomotion-framework/commit/a0a5e9056717622ee55ee4321d0ca48ba9de0c4d