### PR TITLE
Added possibility to avoid logging code status, robot and cameras

### DIFF
--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
@@ -11,6 +11,7 @@ BSD-3-Clause license. -->
   <param name="port_prefix">/yarp-robot-logger</param>
   <param name="log_text">true</param>
   <param name="text_logging_subnames">("ergoCubGazeboV1/yarprobotinterface")</param>
+  <param name="log_code_status">true</param>
   <param name="maximum_admissible_time_step">1.0</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
@@ -4,7 +4,6 @@ BSD-3-Clause license. -->
 
 <?xml version="1.0" encoding="UTF-8" ?>
 <device  xmlns:xi="http://www.w3.org/2001/XInclude" name="yarp-robot-logger" type="YarpRobotLoggerDevice">
-  <param name="robot">ergocubSim</param>
   <param name="sampling_period_in_s">0.002</param>
   <param name="rgb_cameras_fps">(30)</param>
   <param name="video_codec_code">mp4v</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
@@ -77,11 +77,6 @@ BSD-3-Clause license. -->
     <param name="stream_joint_accelerations">true</param>
     <param name="stream_motor_temperature">false</param>
 
-    <group name="RemoteControlBoardRemapper">
-        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
-        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
-    </group>
-
     <group name="SixAxisForceTorqueSensors">
       <param name="sixaxis_forcetorque_sensors_list">("l_arm_ft", "r_arm_ft", "l_leg_ft", "l_foot_front_ft", "l_foot_rear_ft", "r_leg_ft", "r_foot_front_ft", "r_foot_rear_ft")</param>
     </group>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
@@ -75,7 +75,8 @@ BSD-3-Clause license. -->
     <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
-      <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
+        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
     </group>
 
     <group name="SixAxisForceTorqueSensors">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
@@ -13,6 +13,7 @@ BSD-3-Clause license. -->
   <param name="log_code_status">true</param>
   <param name="maximum_admissible_time_step">1.0</param>
   <param name="log_code_status">true</param>
+  <param name="log_cameras">true</param>
   <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
@@ -12,6 +12,8 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergoCubGazeboV1/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="maximum_admissible_time_step">1.0</param>
+  <param name="log_code_status">true</param>
+  <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>
   <group name="REAL_TIME_STREAMING">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
@@ -63,11 +63,6 @@ BSD-3-Clause license. -->
     <param name="stream_joint_accelerations">true</param>
     <param name="stream_motor_temperature">false</param>
 
-    <group name="RemoteControlBoardRemapper">
-        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
-        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
-    </group>
-
     <group name="SixAxisForceTorqueSensors">
       <param name="sixaxis_forcetorque_sensors_list">("l_arm_ft", "r_arm_ft", "l_leg_ft", "l_foot_front_ft", "l_foot_rear_ft", "r_leg_ft", "r_foot_front_ft", "r_foot_rear_ft")</param>
     </group>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
@@ -11,6 +11,7 @@ BSD-3-Clause license. -->
   <param name="port_prefix">/yarp-robot-logger</param>
   <param name="log_text">true</param>
   <param name="text_logging_subnames">("ergoCubGazeboV1/yarprobotinterface")</param>
+  <param name="log_code_status">true</param>
   <param name="maximum_admissible_time_step">1.0</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
@@ -4,7 +4,6 @@ BSD-3-Clause license. -->
 
 <?xml version="1.0" encoding="UTF-8" ?>
 <device  xmlns:xi="http://www.w3.org/2001/XInclude" name="yarp-robot-logger" type="YarpRobotLoggerDevice">
-  <param name="robot">ergocubSim</param>
   <param name="sampling_period_in_s">0.002</param>
   <param name="rgb_cameras_fps">(30)</param>
   <param name="video_codec_code">mp4v</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
@@ -12,6 +12,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergoCubGazeboV1/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="maximum_admissible_time_step">1.0</param>
+  <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>
   <group name="REAL_TIME_STREAMING">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
@@ -62,7 +62,8 @@ BSD-3-Clause license. -->
     <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
-      <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
+        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
     </group>
 
     <group name="SixAxisForceTorqueSensors">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
@@ -12,6 +12,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergoCubGazeboV1/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="maximum_admissible_time_step">1.0</param>
+  <param name="log_cameras">true</param>
   <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
@@ -65,11 +65,6 @@ BSD-3-Clause license. -->
     <param name="stream_joint_accelerations">true</param>
     <param name="stream_motor_temperature">false</param>
 
-    <group name="RemoteControlBoardRemapper">
-        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
-        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw", "l_thumb_add", "l_thumb_oc", "l_index_oc", "l_middle_oc", "l_ring_pinky_oc", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "r_thumb_add", "r_thumb_oc", "r_index_oc", "r_middle_oc", "r_ring_pinky_oc", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
-    </group>
-
     <group name="SixAxisForceTorqueSensors">
       <param name="sixaxis_forcetorque_sensors_list">(l_arm_ft, r_arm_ft, l_foot_front_ft, l_foot_rear_ft, r_foot_front_ft, r_foot_rear_ft, l_leg_ft, r_leg_ft)</param>
     </group>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
@@ -64,7 +64,8 @@ BSD-3-Clause license. -->
     <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
-      <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw", "l_thumb_add", "l_thumb_oc", "l_index_oc", "l_middle_oc", "l_ring_pinky_oc", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "r_thumb_add", "r_thumb_oc", "r_index_oc", "r_middle_oc", "r_ring_pinky_oc", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
+        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_roll", "l_wrist_pitch",  "l_wrist_yaw", "l_thumb_add", "l_thumb_oc", "l_index_oc", "l_middle_oc", "l_ring_pinky_oc", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_roll", "r_wrist_pitch",  "r_wrist_yaw", "r_thumb_add", "r_thumb_oc", "r_index_oc", "r_middle_oc", "r_ring_pinky_oc", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
     </group>
 
     <group name="SixAxisForceTorqueSensors">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
@@ -20,6 +20,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergocub-torso/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh ergocub@10.0.2.2" "ssh ergocub@10.0.2.3")</param>
+  <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>
   <group name="REAL_TIME_STREAMING">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
@@ -20,6 +20,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergocub-torso/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh ergocub@10.0.2.2" "ssh ergocub@10.0.2.3")</param>
+  <param name="log_cameras">true</param>
   <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
@@ -19,6 +19,7 @@ BSD-3-Clause license. -->
   <param name="port_prefix">/yarp-robot-logger</param>
   <param name="log_text">true</param>
   <param name="text_logging_subnames">("ergocub-torso/yarprobotinterface")</param>
+  <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh ergocub@10.0.2.2" "ssh ergocub@10.0.2.3")</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
@@ -4,7 +4,6 @@ BSD-3-Clause license. -->
 
 <?xml version="1.0" encoding="UTF-8" ?>
 <device  xmlns:xi="http://www.w3.org/2001/XInclude" name="yarp-robot-logger" type="YarpRobotLoggerDevice">
-  <param name="robot">ergocub</param>
   <param name="sampling_period_in_s">0.01</param>
 
   <param name="rgb_cameras_fps">()</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
@@ -99,7 +99,8 @@ BSD-3-Clause license. -->
     <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
-      <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_pitch", "l_wrist_roll", "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_pitch", "r_wrist_roll", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
+        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_pitch", "l_wrist_roll", "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_pitch", "r_wrist_roll", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
     </group>
 
     <group name="SixAxisForceTorqueSensors">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
@@ -20,6 +20,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergoCubSN001/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh ergocub@10.0.2.2" "ssh ergocub@10.0.2.3")</param>
+  <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>
   <group name="REAL_TIME_STREAMING">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
@@ -100,11 +100,6 @@ BSD-3-Clause license. -->
     <param name="stream_joint_accelerations">true</param>
     <param name="stream_motor_temperature">false</param>
 
-    <group name="RemoteControlBoardRemapper">
-        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
-        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_pitch", "l_wrist_roll", "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_pitch", "r_wrist_roll", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
-    </group>
-
     <group name="SixAxisForceTorqueSensors">
       <param name="sixaxis_forcetorque_sensors_list">(l_foot_front_ft, l_foot_rear_ft, r_foot_front_ft, r_foot_rear_ft, l_leg_ft, r_leg_ft, r_arm_ft, l_arm_ft)</param>
     </group>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
@@ -4,7 +4,6 @@ BSD-3-Clause license. -->
 
 <?xml version="1.0" encoding="UTF-8" ?>
 <device  xmlns:xi="http://www.w3.org/2001/XInclude" name="yarp-robot-logger" type="YarpRobotLoggerDevice">
-  <param name="robot">ergocub</param>
   <param name="sampling_period_in_s">0.01</param>
 
   <param name="rgb_cameras_fps">(20)</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
@@ -20,6 +20,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergoCubSN001/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh ergocub@10.0.2.2" "ssh ergocub@10.0.2.3")</param>
+  <param name="log_cameras">true</param>
   <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
@@ -19,6 +19,7 @@ BSD-3-Clause license. -->
   <param name="port_prefix">/yarp-robot-logger</param>
   <param name="log_text">true</param>
   <param name="text_logging_subnames">("ergoCubSN001/yarprobotinterface")</param>
+  <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh ergocub@10.0.2.2" "ssh ergocub@10.0.2.3")</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
@@ -93,11 +93,6 @@ BSD-3-Clause license. -->
     <param name="stream_joint_accelerations">true</param>
     <param name="stream_motor_temperature">false</param>
 
-    <group name="RemoteControlBoardRemapper">
-        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
-        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_pitch", "l_wrist_roll", "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_pitch", "r_wrist_roll", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
-    </group>
-
     <group name="SixAxisForceTorqueSensors">
       <param name="sixaxis_forcetorque_sensors_list">(l_foot_front_ft, l_foot_rear_ft, r_foot_front_ft, r_foot_rear_ft, l_leg_ft, r_leg_ft, r_arm_ft, l_arm_ft)</param>
     </group>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
@@ -20,6 +20,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergocub-torso/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh ergocub@10.0.2.22" "ssh ergocub@10.0.2.23")</param>
+  <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>
   <group name="REAL_TIME_STREAMING">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
@@ -4,7 +4,6 @@ BSD-3-Clause license. -->
 
 <?xml version="1.0" encoding="UTF-8" ?>
 <device  xmlns:xi="http://www.w3.org/2001/XInclude" name="yarp-robot-logger" type="YarpRobotLoggerDevice">
-  <param name="robot">ergocub</param>
   <param name="sampling_period_in_s">0.01</param>
 
   <param name="rgb_cameras_fps">(20)</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
@@ -92,7 +92,8 @@ BSD-3-Clause license. -->
     <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
-      <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_pitch", "l_wrist_roll", "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_pitch", "r_wrist_roll", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
+        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "camera_tilt", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_pitch", "l_wrist_roll", "l_wrist_yaw",  "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_pitch", "r_wrist_roll", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
     </group>
 
     <group name="SixAxisForceTorqueSensors">

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
@@ -20,6 +20,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergocub-torso/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh ergocub@10.0.2.22" "ssh ergocub@10.0.2.23")</param>
+  <param name="log_cameras">true</param>
   <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
@@ -19,6 +19,7 @@ BSD-3-Clause license. -->
   <param name="port_prefix">/yarp-robot-logger</param>
   <param name="log_text">true</param>
   <param name="text_logging_subnames">("ergocub-torso/yarprobotinterface")</param>
+  <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh ergocub@10.0.2.22" "ssh ergocub@10.0.2.23")</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
@@ -9,6 +9,7 @@ BSD-3-Clause license. -->
   <param name="maximum_admissible_time_step">1.0</param>
   <param name="log_text">true</param>
   <param name="log_code_status">true</param>
+  <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>
   <group name="REAL_TIME_STREAMING">

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
@@ -9,6 +9,7 @@ BSD-3-Clause license. -->
   <param name="maximum_admissible_time_step">1.0</param>
   <param name="log_text">true</param>
   <param name="log_code_status">true</param>
+  <param name="log_cameras">true</param>
   <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
@@ -9,6 +9,7 @@ BSD-3-Clause license. -->
   <param name="port_prefix">/yarp-robot-logger</param>
   <param name="maximum_admissible_time_step">1.0</param>
   <param name="log_text">true</param>
+  <param name="log_code_status">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>
   <group name="REAL_TIME_STREAMING">

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
@@ -48,11 +48,6 @@ BSD-3-Clause license. -->
     <param name="stream_joint_accelerations">true</param>
     <param name="stream_motor_temperature">false</param>
 
-    <group name="RemoteControlBoardRemapper">
-        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
-        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
-    </group>
-
     <group name="SixAxisForceTorqueSensors">
       <param name="sixaxis_forcetorque_sensors_list">("left_front_ft_client", "left_rear_ft_client", "right_front_ft_client", "right_rear_ft_client", "right_arm_ft_client", "left_arm_ft_client", "right_upper_leg_ft_client")</param>
     </group>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
@@ -47,7 +47,8 @@ BSD-3-Clause license. -->
     <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
-      <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+        <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
+        <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
     </group>
 
     <group name="SixAxisForceTorqueSensors">

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
@@ -4,7 +4,6 @@ BSD-3-Clause license. -->
 
 <?xml version="1.0" encoding="UTF-8" ?>
 <device  xmlns:xi="http://www.w3.org/2001/XInclude" name="yarp-robot-logger" type="YarpRobotLoggerDevice">
-  <param name="robot">icubSim</param>
   <param name="sampling_period_in_s">0.01</param>
   <param name="port_prefix">/yarp-robot-logger</param>
   <param name="maximum_admissible_time_step">1.0</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -4,7 +4,6 @@ BSD-3-Clause license. -->
 
 <?xml version="1.0" encoding="UTF-8" ?>
 <device  xmlns:xi="http://www.w3.org/2001/XInclude" name="yarp-robot-logger" type="YarpRobotLoggerDevice">
-  <param name="robot">icub</param>
   <param name="sampling_period_in_s">0.01</param>
   <param name="rgb_cameras_fps">(30)</param>
   <param name="video_codec_code">mp4v</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -12,6 +12,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("icub-head/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh icub@10.0.0.2" "ssh icub@10.0.0.150")</param>
+  <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>
   <group name="REAL_TIME_STREAMING">

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -57,11 +57,6 @@ BSD-3-Clause license. -->
     <param name="stream_joint_accelerations">true</param>
     <param name="stream_motor_temperature">false</param>
 
-    <group name="RemoteControlBoardRemapper">
-      <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
-      <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_prosup", "l_wrist_pitch",  "l_wrist_yaw", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_prosup", "r_wrist_pitch", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
-    </group>
-
     <group name="SixAxisForceTorqueSensors">
       <param name="sixaxis_forcetorque_sensors_list">(l_arm_ft, r_arm_ft, l_leg_ft, l_foot_front_ft, l_foot_rear_ft, r_leg_ft, r_foot_front_ft, r_foot_rear_ft)</param>
     </group>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -12,6 +12,7 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("icub-head/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh icub@10.0.0.2" "ssh icub@10.0.0.150")</param>
+  <param name="log_cameras">true</param>
   <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -58,6 +58,7 @@ BSD-3-Clause license. -->
     <param name="stream_motor_temperature">false</param>
 
     <group name="RemoteControlBoardRemapper">
+      <!-- The list of joints here is optional and needed to specify the order. If it is not specified, the order used to configure the remotecontrolboardremapper device will be used. -->
       <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_prosup", "l_wrist_pitch",  "l_wrist_yaw", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "r_wrist_prosup", "r_wrist_pitch", "r_wrist_yaw", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
     </group>
 

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -11,6 +11,7 @@ BSD-3-Clause license. -->
   <param name="port_prefix">/yarp-robot-logger</param>
   <param name="log_text">true</param>
   <param name="text_logging_subnames">("icub-head/yarprobotinterface")</param>
+  <param name="log_code_status">true</param>
   <param name="code_status_cmd_prefixes">("ssh icub@10.0.0.2" "ssh icub@10.0.0.150")</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -35,8 +35,6 @@ BSD-3-Clause license. -->
   </group>
 
 
-  </group>
-
   <group name="RobotCameraBridge">
       <param name="stream_cameras">true</param>
       <group name="Cameras">

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -195,6 +195,11 @@ private:
                     std::size_t vectorSize,
                     const std::vector<std::string>& metadata = {});
 
+    bool populateCamerasData(const std::string& logPrefix,
+                             std::shared_ptr<const ParametersHandler::IParametersHandler> params,
+                             const std::string& fpsParamName,
+                             const std::vector<std::string>& cameraNames);
+
     bool hasSubstring(const std::string& str, const std::vector<std::string>& substrings) const;
     void recordVideo(const std::string& cameraName, VideoWriter& writer);
     void saveCodeStatus(const std::string& logPrefix, const std::string& fileName) const;

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -178,6 +178,7 @@ private:
     bool m_streamTemperatureSensors{false};
     bool m_logText{true};
     bool m_logCodeStatus{true};
+    bool m_logCameras{true};
     bool m_logRobot{true};
     std::vector<std::string> m_textLoggingSubnames;
     std::vector<std::string> m_codeStatusCmdPrefixes;

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -176,6 +176,7 @@ private:
     bool m_streamFTSensors{false};
     bool m_streamTemperatureSensors{false};
     bool m_logText{true};
+    bool m_logCodeStatus{true};
     std::vector<std::string> m_textLoggingSubnames;
     std::vector<std::string> m_codeStatusCmdPrefixes;
 
@@ -195,6 +196,7 @@ private:
 
     bool hasSubstring(const std::string& str, const std::vector<std::string>& substrings) const;
     void recordVideo(const std::string& cameraName, VideoWriter& writer);
+    void saveCodeStatus(const std::string& logPrefix, const std::string& fileName) const;
     void unpackIMU(Eigen::Ref<const analog_sensor_t> signal,
                    Eigen::Ref<accelerometer_t> accelerometer,
                    Eigen::Ref<gyro_t> gyro,

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -210,7 +210,7 @@ private:
                    Eigen::Ref<gyro_t> gyro,
                    Eigen::Ref<orientation_t> orientation);
     bool setupRobotSensorBridge(std::weak_ptr<const ParametersHandler::IParametersHandler> params);
-    bool setupRobotCameraBridge(std::shared_ptr<const ParametersHandler::IParametersHandler> params);
+    bool setupRobotCameraBridge(std::weak_ptr<const ParametersHandler::IParametersHandler> params);
     bool setupTelemetry(std::weak_ptr<const ParametersHandler::IParametersHandler> params,
                         const double& devicePeriod);
     bool setupExogenousInputs(std::weak_ptr<const ParametersHandler::IParametersHandler> params);

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -177,6 +177,7 @@ private:
     bool m_streamTemperatureSensors{false};
     bool m_logText{true};
     bool m_logCodeStatus{true};
+    bool m_logRobot{true};
     std::vector<std::string> m_textLoggingSubnames;
     std::vector<std::string> m_codeStatusCmdPrefixes;
 

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -156,6 +156,7 @@ private:
     std::unordered_set<std::string> m_textLogsStoredInManager;
     std::thread m_lookForNewLogsThread;
 
+    std::vector<std::string> m_jointList;
     Eigen::VectorXd m_jointSensorBuffer;
     ft_t m_ftBuffer;
     gyro_t m_gyroBuffer;
@@ -208,7 +209,7 @@ private:
                    Eigen::Ref<gyro_t> gyro,
                    Eigen::Ref<orientation_t> orientation);
     bool setupRobotSensorBridge(std::weak_ptr<const ParametersHandler::IParametersHandler> params);
-    bool setupRobotCameraBridge(std::weak_ptr<const ParametersHandler::IParametersHandler> params);
+    bool setupRobotCameraBridge(std::shared_ptr<const ParametersHandler::IParametersHandler> params);
     bool setupTelemetry(std::weak_ptr<const ParametersHandler::IParametersHandler> params,
                         const double& devicePeriod);
     bool setupExogenousInputs(std::weak_ptr<const ParametersHandler::IParametersHandler> params);
@@ -221,6 +222,10 @@ private:
     bool createFramesFolder(std::shared_ptr<VideoWriter::ImageSaver> imageSaver,
                             const std::string& camera,
                             const std::string& imageType);
+    bool startLogging();
+    bool prepareRobotLogging();
+    bool prepareCameraLogging();
+    bool prepareRTStreaming();
 
     const std::string treeDelim = "::";
 

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -457,6 +457,8 @@ bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
         return false;
     }
 
+    log()->info("{} Logger configuration completed.", logPrefix);
+
     return true;
 }
 
@@ -1173,6 +1175,7 @@ bool YarpRobotLoggerDevice::attachAll(const yarp::dev::PolyDriverList& poly)
 
     if (ok)
     {
+        log()->info("{} Attach completed. Starting logger.", logPrefix);
         return start();
     }
 
@@ -1955,6 +1958,8 @@ void YarpRobotLoggerDevice::run()
 
     m_previousTimestamp = t;
     m_firstRun = false;
+
+    yInfoThrottle(5) << "Logging data..";
 }
 
 bool YarpRobotLoggerDevice::saveCallback(const std::string& fileName,

--- a/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
+++ b/devices/YarpRobotLoggerDevice/src/YarpRobotLoggerDevice.cpp
@@ -129,6 +129,8 @@ YarpRobotLoggerDevice::~YarpRobotLoggerDevice() = default;
 bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
 {
 
+    bool needsAttach = false;
+
     constexpr auto logPrefix = "[YarpRobotLoggerDevice::open]";
     auto params = std::make_shared<ParametersHandler::YarpImplementation>(config);
 
@@ -217,6 +219,11 @@ bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
                     m_logRobot);
     }
 
+    if (m_logRobot)
+    {
+        needsAttach = true;
+    }
+
     if (!this->setupRobotSensorBridge(params->getGroup("RobotSensorBridge")))
     {
         return false;
@@ -273,6 +280,7 @@ bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
                              fourccCodecUrl);
                 return false;
             }
+            needsAttach = true;
         }
     } else
     {
@@ -310,6 +318,13 @@ bool YarpRobotLoggerDevice::open(yarp::os::Searchable& config)
     }
 
     log()->info("{} Logger configuration completed.", logPrefix);
+    if (needsAttach)
+    {
+        log()->info("{} Waiting for the attach phases before starting the logging.", logPrefix);
+    } else
+    {
+        return startLogging();
+    }
 
     return true;
 }

--- a/devices/YarpRobotLoggerDevice/tests/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/tests/yarp-robot-logger.xml
@@ -34,10 +34,6 @@ BSD-3-Clause license. -->
     <param name="stream_motor_PWM">false</param>
     <param name="stream_temperatures">false</param>
 
-    <group name="RemoteControlBoardRemapper">
-      <param name="joints_list">("sim_joint_1","sim_joint_2","sim_joint_3","sim_joint_4")</param>
-    </group>
-
     <group name="InertialSensors">
       <param name="accelerometers_list">(sim_imu_sensor)</param>
       <param name="gyroscopes_list">(sim_imu_sensor)</param>

--- a/devices/YarpRobotLoggerDevice/tests/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/tests/yarp-robot-logger.xml
@@ -8,7 +8,9 @@ BSD-3-Clause license. -->
   <param name="sampling_period_in_s">0.01</param>
 
   <param name="port_prefix">/yarp-robot-logger</param>
+  <param name="log_text">true</param>
   <param name="text_logging_subnames">("ergocub-torso/yarprobotinterface")</param>
+  <param name="log_code_status">true</param>
   <param name="maximum_admissible_time_step">1.0</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>

--- a/devices/YarpRobotLoggerDevice/tests/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/tests/yarp-robot-logger.xml
@@ -11,6 +11,8 @@ BSD-3-Clause license. -->
   <param name="text_logging_subnames">("ergocub-torso/yarprobotinterface")</param>
   <param name="log_code_status">true</param>
   <param name="maximum_admissible_time_step">1.0</param>
+  <param name="log_cameras">true</param>
+  <param name="log_robot_data">true</param>
 
   <param name="enable_real_time_logging" extern-name="enable_real_time_logging">false</param>
   <group name="REAL_TIME_STREAMING">

--- a/devices/YarpRobotLoggerDevice/tests/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/tests/yarp-robot-logger.xml
@@ -4,7 +4,6 @@ BSD-3-Clause license. -->
 
 <?xml version="1.0" encoding="UTF-8" ?>
 <device  xmlns:xi="http://www.w3.org/2001/XInclude" name="yarp-robot-logger" type="YarpRobotLoggerDevice">
-  <param name="robot">fakebot</param>
   <param name="sampling_period_in_s">0.01</param>
 
   <param name="port_prefix">/yarp-robot-logger</param>


### PR DESCRIPTION
I have touched the logger code to allow the following:
- avoid logging the code status
- avoid logging the cameras with a single parameter
- avoid logging the robot.

The last point has been the trickiest, since most of the preparation work was done in the ``attachAll`` method. When not using the robot nor the cameras, it would be possible not to have any device attached. Hence, I had to make sure that the logger was properly started even when the ``attachAll`` method was not called.

I also took the occasion to introduce a few auxiliary methods to make the opening and preparation phases cleaner
