### PR TITLE
Allow logging text exogenous signals

### DIFF
--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1/yarp-robot-logger.xml
@@ -34,6 +34,7 @@ BSD-3-Clause license. -->
   <group name="ExogenousSignals">
     <param name="vectors_collection_exogenous_inputs">("Walking")</param>
     <param name="vectors_exogenous_inputs">()</param>
+    <param name="string_exogenous_inputs">()</param>
 
     <!--group name="Balancing">
       <param name="local">"/yarp-robot-logger/exogenous_signals/balancing:i"</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubGazeboV1_1/yarp-robot-logger.xml
@@ -33,6 +33,7 @@ BSD-3-Clause license. -->
   <group name="ExogenousSignals">
     <param name="vectors_collection_exogenous_inputs">("Walking", "CurrentControl")</param>
     <param name="vectors_exogenous_inputs">()</param>
+    <param name="string_exogenous_inputs">()</param>
 
     <group name="Walking">
       <param name="local">"/yarp-robot-logger/exogenous_signals/walking"</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN000/yarp-robot-logger.xml
@@ -41,6 +41,7 @@ BSD-3-Clause license. -->
   <group name="ExogenousSignals">
     <param name="vectors_collection_exogenous_inputs">("Walking")</param>
     <param name="vectors_exogenous_inputs">()</param>
+    <param name="string_exogenous_inputs">()</param>
 
     <group name="Walking">
       <param name="local">"/yarp-robot-logger/exogenous_signals/walking"</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN001/yarp-robot-logger.xml
@@ -41,6 +41,7 @@ BSD-3-Clause license. -->
   <group name="ExogenousSignals">
     <param name="vectors_collection_exogenous_inputs">("Walking", "GridTracking","cmw", "Balancing", "CurrentControl")</param>
     <param name="vectors_exogenous_inputs">()</param>
+    <param name="string_exogenous_inputs">()</param>
 
     <group name="Walking">
       <param name="local">"/yarp-robot-logger/exogenous_signals/walking"</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/ergoCubSN002/yarp-robot-logger.xml
@@ -41,6 +41,7 @@ BSD-3-Clause license. -->
   <group name="ExogenousSignals">
     <param name="vectors_collection_exogenous_inputs">("Walking", "GridTracking","cmw")</param>
     <param name="vectors_exogenous_inputs">()</param>
+    <param name="string_exogenous_inputs">()</param>
 
     <group name="Walking">
       <param name="local">"/yarp-robot-logger/exogenous_signals/walking"</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGazeboV3/yarp-robot-logger.xml
@@ -30,6 +30,7 @@ BSD-3-Clause license. -->
   <group name="ExogenousSignals">
     <param name="vectors_collection_exogenous_inputs">("Walking")</param>
     <param name="vectors_exogenous_inputs">()</param>
+    <param name="string_exogenous_inputs">()</param>
 
     <group name="Walking">
       <param name="local">"/yarp-robot-logger/exogenous_signals/walking"</param>

--- a/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
+++ b/devices/YarpRobotLoggerDevice/app/robots/iCubGenova09/yarp-robot-logger.xml
@@ -33,6 +33,7 @@ BSD-3-Clause license. -->
   <group name="ExogenousSignals">
     <param name="vectors_collection_exogenous_inputs">("Walking")</param>
     <param name="vectors_exogenous_inputs">()</param>
+    <param name="string_exogenous_inputs">()</param>
 
     <group name="Walking">
       <param name="local">"/yarp-robot-logger/exogenous_signals/walking"</param>

--- a/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
+++ b/devices/YarpRobotLoggerDevice/include/BipedalLocomotion/YarpRobotLoggerDevice.h
@@ -116,6 +116,7 @@ private:
 
     std::unordered_map<std::string, VectorsCollectionSignal> m_vectorsCollectionSignals;
     std::unordered_map<std::string, ExogenousSignal<yarp::sig::Vector>> m_vectorSignals;
+    std::unordered_map<std::string, ExogenousSignal<yarp::os::Bottle>> m_stringSignals;
 
     std::unordered_set<std::string> m_exogenousPortsStoredInManager;
     std::atomic<bool> m_lookForNewExogenousSignalIsRunning{false};


### PR DESCRIPTION
For our data acquisitions, we had the need of storing short strings coming from a yarp port.

I assume that this data would not be streamed for the real time logging, also considering that it relies on ``VectorsCollection`` (that does not handle strings)