### PR TITLE
Use np.inf instead of np.infty in test_TSID.py for NumPy 2.0 compatibility

### DIFF
--- a/bindings/python/TSID/tests/test_TSID.py
+++ b/bindings/python/TSID/tests/test_TSID.py
@@ -336,8 +336,8 @@ def test_variable_feasible_region_task():
 
     # Test infinite bounds (correct case)
     C = np.array([[1, 2], [0, 1]])
-    l = np.array([-np.infty, 0])
-    u = np.array([1, np.infty])
+    l = np.array([-np.inf, 0])
+    u = np.array([1, np.inf])
     assert task_2.set_feasible_region(C, l, u)
 
     # Test inconsistency with the variable size = 2 (incorrect case)


### PR DESCRIPTION
Without this, the test fail on numpy 2 with error:

~~~
E           AttributeError: `np.infty` was removed in the NumPy 2.0 release. Use `np.inf` instead.
~~~

`np.inf` is available also on numpy 1.21 (see https://numpy.org/doc/1.21/reference/constants.html#numpy.inf), that is the version of numpy available via apt on Ubuntu 22.04 (see https://repology.org/project/python%3Anumpy/versions), so this does not remove any compatibility for any older numpy version that it still make sense to support.