### PR TITLE
Remove version constraint for Eigen3 package for Eigen3 5.0.0 compat

### DIFF
--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -20,8 +20,8 @@ endif()
 find_package(iDynTree 12.2.1 REQUIRED)
 dependency_classifier(iDynTree MINIMUM_VERSION 12.2.1 IS_USED TRUE PUBLIC)
 
-find_package(Eigen3 3.2.92 REQUIRED)
-dependency_classifier(Eigen3 MINIMUM_VERSION 3.2.92 IS_USED TRUE PUBLIC)
+find_package(Eigen3 REQUIRED)
+dependency_classifier(Eigen3 IS_USED TRUE PUBLIC)
 
 find_package(spdlog 1.5.0 REQUIRED)
 dependency_classifier(spdlog MINIMUM_VERSION 1.5.0 IS_USED TRUE PUBLIC)


### PR DESCRIPTION
Without this fix, configuration against Eigen 5 fails with:

~~~
CMake Error at cmake/OsqpEigenDependencies.cmake:14 (find_package):
  Could not find a configuration file for package "Eigen3" that is compatible
  with requested version "3.2.92".

  The following configuration files were considered but not accepted:

    /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/share/eigen3/cmake/Eigen3Config.cmake, version: 5.0.0

Call Stack (most recent call first):
~~~

see https://gitlab.com/libeigen/eigen/-/issues/2972 for more details. As Eigen 3.3 was released in 2016, I think we are fine in just asking for Eigen without checking the version of it.

xref: https://github.com/conda-forge/eigen-feedstock/pull/47
xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/pull/1903