### PR TITLE
Add bindings for VectorsCollection Client and Server

### DIFF
--- a/bindings/python/YarpUtilities/src/VectorsCollection.cpp
+++ b/bindings/python/YarpUtilities/src/VectorsCollection.cpp
@@ -45,7 +45,12 @@ void CreateVectorsCollectionServer(pybind11::module& module)
                 Eigen::Ref<const Eigen::VectorXd> data) -> bool {
                  return impl.populateData(key, data);
              })
-        .def("prepare_data", &VectorsCollectionServer::prepareData);
+        .def("prepare_data", &VectorsCollectionServer::prepareData)
+        .def("get_metadata", &VectorsCollectionServer::getMetadata)
+        .def("get_metadata_incremental",
+             &VectorsCollectionServer::getMetadataIncremental,
+             py::arg("from_version"))
+        .def("are_metadata_ready", &VectorsCollectionServer::areMetadataReady);
 }
 
 void CreateVectorsCollectionClient(pybind11::module& module)
@@ -86,7 +91,8 @@ void CreateVectorsCollectionClient(pybind11::module& module)
                  }
                  VectorsCollection collection = *collectionPtr;
                  return collection;
-             });
+             })
+        .def("is_new_metadata_available", &VectorsCollectionClient::isNewMetadataAvailable);
 }
 
 void CreateVectorsCollectionMetadata(pybind11::module& module)


### PR DESCRIPTION
This PR adds some missing python bindings for the methods introduced in https://github.com/ami-iit/bipedal-locomotion-framework/pull/1008