### PR TITLE
RobotInterface: add device parameter in constructRemoteControlBoardRemapper

### DIFF
--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -60,6 +60,7 @@ struct PolyDriverDescriptor
  * | `remote_control_boards` | `vector<string>` | List of the remote control boards associated to the joints |    Yes    |
  * |       `robot_name`      |     `string`     |                      Name of the robot                     |    Yes    |
  * |      `local_prefix`     |     `string`     |    Prefix of the local port (e.g. the application name)    |    Yes    |
+ * |       `device`         |     `string`     | Name of the device to open. (Default value `remotecontrolboardremapper`) |     No    |
  * @return A PolyDriverDescriptor. If one of the parameters is missing an invalid PolyDriverDescriptor is returned.
  */
 PolyDriverDescriptor constructRemoteControlBoardRemapper(

--- a/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
@@ -60,9 +60,18 @@ PolyDriverDescriptor BipedalLocomotion::RobotInterface::constructRemoteControlBo
         return PolyDriverDescriptor();
     }
 
+    // Get optional device parameter, default to "remotecontrolboardremapper"
+    std::string deviceName = "remotecontrolboardremapper";
+    std::string deviceNameFromParam;
+    ok = ptr->getParameter("device", deviceNameFromParam);
+    if (ok)
+    {
+        deviceName = deviceNameFromParam;
+    }
+
     // open the remotecontrolboardremepper YARP device
     yarp::os::Property options;
-    options.put("device", "remotecontrolboardremapper");
+    options.put("device", deviceName);
 
     options.addGroup("axesNames");
     yarp::os::Bottle& bottle = options.findGroup("axesNames").addList();


### PR DESCRIPTION
This is useful to permit to instantiate a device different from `remotecontrolboardremapper` in `BipedalLocomotion::RobotInterface::constructRemoteControlBoardRemapper`, for example the `dr_controlboard_remapper_nwc_yarp` device added in https://github.com/gbionics/dinrail/pull/12 .