### PR TITLE
Implement DinRailRobotControl and bindings

### DIFF
--- a/bindings/python/RobotInterface/CMakeLists.txt
+++ b/bindings/python/RobotInterface/CMakeLists.txt
@@ -27,6 +27,23 @@ if(TARGET BipedalLocomotion::RobotInterface AND TARGET BipedalLocomotion::RobotI
 endif()
 
 if(TARGET BipedalLocomotion::RobotInterface
+   AND TARGET BipedalLocomotion::RobotInterfaceYarpImplementation
+   AND TARGET BipedalLocomotion::RobotInterfaceDinRailImplementation)
+
+  set(H_PREFIX include/BipedalLocomotion/bindings/RobotInterface)
+
+  add_bipedal_locomotion_python_module(
+    NAME RobotInterfaceDinRailImplementationBindings
+    SOURCES src/DinRailRobotControl.cpp src/DinRailModule.cpp
+    HEADERS ${H_PREFIX}/DinRailRobotControl.h ${H_PREFIX}/DinRailModule.h
+    LINK_LIBRARIES BipedalLocomotion::RobotInterface
+                   BipedalLocomotion::RobotInterfaceYarpImplementation
+                   BipedalLocomotion::RobotInterfaceDinRailImplementation
+    )
+
+endif()
+
+if(TARGET BipedalLocomotion::RobotInterface
   AND TARGET BipedalLocomotion::CameraInterface
     AND TARGET BipedalLocomotion::RobotInterfaceYarpImplementation
   AND TARGET BipedalLocomotion::CameraInterfaceYarpImplementation)

--- a/bindings/python/RobotInterface/include/BipedalLocomotion/bindings/RobotInterface/DinRailModule.h
+++ b/bindings/python/RobotInterface/include/BipedalLocomotion/bindings/RobotInterface/DinRailModule.h
@@ -1,0 +1,26 @@
+/**
+ * @file DinRailModule.h
+ * @authors Giulio Romualdi
+ * @copyright Generative Bionics S.R.L. This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_ROBOT_INTERFACE_DINRAIL_MODULE_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_ROBOT_INTERFACE_DINRAIL_MODULE_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace RobotInterface
+{
+
+void CreateDinRailModule(pybind11::module& module);
+
+} // namespace RobotInterface
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_ROBOT_INTERFACE_DINRAIL_MODULE_H

--- a/bindings/python/RobotInterface/include/BipedalLocomotion/bindings/RobotInterface/DinRailRobotControl.h
+++ b/bindings/python/RobotInterface/include/BipedalLocomotion/bindings/RobotInterface/DinRailRobotControl.h
@@ -1,0 +1,26 @@
+/**
+ * @file DinRailRobotControl.h
+ * @authors Giulio Romualdi
+ * @copyright Generative Bionics S.R.L. This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_ROBOT_INTERFACE_DINRAIL_ROBOT_CONTROL_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_ROBOT_INTERFACE_DINRAIL_ROBOT_CONTROL_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace RobotInterface
+{
+
+void CreateDinRailRobotControl(pybind11::module& module);
+
+} // namespace RobotInterface
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_ROBOT_INTERFACE_DINRAIL_ROBOT_CONTROL_H

--- a/bindings/python/RobotInterface/src/DinRailModule.cpp
+++ b/bindings/python/RobotInterface/src/DinRailModule.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file DinRailModule.cpp
+ * @authors Giulio Romualdi
+ * @copyright Generative Bionics S.R.L. This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include <BipedalLocomotion/bindings/RobotInterface/DinRailModule.h>
+#include <BipedalLocomotion/bindings/RobotInterface/DinRailRobotControl.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace RobotInterface
+{
+
+void CreateDinRailModule(pybind11::module& module)
+{
+    CreateDinRailRobotControl(module);
+}
+
+} // namespace RobotInterface
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/RobotInterface/src/DinRailRobotControl.cpp
+++ b/bindings/python/RobotInterface/src/DinRailRobotControl.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file DinRailRobotControl.cpp
+ * @authors Giulio Romualdi
+ * @copyright Generative Bionics S.R.L. This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/RobotInterface/DinRailRobotControl.h>
+#include <BipedalLocomotion/RobotInterface/YarpRobotControl.h>
+#include <BipedalLocomotion/bindings/RobotInterface/DinRailRobotControl.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace RobotInterface
+{
+
+void CreateDinRailRobotControl(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+    using namespace BipedalLocomotion::ParametersHandler;
+    using namespace BipedalLocomotion::RobotInterface;
+
+    py::class_<DinRailRobotControl, YarpRobotControl>(module, "DinRailRobotControl")
+        .def(py::init())
+        .def(
+            "initialize",
+            [](DinRailRobotControl& impl, std::shared_ptr<IParametersHandler> handler) -> bool {
+                return impl.initialize(handler);
+            },
+            py::arg("handler"))
+        .def("set_driver", &DinRailRobotControl::setDriver, py::arg("driver"))
+        .def("set_impedance_set_points", //
+             &DinRailRobotControl::setImpedanceSetPoints,
+             py::arg("position"),
+             py::arg("velocity"),
+             py::arg("torque"),
+             py::arg("stiffness"),
+             py::arg("damping"));
+}
+
+} // namespace RobotInterface
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/bipedal_locomotion_framework.cpp.in
+++ b/bindings/python/bipedal_locomotion_framework.cpp.in
@@ -62,6 +62,10 @@
 #include <BipedalLocomotion/bindings/RobotInterface/YarpModule.h>
 @endcmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::RobotInterfaceYarpImplementation
 
+@cmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::RobotInterfaceYarpImplementation && BipedalLocomotion::RobotInterfaceDinRailImplementation
+#include <BipedalLocomotion/bindings/RobotInterface/DinRailModule.h>
+@endcmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::RobotInterfaceYarpImplementation && BipedalLocomotion::RobotInterfaceDinRailImplementation
+
 @cmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::CameraInterface && BipedalLocomotion::RobotInterfaceYarpImplementation && BipedalLocomotion::CameraInterfaceYarpImplementation
 #include <BipedalLocomotion/bindings/RobotInterface/CameraModule.h>
 @endcmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::CameraInterface && BipedalLocomotion::RobotInterfaceYarpImplementation && BipedalLocomotion::CameraInterfaceYarpImplementation
@@ -183,6 +187,10 @@ PYBIND11_MODULE(bindings, m)
     @cmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::RobotInterfaceYarpImplementation
     bindings::RobotInterface::CreateYarpModule(robotInterfaceModule);
     @endcmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::RobotInterfaceYarpImplementation
+
+    @cmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::RobotInterfaceYarpImplementation && BipedalLocomotion::RobotInterfaceDinRailImplementation
+    bindings::RobotInterface::CreateDinRailModule(robotInterfaceModule);
+    @endcmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::RobotInterfaceYarpImplementation && BipedalLocomotion::RobotInterfaceDinRailImplementation
 
     @cmakeiftarget BipedalLocomotion::RobotInterface && BipedalLocomotion::CameraInterface && BipedalLocomotion::RobotInterfaceYarpImplementation && BipedalLocomotion::CameraInterfaceYarpImplementation
     bindings::RobotInterface::CreateCameraModule(robotInterfaceModule);

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -121,6 +121,10 @@ checkandset_dependency(onnxruntime)
 blf_optional_find_package(trintrin QUIET)
 checkandset_dependency(trintrin)
 
+blf_optional_find_package(dinrail QUIET)
+checkandset_dependency(dinrail)
+dependency_classifier(dinrail IS_USED ${FRAMEWORK_USE_dinrail} PUBLIC)
+
 ##########################      Test-related options       ##############################
 
 # MemoryAllocationMonitor require glibc >= 2.35
@@ -155,6 +159,10 @@ framework_dependent_option(FRAMEWORK_COMPILE_RosImplementation
 framework_dependent_option(FRAMEWORK_COMPILE_YarpImplementation
   "Compile All the YARP implementations?" ON
   "FRAMEWORK_COMPILE_YarpUtilities" OFF)
+
+framework_dependent_option(FRAMEWORK_COMPILE_DinRailImplementation
+  "Compile the DinRail implementation of RobotInterface?" ON
+  "FRAMEWORK_COMPILE_YarpImplementation;FRAMEWORK_USE_dinrail" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_TomlImplementation
   "Compile All the TOML implementations?" ON

--- a/src/RobotInterface/CMakeLists.txt
+++ b/src/RobotInterface/CMakeLists.txt
@@ -12,7 +12,7 @@ add_bipedal_locomotion_library(
     PUBLIC_HEADERS         ${H_PREFIX}/ISensorBridge.h ${H_PREFIX}/IRobotControl.h ${H_PREFIX}/JointType.h
     PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler Eigen3::Eigen
     PRIVATE_LINK_LIBRARIES BipedalLocomotion::TextLogging
-    SUBDIRECTORIES         YarpImplementation tests)
+    SUBDIRECTORIES         YarpImplementation DinRailImplementation tests)
 endif()
 
 if (FRAMEWORK_COMPILE_Camera)

--- a/src/RobotInterface/DinRailImplementation/CMakeLists.txt
+++ b/src/RobotInterface/DinRailImplementation/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (C) Generative Bionics S.R.L. All rights reserved.
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license.
+
+if(FRAMEWORK_COMPILE_DinRailImplementation)
+
+  add_bipedal_locomotion_library(
+    NAME                   RobotInterfaceDinRailImplementation
+    SOURCES                src/DinRailRobotControl.cpp
+    PUBLIC_HEADERS         include/BipedalLocomotion/RobotInterface/DinRailRobotControl.h
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::RobotInterfaceYarpImplementation
+                           dinrail::dinrail
+                           YARP::YARP_dev
+    PRIVATE_LINK_LIBRARIES BipedalLocomotion::TextLogging
+    INSTALLATION_FOLDER    RobotInterface)
+
+endif()

--- a/src/RobotInterface/DinRailImplementation/include/BipedalLocomotion/RobotInterface/DinRailRobotControl.h
+++ b/src/RobotInterface/DinRailImplementation/include/BipedalLocomotion/RobotInterface/DinRailRobotControl.h
@@ -87,8 +87,10 @@ public:
      * for all joints.  Position and velocity inputs are expected in SI units
      * (radians and radians per second); they are converted to degrees /
      * degrees-per-second internally for revolute joints before being forwarded
-     * to the underlying device.  Torque, stiffness and damping are forwarded
-     * as-is (Nm, Nm/rad, Nms/rad respectively).
+     * to the underlying device.  For revolute joints, position and velocity are
+     * converted from radians to degrees, stiffness from Nm/rad to Nm/deg, and
+     * damping from Nms/rad to Nms/deg (all multiplied by π/180).
+     * Torque feedforward is always forwarded in Nm without conversion.
      *
      * @param pos      Position setpoints for all controlled joints [rad].
      * @param vel      Velocity setpoints for all controlled joints [rad/s].

--- a/src/RobotInterface/DinRailImplementation/include/BipedalLocomotion/RobotInterface/DinRailRobotControl.h
+++ b/src/RobotInterface/DinRailImplementation/include/BipedalLocomotion/RobotInterface/DinRailRobotControl.h
@@ -92,15 +92,15 @@ public:
      * damping from Nms/rad to Nms/deg (all multiplied by π/180).
      * Torque feedforward is always forwarded in Nm without conversion.
      *
-     * @param pos      Position setpoints for all controlled joints [rad].
-     * @param vel      Velocity setpoints for all controlled joints [rad/s].
-     * @param torque   Torque feedforward setpoints for all controlled joints [Nm].
+     * @param position Position setpoints for all controlled joints [rad].
+     * @param velocity Velocity setpoints for all controlled joints [rad/s].
+     * @param torque Torque feedforward setpoints for all controlled joints [Nm].
      * @param stiffness Stiffness setpoints for all controlled joints [Nm/rad].
-     * @param damping  Damping setpoints for all controlled joints [Nms/rad].
+     * @param damping Damping setpoints for all controlled joints [Nms/rad].
      * @return True on success, false otherwise.
      */
-    bool setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> pos,
-                               Eigen::Ref<const Eigen::VectorXd> vel,
+    bool setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> position,
+                               Eigen::Ref<const Eigen::VectorXd> velocity,
                                Eigen::Ref<const Eigen::VectorXd> torque,
                                Eigen::Ref<const Eigen::VectorXd> stiffness,
                                Eigen::Ref<const Eigen::VectorXd> damping);

--- a/src/RobotInterface/DinRailImplementation/include/BipedalLocomotion/RobotInterface/DinRailRobotControl.h
+++ b/src/RobotInterface/DinRailImplementation/include/BipedalLocomotion/RobotInterface/DinRailRobotControl.h
@@ -1,0 +1,110 @@
+/**
+ * @file DinRailRobotControl.h
+ * @authors Giulio Romualdi
+ * @copyright Generative Bionics S.R.L. This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_DINRAIL_ROBOT_CONTROL_H
+#define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_DINRAIL_ROBOT_CONTROL_H
+
+#include <memory>
+
+#include <Eigen/Dense>
+
+#include <yarp/dev/PolyDriver.h>
+
+#include <BipedalLocomotion/RobotInterface/YarpRobotControl.h>
+
+namespace BipedalLocomotion
+{
+namespace RobotInterface
+{
+
+/**
+ * DinRailRobotControl extends YarpRobotControl with support for the
+ * dinrail::IImpedanceAllSetPointsControl interface exposed by DinRailControlBoardNWCYarp.
+ *
+ * All standard control modes (Position, PositionDirect, Velocity, Torque, PWM, Current)
+ * are inherited from YarpRobotControl without modification.  The new method
+ * setImpedanceSetPoints() additionally allows setting all impedance control
+ * setpoints (position, velocity, torque feedforward, stiffness, damping) in a
+ * single call, as defined by the MIT-mode / IImpedanceAllSetPointsControl interface.
+ *
+ * @note The dinrail::IImpedanceAllSetPointsControl interface uses the same units
+ *       as the corresponding YARP interfaces (degrees / degrees per second for
+ *       revolute joints).  setImpedanceSetPoints() therefore performs the same
+ *       radian-to-degree conversion for position and velocity of revolute joints
+ *       that YarpRobotControl applies to the other control modes.
+ *       Torque, stiffness and damping are forwarded without unit conversion.
+ *
+ * @warning SensorBridge: since DinRailControlBoardNWCYarp already exposes the
+ *          standard YARP encoder and sensor interfaces, YarpSensorBridge can be
+ *          used directly and no separate DinRail sensor bridge is required.
+ */
+class DinRailRobotControl : public YarpRobotControl
+{
+    struct Impl;
+    std::unique_ptr<Impl> m_pimpl;
+
+public:
+    /**
+     * Constructor.
+     */
+    DinRailRobotControl();
+
+    /**
+     * Destructor.
+     */
+    ~DinRailRobotControl() override;
+
+    /**
+     * Initialize the interface.
+     * @param handler pointer to a parameter handler interface.
+     * @note Accepts the same parameters as YarpRobotControl::initialize().
+     * @return True/False in case of success/failure.
+     */
+    bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler) override;
+
+    /**
+     * Set the driver required to control the robot.
+     *
+     * In addition to all YARP interfaces acquired by YarpRobotControl, this
+     * method also acquires the dinrail::IImpedanceAllSetPointsControl interface
+     * from the device.  The device is expected to be an instance of
+     * DinRailControlBoardNWCYarp (or a compatible device that exposes
+     * dinrail::IImpedanceAllSetPointsControl).
+     *
+     * @param robotDevice device used to control the robot.
+     * @return True/False in case of success/failure.
+     */
+    bool setDriver(std::shared_ptr<yarp::dev::PolyDriver> robotDevice);
+
+    /**
+     * Set all impedance control setpoints (MIT mode) for all controlled joints.
+     *
+     * This method maps to dinrail::IImpedanceAllSetPointsControl::setSetPoints()
+     * for all joints.  Position and velocity inputs are expected in SI units
+     * (radians and radians per second); they are converted to degrees /
+     * degrees-per-second internally for revolute joints before being forwarded
+     * to the underlying device.  Torque, stiffness and damping are forwarded
+     * as-is (Nm, Nm/rad, Nms/rad respectively).
+     *
+     * @param pos      Position setpoints for all controlled joints [rad].
+     * @param vel      Velocity setpoints for all controlled joints [rad/s].
+     * @param torque   Torque feedforward setpoints for all controlled joints [Nm].
+     * @param stiffness Stiffness setpoints for all controlled joints [Nm/rad].
+     * @param damping  Damping setpoints for all controlled joints [Nms/rad].
+     * @return True on success, false otherwise.
+     */
+    bool setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> pos,
+                               Eigen::Ref<const Eigen::VectorXd> vel,
+                               Eigen::Ref<const Eigen::VectorXd> torque,
+                               Eigen::Ref<const Eigen::VectorXd> stiffness,
+                               Eigen::Ref<const Eigen::VectorXd> damping);
+};
+
+} // namespace RobotInterface
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_DINRAIL_ROBOT_CONTROL_H

--- a/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
+++ b/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
@@ -38,6 +38,8 @@ struct DinRailRobotControl::Impl
      */
     std::vector<double> posBuffer;
     std::vector<double> velBuffer;
+    std::vector<double> stiffnessBuffer;
+    std::vector<double> dampingBuffer;
 };
 
 DinRailRobotControl::DinRailRobotControl()
@@ -103,12 +105,14 @@ bool DinRailRobotControl::setDriver(std::shared_ptr<yarp::dev::PolyDriver> robot
     // Pre-allocate conversion buffers.
     m_pimpl->posBuffer.resize(m_pimpl->actuatedDOFs);
     m_pimpl->velBuffer.resize(m_pimpl->actuatedDOFs);
+    m_pimpl->stiffnessBuffer.resize(m_pimpl->actuatedDOFs);
+    m_pimpl->dampingBuffer.resize(m_pimpl->actuatedDOFs);
 
     return true;
 }
 
-bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> pos,
-                                                Eigen::Ref<const Eigen::VectorXd> vel,
+bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> position,
+                                                Eigen::Ref<const Eigen::VectorXd> velocity,
                                                 Eigen::Ref<const Eigen::VectorXd> torque,
                                                 Eigen::Ref<const Eigen::VectorXd> stiffness,
                                                 Eigen::Ref<const Eigen::VectorXd> damping)
@@ -124,15 +128,15 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
 
     const auto n = static_cast<Eigen::Index>(m_pimpl->actuatedDOFs);
 
-    if (pos.size() != n || vel.size() != n || torque.size() != n || stiffness.size() != n
+    if (position.size() != n || velocity.size() != n || torque.size() != n || stiffness.size() != n
         || damping.size() != n)
     {
         log()->error("{} Input vector size mismatch. Expected {} for all inputs. "
-                     "Got pos={}, vel={}, torque={}, stiffness={}, damping={}.",
+                     "Got position={}, velocity={}, torque={}, stiffness={}, damping={}.",
                      errorPrefix,
                      n,
-                     pos.size(),
-                     vel.size(),
+                     position.size(),
+                     velocity.size(),
                      torque.size(),
                      stiffness.size(),
                      damping.size());
@@ -140,31 +144,37 @@ bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd
     }
 
     // Convert position (rad→deg) and velocity (rad/s→deg/s) for revolute joints.
-    // Prismatic joints are forwarded in SI units (metres, m/s) without conversion.
+    // Stiffness (Nm/rad→Nm/deg) and damping (Nms/rad→Nms/deg) are also scaled by
+    // the same factor for revolute joints: 1 Nm/rad = (π/180) Nm/deg.
+    // Prismatic joints are forwarded in SI units without conversion.
     constexpr double radToDeg = 180.0 / M_PI;
+    constexpr double degToRad = M_PI / 180.0; // scaling factor for stiffness/damping
     for (std::size_t i = 0; i < m_pimpl->actuatedDOFs; ++i)
     {
         if (m_pimpl->jointTypes[i] == JointType::REVOLUTE)
         {
-            m_pimpl->posBuffer[i] = radToDeg * pos[static_cast<Eigen::Index>(i)];
-            m_pimpl->velBuffer[i] = radToDeg * vel[static_cast<Eigen::Index>(i)];
+            m_pimpl->posBuffer[i] = radToDeg * position[static_cast<Eigen::Index>(i)];
+            m_pimpl->velBuffer[i] = radToDeg * velocity[static_cast<Eigen::Index>(i)];
+            m_pimpl->stiffnessBuffer[i] = degToRad * stiffness[static_cast<Eigen::Index>(i)];
+            m_pimpl->dampingBuffer[i] = degToRad * damping[static_cast<Eigen::Index>(i)];
         } else
         {
-            m_pimpl->posBuffer[i] = pos[static_cast<Eigen::Index>(i)];
-            m_pimpl->velBuffer[i] = vel[static_cast<Eigen::Index>(i)];
+            m_pimpl->posBuffer[i] = position[static_cast<Eigen::Index>(i)];
+            m_pimpl->velBuffer[i] = velocity[static_cast<Eigen::Index>(i)];
+            m_pimpl->stiffnessBuffer[i] = stiffness[static_cast<Eigen::Index>(i)];
+            m_pimpl->dampingBuffer[i] = damping[static_cast<Eigen::Index>(i)];
         }
     }
 
-    // Build non-owning VectorProxy views over the converted buffers and the
-    // Eigen inputs that require no conversion (torque, stiffness, damping).
+    // Build non-owning VectorProxy views over the converted buffers.
     // VectorProxy<const double>::Ref can be constructed from any contiguous
-    // container with .data() and .size(), which includes both std::vector and
+    // container with .data() and .size(), which includes std::vector and
     // Eigen::Ref<const Eigen::VectorXd>.
-    if (!m_pimpl->impedanceInterface->setSetPoints(m_pimpl->posBuffer, //
+    if (!m_pimpl->impedanceInterface->setSetPoints(m_pimpl->posBuffer,
                                                    m_pimpl->velBuffer,
                                                    torque,
-                                                   stiffness,
-                                                   damping))
+                                                   m_pimpl->stiffnessBuffer,
+                                                   m_pimpl->dampingBuffer))
     {
         log()->error("{} Failed to set impedance setpoints.", errorPrefix);
         return false;

--- a/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
+++ b/src/RobotInterface/DinRailImplementation/src/DinRailRobotControl.cpp
@@ -1,0 +1,174 @@
+/**
+ * @file DinRailRobotControl.cpp
+ * @authors Giulio Romualdi
+ * @copyright Generative Bionics S.R.L. This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include <yarp/dev/IAxisInfo.h>
+#include <yarp/dev/PolyDriver.h>
+
+#include <dinrail/IImpedanceAllSetPointsControl.h>
+#include <dinrail/VectorProxy.h>
+
+#include <BipedalLocomotion/RobotInterface/DinRailRobotControl.h>
+#include <BipedalLocomotion/RobotInterface/JointType.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+using namespace BipedalLocomotion::RobotInterface;
+
+struct DinRailRobotControl::Impl
+{
+    /** Pointer to the DinRail-specific impedance set-point interface. */
+    dinrail::IImpedanceAllSetPointsControl* impedanceInterface{nullptr};
+
+    /** Joint type list (revolute vs prismatic), populated in setDriver(). */
+    std::vector<JointType> jointTypes;
+
+    /** Number of actuated degrees of freedom. */
+    std::size_t actuatedDOFs{0};
+
+    /**
+     * Scratch buffers used in setImpedanceSetPoints() to avoid per-call heap
+     * allocations in the control loop.
+     */
+    std::vector<double> posBuffer;
+    std::vector<double> velBuffer;
+};
+
+DinRailRobotControl::DinRailRobotControl()
+    : m_pimpl(std::make_unique<Impl>())
+{
+}
+
+DinRailRobotControl::~DinRailRobotControl() = default;
+
+bool DinRailRobotControl::initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler)
+{
+    // Delegate entirely to the parent; no additional parameters are needed.
+    return YarpRobotControl::initialize(handler);
+}
+
+bool DinRailRobotControl::setDriver(std::shared_ptr<yarp::dev::PolyDriver> robotDevice)
+{
+    constexpr auto errorPrefix = "[DinRailRobotControl::setDriver]";
+
+    // First set up all standard YARP interfaces via the parent implementation.
+    if (!YarpRobotControl::setDriver(robotDevice))
+    {
+        log()->error("{} Failed to initialize the base YarpRobotControl.", errorPrefix);
+        return false;
+    }
+
+    // Additionally acquire the DinRail-specific impedance interface.
+    if (!robotDevice->view(m_pimpl->impedanceInterface) || m_pimpl->impedanceInterface == nullptr)
+    {
+        log()->error("{} Cannot load the dinrail::IImpedanceAllSetPointsControl interface. "
+                     "Make sure the device is a DinRailControlBoardNWCYarp.",
+                     errorPrefix);
+        return false;
+    }
+
+    // Cache the joint types so that setImpedanceSetPoints() can perform the
+    // correct radian-to-degree conversion without querying the device each call.
+    yarp::dev::IAxisInfo* axisInfo{nullptr};
+    if (!robotDevice->view(axisInfo) || axisInfo == nullptr)
+    {
+        log()->error("{} Cannot load the yarp::dev::IAxisInfo interface.", errorPrefix);
+        return false;
+    }
+
+    int dofs{0};
+    if (!axisInfo->getAxes(&dofs) || dofs <= 0)
+    {
+        log()->error("{} Cannot retrieve the number of actuated DoFs.", errorPrefix);
+        return false;
+    }
+    m_pimpl->actuatedDOFs = static_cast<std::size_t>(dofs);
+
+    m_pimpl->jointTypes.resize(m_pimpl->actuatedDOFs);
+    for (int i = 0; i < dofs; ++i)
+    {
+        yarp::dev::JointTypeEnum jType;
+        axisInfo->getJointType(i, jType);
+        m_pimpl->jointTypes[i] = (jType == yarp::dev::VOCAB_JOINTTYPE_REVOLUTE)
+                                     ? JointType::REVOLUTE
+                                     : JointType::PRISMATIC;
+    }
+
+    // Pre-allocate conversion buffers.
+    m_pimpl->posBuffer.resize(m_pimpl->actuatedDOFs);
+    m_pimpl->velBuffer.resize(m_pimpl->actuatedDOFs);
+
+    return true;
+}
+
+bool DinRailRobotControl::setImpedanceSetPoints(Eigen::Ref<const Eigen::VectorXd> pos,
+                                                Eigen::Ref<const Eigen::VectorXd> vel,
+                                                Eigen::Ref<const Eigen::VectorXd> torque,
+                                                Eigen::Ref<const Eigen::VectorXd> stiffness,
+                                                Eigen::Ref<const Eigen::VectorXd> damping)
+{
+    constexpr auto errorPrefix = "[DinRailRobotControl::setImpedanceSetPoints]";
+
+    if (m_pimpl->impedanceInterface == nullptr)
+    {
+        log()->error("{} The impedance interface is not ready. Did you call setDriver()?",
+                     errorPrefix);
+        return false;
+    }
+
+    const auto n = static_cast<Eigen::Index>(m_pimpl->actuatedDOFs);
+
+    if (pos.size() != n || vel.size() != n || torque.size() != n || stiffness.size() != n
+        || damping.size() != n)
+    {
+        log()->error("{} Input vector size mismatch. Expected {} for all inputs. "
+                     "Got pos={}, vel={}, torque={}, stiffness={}, damping={}.",
+                     errorPrefix,
+                     n,
+                     pos.size(),
+                     vel.size(),
+                     torque.size(),
+                     stiffness.size(),
+                     damping.size());
+        return false;
+    }
+
+    // Convert position (rad→deg) and velocity (rad/s→deg/s) for revolute joints.
+    // Prismatic joints are forwarded in SI units (metres, m/s) without conversion.
+    constexpr double radToDeg = 180.0 / M_PI;
+    for (std::size_t i = 0; i < m_pimpl->actuatedDOFs; ++i)
+    {
+        if (m_pimpl->jointTypes[i] == JointType::REVOLUTE)
+        {
+            m_pimpl->posBuffer[i] = radToDeg * pos[static_cast<Eigen::Index>(i)];
+            m_pimpl->velBuffer[i] = radToDeg * vel[static_cast<Eigen::Index>(i)];
+        } else
+        {
+            m_pimpl->posBuffer[i] = pos[static_cast<Eigen::Index>(i)];
+            m_pimpl->velBuffer[i] = vel[static_cast<Eigen::Index>(i)];
+        }
+    }
+
+    // Build non-owning VectorProxy views over the converted buffers and the
+    // Eigen inputs that require no conversion (torque, stiffness, damping).
+    // VectorProxy<const double>::Ref can be constructed from any contiguous
+    // container with .data() and .size(), which includes both std::vector and
+    // Eigen::Ref<const Eigen::VectorXd>.
+    if (!m_pimpl->impedanceInterface->setSetPoints(m_pimpl->posBuffer, //
+                                                   m_pimpl->velBuffer,
+                                                   torque,
+                                                   stiffness,
+                                                   damping))
+    {
+        log()->error("{} Failed to set impedance setpoints.", errorPrefix);
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
Introduce the DinRailRobotControl class and its associated bindings, along with necessary adjustments for gain conversions and module integration. This enhances the RobotInterface with DinRail capabilities.