### PR TITLE
Add FirstOrderSmoother module with time-varying settling time support

### DIFF
--- a/bindings/python/ContinuousDynamicalSystem/CMakeLists.txt
+++ b/bindings/python/ContinuousDynamicalSystem/CMakeLists.txt
@@ -6,11 +6,11 @@ if(TARGET BipedalLocomotion::ContinuousDynamicalSystem)
 
   add_bipedal_locomotion_python_module(
     NAME ContinuousDynamicalSystemBindings
-    SOURCES src/MultiStateWeightProvider.cpp src/LinearTimeInvariantSystem.cpp src/FloatingBaseSystemVelocityKinematics.cpp src/FloatingBaseSystemAccelerationKinematics.cpp src/CentroidalDynamics.cpp src/ButterworthLowPassFilter.cpp src/Module.cpp
+    SOURCES src/MultiStateWeightProvider.cpp src/LinearTimeInvariantSystem.cpp src/FloatingBaseSystemVelocityKinematics.cpp src/FloatingBaseSystemAccelerationKinematics.cpp src/CentroidalDynamics.cpp src/ButterworthLowPassFilter.cpp src/FirstOrderSmoother.cpp src/Module.cpp
     HEADERS ${H_PREFIX}/DynamicalSystem.h ${H_PREFIX}/LinearTimeInvariantSystem.h ${H_PREFIX}/FloatingBaseSystemVelocityKinematics.h ${H_PREFIX}/FloatingBaseSystemAccelerationKinematics.h ${H_PREFIX}/Integrator.h
-            ${H_PREFIX}/MultiStateWeightProvider.h ${H_PREFIX}/CentroidalDynamics.h ${H_PREFIX}/ButterworthLowPassFilter.h
+            ${H_PREFIX}/MultiStateWeightProvider.h ${H_PREFIX}/CentroidalDynamics.h ${H_PREFIX}/ButterworthLowPassFilter.h ${H_PREFIX}/FirstOrderSmoother.h
             ${H_PREFIX}/Module.h
     LINK_LIBRARIES BipedalLocomotion::ContinuousDynamicalSystem
-    TESTS tests/test_linear_system.py tests/test_floating_base_system_kinematics.py tests/test_centroidal_dynamics.py
+    TESTS tests/test_linear_system.py tests/test_floating_base_system_kinematics.py tests/test_centroidal_dynamics.py tests/test_first_order_smoother.py
     )
 endif()

--- a/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/FirstOrderSmoother.h
+++ b/bindings/python/ContinuousDynamicalSystem/include/BipedalLocomotion/bindings/ContinuousDynamicalSystem/FirstOrderSmoother.h
@@ -1,0 +1,26 @@
+/**
+ * @file FirstOrderSmoother.h
+ * @authors Giulio Romualdi
+ * @copyright 2024 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_CONTINUOUS_DYNAMICAL_SYSTEM_FIRST_ORDER_SMOOTHER_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_CONTINUOUS_DYNAMICAL_SYSTEM_FIRST_ORDER_SMOOTHER_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ContinuousDynamicalSystem
+{
+
+void CreateFirstOrderSmoother(pybind11::module& module);
+
+} // namespace ContinuousDynamicalSystem
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_CONTINUOUS_DYNAMICAL_SYSTEM_FIRST_ORDER_SMOOTHER_H

--- a/bindings/python/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
+++ b/bindings/python/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
@@ -1,0 +1,47 @@
+/**
+ * @file FirstOrderSmoother.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2024 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the BSD-3-Clause license.
+ */
+
+#include <BipedalLocomotion/ContinuousDynamicalSystem/FirstOrderSmoother.h>
+#include <BipedalLocomotion/System/Advanceable.h>
+
+#include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/FirstOrderSmoother.h>
+#include <BipedalLocomotion/bindings/System/Advanceable.h>
+
+#include <pybind11/eigen.h>
+#include <pybind11/stl.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ContinuousDynamicalSystem
+{
+
+void CreateFirstOrderSmoother(pybind11::module& module)
+{
+    using namespace BipedalLocomotion::ContinuousDynamicalSystem;
+    namespace py = ::pybind11;
+
+    BipedalLocomotion::bindings::System::CreateAdvanceable<Eigen::VectorXd, //
+                                                           Eigen::VectorXd>(module,
+                                                                            "FirstOrderSmoother");
+
+    py::class_<FirstOrderSmoother, //
+               ::BipedalLocomotion::System::Advanceable<Eigen::VectorXd, //
+                                                        Eigen::VectorXd>>(module,
+                                                                          "FirstOrderSmoother")
+        .def(py::init())
+        .def("reset", &FirstOrderSmoother::reset, py::arg("initial_state"))
+        .def("set_settling_time",
+             &FirstOrderSmoother::setSettlingTime,
+             py::arg("settling_time"))
+        .def("get_settling_time", &FirstOrderSmoother::getSettlingTime);
+}
+
+} // namespace ContinuousDynamicalSystem
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/ContinuousDynamicalSystem/src/Module.cpp
+++ b/bindings/python/ContinuousDynamicalSystem/src/Module.cpp
@@ -9,6 +9,7 @@
 
 #include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/ButterworthLowPassFilter.h>
 #include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/CentroidalDynamics.h>
+#include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/FirstOrderSmoother.h>
 #include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/FloatingBaseSystemAccelerationKinematics.h>
 #include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/FloatingBaseSystemVelocityKinematics.h>
 #include <BipedalLocomotion/bindings/ContinuousDynamicalSystem/LinearTimeInvariantSystem.h>
@@ -29,6 +30,7 @@ void CreateModule(pybind11::module& module)
     CreateLinearTimeInvariantSystem(module);
     CreateFloatingBaseSystemVelocityKinematics(module);
     CreateFloatingBaseSystemAccelerationKinematics(module);
+    CreateFirstOrderSmoother(module);
     CreateMultiStateWeightProvider(module);
     CreateCentroidalDynamics(module);
     CreateButterworthLowPassFilter(module);

--- a/bindings/python/ContinuousDynamicalSystem/tests/test_first_order_smoother.py
+++ b/bindings/python/ContinuousDynamicalSystem/tests/test_first_order_smoother.py
@@ -1,0 +1,62 @@
+import pytest
+
+import bipedal_locomotion_framework.bindings as blf
+import numpy as np
+
+from datetime import timedelta
+
+
+def test_first_order_smoother():
+
+    dT = timedelta(microseconds=100)
+    settling_time = 0.1
+    updated_settling_time = 0.05
+    tolerance = 1e-2
+
+    parameters_handler = blf.parameters_handler.StdParametersHandler()
+    parameters_handler.set_parameter_float("settling_time", settling_time)
+    parameters_handler.set_parameter_datetime("sampling_time", dT)
+
+    smoother = blf.continuous_dynamical_system.FirstOrderSmoother()
+
+    # the settling time cannot be changed before the class is initialized
+    assert not smoother.set_settling_time(updated_settling_time)
+
+    assert smoother.initialize(parameters_handler)
+
+    # the settling time cannot be changed before reset()
+    assert not smoother.set_settling_time(updated_settling_time)
+
+    initial_state = np.zeros(2)
+    input = np.ones(2)
+
+    assert smoother.reset(initial_state)
+    assert smoother.set_input(input)
+    assert smoother.get_settling_time() == settling_time
+
+    # a non positive settling time is not valid
+    assert not smoother.set_settling_time(0.0)
+    assert not smoother.set_settling_time(-1.0)
+
+    # let the system evolve for half of the initial settling time
+    for _ in range(500):
+        assert smoother.advance()
+
+    # speed up the response by reducing the settling time. The state reached so far is used as
+    # initial condition of the new dynamics
+    assert smoother.set_settling_time(updated_settling_time)
+    assert smoother.get_settling_time() == updated_settling_time
+
+    state_at_switch = smoother.get_output()
+    a = 3.0 / updated_settling_time
+
+    def close_form_solution(t):
+        return np.ones(2) - (np.ones(2) - state_at_switch) * np.exp(-a * t)
+
+    for i in range(500):
+        output = smoother.get_output()
+        assert output == pytest.approx(close_form_solution(i * dT.total_seconds()), abs=tolerance)
+        assert smoother.advance()
+
+    # since the settling time has been reduced the system should have already converged
+    assert smoother.get_output() == pytest.approx(input, abs=tolerance)

--- a/bindings/python/ContinuousDynamicalSystem/tests/test_first_order_smoother.py
+++ b/bindings/python/ContinuousDynamicalSystem/tests/test_first_order_smoother.py
@@ -47,13 +47,13 @@ def test_first_order_smoother():
     assert smoother.set_settling_time(updated_settling_time)
     assert smoother.get_settling_time() == updated_settling_time
 
-    state_at_switch = smoother.get_output()
+    state_at_switch = smoother.get_output().copy()
     a = 3.0 / updated_settling_time
 
     def close_form_solution(t):
         return np.ones(2) - (np.ones(2) - state_at_switch) * np.exp(-a * t)
 
-    for i in range(500):
+    for i in range(1000):
         output = smoother.get_output()
         assert output == pytest.approx(close_form_solution(i * dT.total_seconds()), abs=tolerance)
         assert smoother.advance()

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FirstOrderSmoother.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FirstOrderSmoother.h
@@ -29,6 +29,9 @@ namespace ContinuousDynamicalSystem
  * \f]
  * where the \f$a\f$ is given by \f$a = 3.0/T_{s_5}\f$. \f$T_{s_5}\f$ is the settling time at 5%.
  * The linear system is propagated with a Forward Euler integrator.
+ * @note The settling time can be time-varying. Indeed, it can be updated at run time by calling
+ * FirstOrderSmoother::setSettlingTime(). This is useful, for instance, when the desired smoothness
+ * of the output needs to change while the smoother is running.
  */
 class FirstOrderSmoother
     : public BipedalLocomotion::System::Advanceable<Eigen::VectorXd, Eigen::VectorXd>
@@ -42,6 +45,8 @@ public:
      * |:-----------------:|:--------:|:------------------------------------------------:|:---------:|
      * |  `sampling_time`  | `double` | Sampling time used to discrete the linear system |     Yes    |
      * |  `settling_time`  | `double` | 5% settling time (The settling time, \f$T_s\f$, is the time required for the system output to fall within a certain percentage (i.e. 5%) of the steady-state value for a step input.) |    Yes    |
+     * @note the `settling_time` set here is only the initial value. It can be changed at run time,
+     * i.e. it can be time-varying, by calling FirstOrderSmoother::setSettlingTime().
      * @return true in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) override;
@@ -52,6 +57,20 @@ public:
      * @return true in case of success, false otherwise.
      */
     bool reset(Eigen::Ref<const Eigen::VectorXd> initialState);
+
+    /**
+     * Set (or update) the settling time of the smoother. This method can be called at any time
+     * after FirstOrderSmoother::reset() to make the settling time time-varying.
+     * @param settlingTime the new 5% settling time. It must be strictly positive.
+     * @return true in case of success, false otherwise.
+     */
+    bool setSettlingTime(const double settlingTime);
+
+    /**
+     * Get the settling time currently used by the smoother.
+     * @return the 5% settling time.
+     */
+    double getSettlingTime() const;
 
     /**
      * @brief Perform one integration step using the input set by the FirstOrderSmoother::setInput

--- a/src/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
+++ b/src/ContinuousDynamicalSystem/src/FirstOrderSmoother.cpp
@@ -69,16 +69,11 @@ bool FirstOrderSmoother::reset(Eigen::Ref<const Eigen::VectorXd> initialPoint)
         return false;
     }
 
-    // The following code is required to implement the following linear system
-    // dx = -a * x + a * u
-    // where a is given by 3.0 / settling_time
-    const int systemSize = initialPoint.size();
-    const Eigen::MatrixXd A = 3.0 / m_settlingTime //
-                              * Eigen::MatrixXd::Identity(systemSize, systemSize);
+    m_output = initialPoint;
 
-    if (!m_linearSystem->setSystemMatrices(-A, A))
+    if (!this->setSettlingTime(m_settlingTime))
     {
-        log()->error("{} Unable to set the linear system matrices.", logPrefix);
+        log()->error("{} Unable to set the settling time.", logPrefix);
         return false;
     }
 
@@ -88,11 +83,56 @@ bool FirstOrderSmoother::reset(Eigen::Ref<const Eigen::VectorXd> initialPoint)
         return false;
     }
 
-    m_output = initialPoint;
     m_isInitialStateSet = true;
 
     return true;
 }
+
+bool FirstOrderSmoother::setSettlingTime(const double settlingTime)
+{
+    constexpr auto logPrefix = "[FirstOrderSmoother::setSettlingTime]";
+
+    if (!m_isInitialized)
+    {
+        log()->error("{} Please initialize the class before.", logPrefix);
+        return false;
+    }
+
+    if (m_output.size() == 0)
+    {
+        log()->error("{} Please call reset() before setting the settling time.", logPrefix);
+        return false;
+    }
+
+    if (settlingTime <= 0)
+    {
+        log()->error("{} The settling time must be a positive number.", logPrefix);
+        return false;
+    }
+
+    // The following code is required to implement the following linear system
+    // dx = -a * x + a * u
+    // where a is given by 3.0 / settling_time
+    const int systemSize = m_output.size();
+    const Eigen::MatrixXd A = 3.0 / settlingTime //
+                              * Eigen::MatrixXd::Identity(systemSize, systemSize);
+
+    if (!m_linearSystem->setSystemMatrices(-A, A))
+    {
+        log()->error("{} Unable to set the linear system matrices.", logPrefix);
+        return false;
+    }
+
+    m_settlingTime = settlingTime;
+
+    return true;
+}
+
+double FirstOrderSmoother::getSettlingTime() const
+{
+    return m_settlingTime;
+}
+
 
 bool FirstOrderSmoother::advance()
 {

--- a/src/ContinuousDynamicalSystem/tests/FirstOrderSmoother.cpp
+++ b/src/ContinuousDynamicalSystem/tests/FirstOrderSmoother.cpp
@@ -109,3 +109,67 @@ TEST_CASE("First order smoother")
     REQUIRE(settilingTimeSubSystem1 <= settlingTime);
     REQUIRE(settilingTimeSubSystem2 <= settlingTime);
 }
+
+TEST_CASE("First order smoother - time-varying settling time")
+{
+    using namespace std::chrono_literals;
+
+    constexpr std::chrono::nanoseconds dT = 100us;
+    constexpr double initialSettlingTime = 0.1;
+    constexpr double updatedSettlingTime = 0.05;
+    constexpr double tolerance = 1e-2;
+
+    auto params = std::make_shared<BipedalLocomotion::ParametersHandler::StdImplementation>();
+    params->setParameter("settling_time", initialSettlingTime);
+    params->setParameter("sampling_time", dT);
+
+    FirstOrderSmoother smoother;
+
+    // the settling time cannot be changed before the class is initialized
+    REQUIRE_FALSE(smoother.setSettlingTime(updatedSettlingTime));
+
+    REQUIRE(smoother.initialize(params));
+
+    // the settling time cannot be changed before reset() since the size of the system is unknown
+    REQUIRE_FALSE(smoother.setSettlingTime(updatedSettlingTime));
+
+    Eigen::Vector2d initialState = Eigen::Vector2d::Zero();
+    Eigen::Vector2d input = Eigen::Vector2d::Ones();
+
+    REQUIRE(smoother.reset(initialState));
+    REQUIRE(smoother.setInput(input));
+    REQUIRE(smoother.getSettlingTime() == initialSettlingTime);
+
+    // a non positive settling time is not valid
+    REQUIRE_FALSE(smoother.setSettlingTime(0.0));
+    REQUIRE_FALSE(smoother.setSettlingTime(-1.0));
+
+    // let the system evolve for half of the initial settling time
+    for (unsigned int i = 0; i < 500; i++)
+    {
+        REQUIRE(smoother.advance());
+    }
+
+    // speed up the response by reducing the settling time. The smoother should keep the current
+    // state as initial condition of the new dynamics
+    REQUIRE(smoother.setSettlingTime(updatedSettlingTime));
+    REQUIRE(smoother.getSettlingTime() == updatedSettlingTime);
+
+    const Eigen::Vector2d stateAtSwitch = smoother.getOutput();
+    const double a = 3.0 / updatedSettlingTime;
+    auto closeFormSolution = [&stateAtSwitch, a](const double& t) -> Eigen::Vector2d {
+        return Eigen::Vector2d::Ones() - (Eigen::Vector2d::Ones() - stateAtSwitch) * std::exp(-a * t);
+    };
+
+    for (unsigned int i = 0; i < 500; i++)
+    {
+        const Eigen::Vector2d output = smoother.getOutput();
+        REQUIRE(output.isApprox(closeFormSolution(std::chrono::duration<double>(dT * i).count()),
+                                tolerance));
+        REQUIRE(smoother.advance());
+    }
+
+    // since the settling time has been reduced the system should have already converged to the
+    // input
+    REQUIRE(smoother.getOutput().isApprox(input, tolerance));
+}

--- a/src/ContinuousDynamicalSystem/tests/FirstOrderSmoother.cpp
+++ b/src/ContinuousDynamicalSystem/tests/FirstOrderSmoother.cpp
@@ -161,7 +161,7 @@ TEST_CASE("First order smoother - time-varying settling time")
         return Eigen::Vector2d::Ones() - (Eigen::Vector2d::Ones() - stateAtSwitch) * std::exp(-a * t);
     };
 
-    for (unsigned int i = 0; i < 500; i++)
+    for (unsigned int i = 0; i < 1000; i++)
     {
         const Eigen::Vector2d output = smoother.getOutput();
         REQUIRE(output.isApprox(closeFormSolution(std::chrono::duration<double>(dT * i).count()),


### PR DESCRIPTION
Introduce the FirstOrderSmoother module, enabling dynamic adjustment of settling time during operation. Include corresponding tests to validate functionality.